### PR TITLE
Harden Telegram in-process auth + bind service ports to loopback

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,9 @@ services:
       target: base
     container_name: ai-employee-orchestrator
     ports:
-      - "${ORCHESTRATOR_PORT:-8000}:8000"
+      # Bind to loopback only — external access goes via reverse proxy.
+      # Prevents the orchestrator API being directly reachable on the public IP.
+      - "127.0.0.1:${ORCHESTRATOR_PORT:-8000}:8000"
     environment:
       DATABASE_URL: postgresql+asyncpg://ai_employee:${DB_PASSWORD:-devpassword}@postgres:5432/ai_employee
       REDIS_URL: redis://:${REDIS_PASSWORD:-changeme-redis-password}@redis:6379
@@ -215,7 +217,8 @@ services:
         NEXT_PUBLIC_WS_URL: ${NEXT_PUBLIC_WS_URL:-ws://localhost:8000}
     container_name: ai-employee-frontend
     ports:
-      - "${FRONTEND_PORT:-3000}:3000"
+      # Bind to loopback only — external access goes via reverse proxy.
+      - "127.0.0.1:${FRONTEND_PORT:-3000}:3000"
     depends_on:
       - orchestrator
     restart: unless-stopped

--- a/orchestrator/app/core/auth.py
+++ b/orchestrator/app/core/auth.py
@@ -1,5 +1,7 @@
 """JWT authentication and password hashing utilities."""
 
+import hashlib
+import hmac
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -12,6 +14,17 @@ from app.config import settings
 ALGORITHM = "HS256"
 ACCESS_TOKEN_TTL = timedelta(minutes=30)
 REFRESH_TOKEN_TTL = timedelta(days=7)
+
+
+def internal_service_secret() -> str:
+    """Shared secret for in-process service calls (e.g. the Telegram bot calling
+    its own API over loopback). Domain-separated from ``api_secret_key`` via HMAC
+    so the value transmitted in the ``X-Internal-Secret`` header is NOT the JWT
+    signing key — a leak of this header therefore cannot be used to forge tokens.
+    Mirrors the derivation in ``core.mcp_oauth``."""
+    return hmac.new(
+        settings.api_secret_key.encode(), b"internal-service-auth-v1", hashlib.sha256
+    ).hexdigest()
 
 
 def hash_password(password: str) -> str:

--- a/orchestrator/app/dependencies.py
+++ b/orchestrator/app/dependencies.py
@@ -73,16 +73,18 @@ async def get_current_user(request: Request, db: AsyncSession) -> "User":
     If no users have registered yet (setup mode), returns an anonymous admin
     to allow the platform to function before first registration.
     """
-    from app.core.auth import decode_token
+    from app.core.auth import decode_token, internal_service_secret
     from app.models.user import User, UserRole
 
     # Internal service auth: localhost calls with a matching X-Internal-Secret
     # header authenticate as the first active admin user. Used by the in-process
-    # Telegram bot to call its own API without owning a user JWT.
+    # Telegram bot to call its own API without owning a user JWT. The expected
+    # secret is HMAC-derived from api_secret_key (NOT the raw JWT signing key),
+    # so leaking this header cannot be used to forge tokens.
     client_host = request.client.host if request.client else ""
     if client_host in ("127.0.0.1", "::1", "localhost"):
         internal_secret = request.headers.get("X-Internal-Secret", "")
-        if internal_secret and hmac.compare_digest(internal_secret, settings.api_secret_key):
+        if internal_secret and hmac.compare_digest(internal_secret, internal_service_secret()):
             admin = await db.scalar(
                 select(User).where(User.role == UserRole.ADMIN).order_by(User.created_at).limit(1)
             )

--- a/orchestrator/app/dependencies.py
+++ b/orchestrator/app/dependencies.py
@@ -74,7 +74,22 @@ async def get_current_user(request: Request, db: AsyncSession) -> "User":
     to allow the platform to function before first registration.
     """
     from app.core.auth import decode_token
-    from app.models.user import User
+    from app.models.user import User, UserRole
+
+    # Internal service auth: localhost calls with a matching X-Internal-Secret
+    # header authenticate as the first active admin user. Used by the in-process
+    # Telegram bot to call its own API without owning a user JWT.
+    client_host = request.client.host if request.client else ""
+    if client_host in ("127.0.0.1", "::1", "localhost"):
+        internal_secret = request.headers.get("X-Internal-Secret", "")
+        if internal_secret and hmac.compare_digest(internal_secret, settings.api_secret_key):
+            admin = await db.scalar(
+                select(User).where(User.role == UserRole.ADMIN).order_by(User.created_at).limit(1)
+            )
+            if admin and admin.is_active:
+                from app.db.session import set_rls_user
+                await set_rls_user(db, None)  # admin bypasses RLS
+                return admin
 
     token = request.cookies.get("access_token")
 

--- a/orchestrator/app/telegram/agent_bot.py
+++ b/orchestrator/app/telegram/agent_bot.py
@@ -248,8 +248,9 @@ class TelegramAgentBot:
             return
 
         import httpx
+        from app.telegram.handlers.commands import INTERNAL_HEADERS
         try:
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(headers=INTERNAL_HEADERS) as client:
                 resp = await client.get(f"http://127.0.0.1:8000/api/v1/agents/{self.agent_id}")
                 data = resp.json()
                 state = data.get("state", "unknown")

--- a/orchestrator/app/telegram/handlers/commands.py
+++ b/orchestrator/app/telegram/handlers/commands.py
@@ -11,6 +11,10 @@ from app.config import settings
 # Use localhost since the bot runs INSIDE the orchestrator container
 API_BASE = "http://127.0.0.1:8000/api/v1"
 
+# Service-auth header: dependencies.get_current_user accepts requests from
+# 127.0.0.1 with X-Internal-Secret == api_secret_key as the first admin user.
+INTERNAL_HEADERS = {"X-Internal-Secret": settings.api_secret_key}
+
 # Track which Telegram user chats with which agent
 _active_chats: dict[int, str] = {}  # chat_id -> agent_id
 _chat_listeners: dict[int, asyncio.Task] = {}  # chat_id -> listener task
@@ -36,7 +40,7 @@ async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 async def cmd_status(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(headers=INTERNAL_HEADERS) as client:
         try:
             resp = await client.get(f"{API_BASE}/agents/")
             data = resp.json()
@@ -79,7 +83,7 @@ async def cmd_task(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
     prompt = " ".join(context.args)
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(headers=INTERNAL_HEADERS) as client:
         try:
             resp = await client.post(
                 f"{API_BASE}/tasks/",
@@ -107,7 +111,7 @@ async def cmd_task(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 async def cmd_agents(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(headers=INTERNAL_HEADERS) as client:
         try:
             resp = await client.get(f"{API_BASE}/agents/")
             data = resp.json()
@@ -145,7 +149,7 @@ async def cmd_chat(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         return
 
     # Otherwise show agent selection
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(headers=INTERNAL_HEADERS) as client:
         try:
             resp = await client.get(f"{API_BASE}/agents/")
             data = resp.json()
@@ -231,7 +235,7 @@ async def _handle_rating_callback(query, data: str) -> None:
             return
 
         # Save rating via internal API
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(headers=INTERNAL_HEADERS) as client:
             resp = await client.post(
                 f"{API_BASE}/ratings/tasks/{task_id}/rate",
                 json={"rating": rating},

--- a/orchestrator/app/telegram/handlers/commands.py
+++ b/orchestrator/app/telegram/handlers/commands.py
@@ -7,13 +7,16 @@ from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
 
 from app.config import settings
+from app.core.auth import internal_service_secret
 
 # Use localhost since the bot runs INSIDE the orchestrator container
 API_BASE = "http://127.0.0.1:8000/api/v1"
 
 # Service-auth header: dependencies.get_current_user accepts requests from
-# 127.0.0.1 with X-Internal-Secret == api_secret_key as the first admin user.
-INTERNAL_HEADERS = {"X-Internal-Secret": settings.api_secret_key}
+# 127.0.0.1 with a matching X-Internal-Secret as the first admin user. The
+# secret is HMAC-derived from api_secret_key (domain-separated), not the raw
+# JWT signing key — see core.auth.internal_service_secret.
+INTERNAL_HEADERS = {"X-Internal-Secret": internal_service_secret()}
 
 # Track which Telegram user chats with which agent
 _active_chats: dict[int, str] = {}  # chat_id -> agent_id


### PR DESCRIPTION
## Was & warum

Eine Härtungs-Session (urspr. 18.05., Author-Dates erhalten) in 3 Commits. Hintergrund: der Telegram-Bot läuft **in-process im Orchestrator-Container** und callt seine eigene API über `127.0.0.1:8000`. Damit die Ports nicht mehr öffentlich offen stehen mussten, brauchte der eingesperrte Bot einen internen Auth-Pfad.

### 1. `fix(security)`: Service-Ports an 127.0.0.1 binden
`docker-compose.yml`: Orchestrator (8000) und Frontend (3000) werden nur noch auf Loopback gepublished — externer Zugang ausschließlich über Caddy + Cloudflare Tunnel. Vorher war die API direkt auf der öffentlichen IP erreichbar.

### 2. `fix(telegram)`: interne Service-Auth für den in-process Bot
`get_current_user` akzeptiert Requests **von echtem Loopback** (`request.client.host ∈ {127.0.0.1, ::1}`) mit gültigem `X-Internal-Secret`-Header als ersten aktiven Admin (RLS-Bypass). Der Loopback-Check ist sicher, weil Caddy auf den **Docker-Servicenamen** `ai-employee-orchestrator:8000` proxyt → externer Traffic erscheint mit der Caddy-Container-IP, nicht als `127.0.0.1`. `X-Forwarded-For` wird bewusst nicht vertraut.

### 3. `refactor(security)`: Internal-Secret von JWT-Key domain-separieren
Commit 2 verschickte den **rohen `api_secret_key`** im Header — und der ist gleichzeitig der JWT-Signing-Key. Ein Leak (Logs/Traces) hätte das Fälschen beliebiger Tokens erlaubt. Jetzt: `HMAC(api_secret_key, "internal-service-auth-v1")`, analog zur bestehenden Domain-Separation in `core.mcp_oauth`. Sender und Verifier teilen sich `core.auth.internal_service_secret()`.

## Offen / zur Diskussion mit Daniel
- **Service-Principal statt Admin-Impersonation:** Der Bot agiert aktuell als „erster aktiver Admin" → Bot-Aktionen werden in Audit-Logs einem echten Menschen zugeschrieben und laufen mit Voll-Admin ohne RLS. Sauberer wäre ein dediziertes System-Principal (analog zum vorhandenen `AgentPrincipal`). Bewusst nicht in diesem PR, da größerer Eingriff.

## Verifikation
- Ableitung getestet: deterministisch, 64-hex, ≠ rohem Key, ≠ mcp-Secret (von beiden Token-Familien separiert).
- `change-me-in-production`-Default wird bereits in `main.py:134` beim Start abgelehnt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)