### PR TITLE
feat(telegram): expose sendRichMessage (Bot API 10.1)

### DIFF
--- a/orchestrator/app/api/telegram_actions.py
+++ b/orchestrator/app/api/telegram_actions.py
@@ -82,6 +82,28 @@ class SendMessageRequest(BaseModel):
     disable_notification: bool = False
 
 
+class SendRichMessageRequest(BaseModel):
+    """Bot API 10.1 (June 2026): block-structured rich messages.
+
+    `rich_message` mirrors the `InputRichMessage` shape from the Bot API. The
+    common case is `{"blocks": [...]}` where each block is one of the
+    documented Rich* block types (section_heading, paragraph, table, list,
+    details, map, audio, photo, video, preformatted, …) carrying inline
+    rich-text spans.
+
+    We forward verbatim so callers can use the full Bot API surface without
+    having to redeploy the orchestrator each time Telegram adds a block type.
+    """
+
+    chat_id: int | str
+    rich_message: dict
+    business_connection_id: str | None = None
+    message_thread_id: int | None = None
+    reply_parameters: dict | None = None
+    reply_markup: dict | None = None
+    disable_notification: bool = False
+
+
 class SendVoiceRequest(BaseModel):
     chat_id: int | str
     voice_base64: str  # base64-encoded OGG/OPUS audio
