### PR TITLE
fix: deliver scheduled present_file output to chat (#180)

### DIFF
--- a/agent/app/agent_runner.py
+++ b/agent/app/agent_runner.py
@@ -109,6 +109,8 @@ class AgentRunner:
         result_data: dict = {"status": "completed"}
         stderr_lines: list[str] = []
         text_output: list[str] = []
+        presented_files: list[dict] = []  # collected from `present_file` markers
+        seen_file_paths: set[str] = set()
 
         async def _collect_stderr(proc: asyncio.subprocess.Process) -> None:
             """Read stderr concurrently so it's not lost when process exits."""
@@ -143,6 +145,15 @@ class AgentRunner:
                     for block in event.get("message", {}).get("content", []):
                         if block.get("type") == "text" and block.get("text"):
                             text_output.append(block["text"])
+
+                # Capture `present_file` deliveries so we can mirror them to the
+                # chat channel (live + persisted) — see _maybe_emit_present_file.
+                if event.get("type") == "tool_result":
+                    marker_payload = self._parse_present_file_marker(event.get("content"))
+                    if marker_payload and marker_payload.get("path") not in seen_file_paths:
+                        presented_files.append(marker_payload)
+                        seen_file_paths.add(marker_payload.get("path", ""))
+                        await self._mirror_present_file_to_chat(task_id, marker_payload)
 
                 if event.get("type") == "result":
                     result_text = event.get("result", "") or "\n".join(text_output)
@@ -184,6 +195,15 @@ class AgentRunner:
         finally:
             self.is_running = False
             self._process = None
+
+        if presented_files:
+            result_data.setdefault("presented_files", []).extend(presented_files)
+            await self._publish_scheduler_chat_completion(
+                task_id=task_id,
+                presented_files=presented_files,
+                final_text="\n".join(text_output).strip(),
+                result_data=result_data,
+            )
 
         return result_data
 
@@ -271,6 +291,80 @@ class AgentRunner:
             await self.log_publisher.publish(
                 task_id, "raw", {"text": event.get("text", "")}
             )
+
+    @staticmethod
+    def _parse_present_file_marker(content) -> dict | None:
+        """Extracts a present_file payload from a tool_result content blob.
+
+        The MCP server returns `__AI_EMPLOYEE_PRESENT_FILE__<json>` either as the
+        whole result string or wrapped in `[{"type":"text","text":"..."}]`.
+        """
+        marker = "__AI_EMPLOYEE_PRESENT_FILE__"
+
+        def _extract(text: str) -> dict | None:
+            if not text or not text.startswith(marker):
+                return None
+            try:
+                return json.loads(text.removeprefix(marker))
+            except (json.JSONDecodeError, TypeError):
+                return None
+
+        if isinstance(content, str):
+            return _extract(content)
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict):
+                    payload = _extract(str(block.get("text", "")))
+                    if payload:
+                        return payload
+        return None
+
+    async def _mirror_present_file_to_chat(self, task_id: str, payload: dict) -> None:
+        """Push a `file` event onto the agent chat channel so iOS/Web see the
+        attachment live, regardless of whether the task ran from the chat or
+        scheduler queue.
+        """
+        try:
+            await self.log_publisher.publish_chat(task_id, "file", payload)
+        except Exception:
+            logger.warning("Failed to mirror present_file to chat channel", exc_info=True)
+
+    async def _publish_scheduler_chat_completion(
+        self,
+        task_id: str,
+        presented_files: list[dict],
+        final_text: str,
+        result_data: dict,
+    ) -> None:
+        """Synthesise a chat:completions event for scheduler-originated tasks so
+        the orchestrator persists a chat_message row with the file attachments.
+
+        Distinguished by `source="scheduler"`. The orchestrator's
+        _listen_chat_completions handler creates a `session_id="scheduler"` row
+        when no matching user-message exists, avoiding interference with the
+        normal chat flow.
+        """
+        try:
+            from datetime import datetime, timezone
+
+            payload = {
+                "agent_id": self.log_publisher.agent_id,
+                "message_id": task_id,
+                "type": "done",
+                "source": "scheduler",
+                "data": {
+                    "text": final_text,
+                    "presented_files": presented_files,
+                    "cost_usd": result_data.get("cost_usd"),
+                    "duration_ms": result_data.get("duration_ms"),
+                    "input_tokens": result_data.get("input_tokens"),
+                    "output_tokens": result_data.get("output_tokens"),
+                },
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+            await self.log_publisher.redis.publish("chat:completions", json.dumps(payload))
+        except Exception:
+            logger.warning("Failed to publish scheduler chat completion", exc_info=True)
 
     async def interrupt(self) -> None:
         """Interrupt the currently running task."""

--- a/agent/tests/test_present_file_marker.py
+++ b/agent/tests/test_present_file_marker.py
@@ -1,0 +1,34 @@
+"""Tests for present_file marker parsing in AgentRunner (issue #180)."""
+
+from app.agent_runner import AgentRunner
+
+
+def test_parse_present_file_marker_from_string():
+    raw = '__AI_EMPLOYEE_PRESENT_FILE__{"path": "/workspace/transfer/x.mp3", "filename": "x.mp3", "media_type": "audio/mpeg", "size": 1024, "caption": "hi"}'
+    payload = AgentRunner._parse_present_file_marker(raw)
+    assert payload is not None
+    assert payload["path"] == "/workspace/transfer/x.mp3"
+    assert payload["filename"] == "x.mp3"
+    assert payload["media_type"] == "audio/mpeg"
+    assert payload["size"] == 1024
+    assert payload["caption"] == "hi"
+
+
+def test_parse_present_file_marker_from_blocks():
+    content = [
+        {"type": "text", "text": '__AI_EMPLOYEE_PRESENT_FILE__{"path": "/p/a.pdf", "filename": "a.pdf"}'},
+    ]
+    payload = AgentRunner._parse_present_file_marker(content)
+    assert payload is not None
+    assert payload["path"] == "/p/a.pdf"
+
+
+def test_parse_present_file_marker_missing_returns_none():
+    assert AgentRunner._parse_present_file_marker("just a regular tool result") is None
+    assert AgentRunner._parse_present_file_marker(None) is None
+    assert AgentRunner._parse_present_file_marker([]) is None
+    assert AgentRunner._parse_present_file_marker([{"type": "text", "text": "no marker"}]) is None
+
+
+def test_parse_present_file_marker_invalid_json_returns_none():
+    assert AgentRunner._parse_present_file_marker("__AI_EMPLOYEE_PRESENT_FILE__{broken json}") is None

--- a/orchestrator/app/main.py
+++ b/orchestrator/app/main.py
@@ -303,6 +303,7 @@ async def _listen_chat_completions(redis: RedisService) -> None:
                 agent_id = data.get("agent_id", "")
                 message_id = data.get("message_id", "")
                 event_data = data.get("data", {})
+                source = data.get("source", "chat")
 
                 if not agent_id or not message_id:
                     continue
@@ -323,7 +324,7 @@ async def _listen_chat_completions(redis: RedisService) -> None:
                     if existing:
                         continue  # Already saved by WebSocket handler
 
-                    # Look up session_id from the user message
+                    # Look up session_id from the user message (chat flow only)
                     user_msg = await db.scalar(
                         sel(ChatMessage).where(
                             ChatMessage.agent_id == agent_id,
@@ -331,11 +332,18 @@ async def _listen_chat_completions(redis: RedisService) -> None:
                             ChatMessage.role == "user",
                         )
                     )
-                    if not user_msg:
+
+                    if user_msg:
+                        session_id = user_msg.session_id
+                    elif source == "scheduler":
+                        # Scheduler-originated tasks have no user message — drop them
+                        # into a dedicated `scheduler` session so iOS history shows
+                        # the file delivery (see issue #180).
+                        session_id = "scheduler"
+                    else:
                         print(f"[ChatPersist] No user message found for {message_id}, skipping")
                         continue
 
-                    session_id = user_msg.session_id
                     content = str(event_data.get("text", ""))
                     tool_calls = event_data.get("tool_calls")
                     meta = {
@@ -343,7 +351,10 @@ async def _listen_chat_completions(redis: RedisService) -> None:
                         "duration_ms": event_data.get("duration_ms"),
                         "num_turns": event_data.get("num_turns"),
                         "presented_files": event_data.get("presented_files"),
+                        "source": source if source != "chat" else None,
                     }
+                    # Remove keys with None values for cleaner JSON
+                    meta = {k: v for k, v in meta.items() if v is not None}
 
                     db.add(ChatMessage(
                         agent_id=agent_id,
@@ -357,7 +368,7 @@ async def _listen_chat_completions(redis: RedisService) -> None:
                     await db.commit()
                     print(
                         f"[ChatPersist] Saved response for {message_id} "
-                        f"(agent={agent_id}, session={session_id})"
+                        f"(agent={agent_id}, session={session_id}, source={source})"
                     )
         except Exception as e:
             print(f"[ChatPersist] Error: {e}")


### PR DESCRIPTION
## Summary
- Scheduled tasks that call `present_file` now reach the iOS/Web chat as a real message+attachment instead of only firing a notification.
- The agent runner detects the `__AI_EMPLOYEE_PRESENT_FILE__` sentinel in tool_result events, mirrors it live onto `agent:{id}:chat:response` as a `file` event, and publishes a synthetic `chat:completions` event with `source="scheduler"`.
- The orchestrator's chat-persistence loop now accepts scheduler-originated completions even when no user message exists, storing them in a dedicated `scheduler` session.

## Root cause
For chat-originated tasks, `_listen_chat_completions` requires a matching user message to derive `session_id`. Scheduler-originated tasks have no such message, so the response was silently dropped — meanwhile the runner only published to the logs channel, so iOS never saw a live `file` event either.

## Changes
- `agent/app/agent_runner.py`
  - `_parse_present_file_marker` (new): extracts the JSON payload from string or block content.
  - `_mirror_present_file_to_chat` (new): publishes `file` events to `agent:{id}:chat:response`.
  - `_publish_scheduler_chat_completion` (new): publishes a `done` event to `chat:completions` tagged `source="scheduler"`.
  - `execute_task`: collects deliveries during the stream, dedupes by path, and triggers the scheduler chat completion when any file was presented.
- `orchestrator/app/main.py`
  - `_listen_chat_completions`: reads `source` from the payload; routes scheduler sources into `session_id="scheduler"` instead of dropping; persists the source in meta.
- `agent/tests/test_present_file_marker.py` (new): 4 unit tests covering string, block, missing, and invalid-JSON forms.

## Related
- Closes #180
- iOS counterpart: greeves89/ai-employee-ios#1

## Test plan
- [x] `pytest agent/tests/test_present_file_marker.py` — 4 passed
- [ ] End-to-end: trigger a scheduled task that calls `present_file`, verify a chat row appears with the attachment and that iOS displays the file inline
- [ ] Verify the existing chat flow still works (user message → assistant response with attachments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)