@@ -283,6 +305,35 @@ async def send_message(
     if body.disable_notification:
         data["disable_notification"] = True
     return await _tg_request(token, "sendMessage", data)
+
+
+@router.post("/send-rich-message")
+async def send_rich_message(
+    body: SendRichMessageRequest,
+    agent_auth: dict = Depends(verify_agent_token),
+    db: AsyncSession = Depends(get_db),
+):
+    """Send a block-structured rich message (Bot API 10.1, June 2026).
+
+    Supports real headings, tables, interactive checklists, math expressions,
+    inline maps and audio — i.e. everything `parse_mode=HTML` cannot reach.
+    The `rich_message` field is forwarded as-is to Telegram's
+    `sendRichMessage`, so new block types added upstream work without an
+    orchestrator change.
+    """
+    token = await _get_bot_token(agent_auth["agent_id"], db)
+    data: dict = {"chat_id": body.chat_id, "rich_message": body.rich_message}
+    if body.business_connection_id:
+        data["business_connection_id"] = body.business_connection_id
+    if body.message_thread_id is not None:
+        data["message_thread_id"] = body.message_thread_id
+    if body.reply_parameters:
+        data["reply_parameters"] = body.reply_parameters
+    if body.reply_markup:
+        data["reply_markup"] = body.reply_markup
+    if body.disable_notification:
+        data["disable_notification"] = True
+    return await _tg_request(token, "sendRichMessage", data)
 
 
 @router.post("/send-voice")

--- a/orchestrator/tests/test_telegram_rich_message.py
+++ b/orchestrator/tests/test_telegram_rich_message.py
@@ -1,0 +1,117 @@
+"""Tests for the /telegram/send-rich-message endpoint.
+
+Covers the Bot API 10.1 (June 2026) `sendRichMessage` passthrough that lets
+agents emit block-structured messages (headings, tables, checklists, math,
+inline media) instead of being capped at `parse_mode=HTML`.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.api.telegram_actions import SendRichMessageRequest, send_rich_message
+
+
+@pytest.mark.asyncio
+async def test_send_rich_message_forwards_blocks_verbatim():
+    body = SendRichMessageRequest(
+        chat_id=480455764,
+        rich_message={
+            "blocks": [
+                {"type": "section_heading", "text": "Final Exams 2026"},
+                {
+                    "type": "paragraph",
+                    "text": "Everything you need to know.",
+                },
+                {
+                    "type": "table",
+                    "rows": [
+                        ["Monday", "Tuesday", "Wednesday"],
+                        ["Review", "Exam 1", "Review"],
+                    ],
+                },
+            ]
+        },
+    )
+
+    captured: dict = {}
+
+    async def fake_tg_request(token, method, data=None, files=None):
+        captured["token"] = token
+        captured["method"] = method
+        captured["data"] = data
+        return {"message_id": 999, "chat": {"id": 480455764}}
+
+    with patch(
+        "app.api.telegram_actions._get_bot_token",
+        new=AsyncMock(return_value="bot:token"),
+    ), patch(
+        "app.api.telegram_actions._tg_request",
+        new=fake_tg_request,
+    ):
+        result = await send_rich_message(
+            body=body,
+            agent_auth={"agent_id": "67874999"},
+            db=AsyncMock(),
+        )
+
+    assert captured["method"] == "sendRichMessage"
+    assert captured["data"]["chat_id"] == 480455764
+    assert captured["data"]["rich_message"]["blocks"][0]["type"] == "section_heading"
+    assert len(captured["data"]["rich_message"]["blocks"][2]["rows"]) == 2
+    # Optional fields stay out when not set — keeps the payload minimal.
+    assert "business_connection_id" not in captured["data"]
+    assert "message_thread_id" not in captured["data"]
+    assert "reply_parameters" not in captured["data"]
+    assert "reply_markup" not in captured["data"]
+    assert "disable_notification" not in captured["data"]
+    assert result["message_id"] == 999
+
+
+@pytest.mark.asyncio
+async def test_send_rich_message_includes_optional_fields():
+    body = SendRichMessageRequest(
+        chat_id="@somechan",
+        rich_message={"blocks": [{"type": "paragraph", "text": "hi"}]},
+        business_connection_id="bc-1",
+        message_thread_id=42,
+        reply_parameters={"message_id": 17},
+        reply_markup={"inline_keyboard": [[{"text": "ok", "callback_data": "ok"}]]},
+        disable_notification=True,
+    )
+
+    captured: dict = {}
+
+    async def fake_tg_request(token, method, data=None, files=None):
+        captured["data"] = data
+        return {}
+
+    with patch(
+        "app.api.telegram_actions._get_bot_token",
+        new=AsyncMock(return_value="bot:token"),
+    ), patch(
+        "app.api.telegram_actions._tg_request",
+        new=fake_tg_request,
+    ):
+        await send_rich_message(
+            body=body,
+            agent_auth={"agent_id": "67874999"},
+            db=AsyncMock(),
+        )
+
+    assert captured["data"]["business_connection_id"] == "bc-1"
+    assert captured["data"]["message_thread_id"] == 42
+    assert captured["data"]["reply_parameters"] == {"message_id": 17}
+    assert captured["data"]["reply_markup"]["inline_keyboard"][0][0]["text"] == "ok"
+    assert captured["data"]["disable_notification"] is True
+
+
+@pytest.mark.asyncio
+async def test_send_rich_message_accepts_string_chat_id():
+    """Channel usernames (@channel) are valid chat_ids — must not be coerced."""
+    body = SendRichMessageRequest(
+        chat_id="@mychannel",
+        rich_message={"blocks": []},
+    )
+    assert isinstance(body.chat_id, str)
+    assert body.chat_id == "@mychannel"


### PR DESCRIPTION
## Why

Telegram introduced **block-structured rich messages** in Bot API 10.1 (June 2026): real headings, tables, interactive checklists, LaTeX, inline maps/audio. Our \`/telegram/send-message\` tops out at \`parse_mode=HTML\` and cannot reach any of that — bots end up shipping bold/italic/code instead of the Study-Bot-style structured docs Pavel Durov showed in the announcement.

## What

A passthrough endpoint **\`/telegram/send-rich-message\`** that:

- accepts the \`rich_message\` JSON shape from the Bot API verbatim (\`{"blocks": [...]}\` with section_heading, paragraph, table, list, details, map, audio, photo, video, preformatted, …)
- forwards the full optional surface: \`business_connection_id\`, \`message_thread_id\`, \`reply_parameters\`, \`reply_markup\`, \`disable_notification\`
- needs **no orchestrator change** when Telegram adds new block types — we don't model the inner schema, we forward it

## Tests

3 new unit tests in \`tests/test_telegram_rich_message.py\` covering:
- verbatim forward of the \`rich_message\` body
- the full optional-field surface
- string \`chat_id\` (channel usernames like \`@mychan\`)

Full suite: **121 passed**.

## Test plan
- [x] Unit tests pass
- [ ] Manual: deploy + send a rich message with section_heading + table + checklist and verify it renders block-structured in the iOS Telegram client
- [ ] Update CLAUDE.md to add a \`send-rich-message\` curl snippet for agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)