### PR TITLE
fix(orchestrator): wake parent/delegating agent on subtask completion

### DIFF
--- a/orchestrator/app/core/task_router.py
+++ b/orchestrator/app/core/task_router.py
@@ -1046,6 +1046,18 @@ class TaskRouter:
             if not parent_task or not parent_task.agent_id:
                 return
 
+            # Wake the parent agent if it idle-stopped while waiting, so it
+            # actually consumes the queued completion message (mirrors dispatch).
+            if self.docker:
+                try:
+                    from app.services.user_lifecycle import wake_agent
+                    await wake_agent(self.db, self.docker, parent_task.agent_id)
+                except Exception as e:
+                    logger.warning(
+                        f"Could not wake parent agent {parent_task.agent_id} "
+                        f"for subtask {subtask.id}: {e}"
+                    )
+
             status = "completed" if subtask.status == TaskStatus.COMPLETED else "failed"
             result_preview = (subtask.result or subtask.error or "")[:500]
 
@@ -1124,6 +1136,18 @@ class TaskRouter:
         try:
             status = "completed" if task.status == TaskStatus.COMPLETED else "failed"
             result_preview = (task.result or task.error or "No output")[:800]
+
+            # Wake the delegating agent if it idle-stopped while waiting, so it
+            # actually consumes the queued result (mirrors dispatch).
+            if self.docker:
+                try:
+                    from app.services.user_lifecycle import wake_agent
+                    await wake_agent(self.db, self.docker, delegator_agent_id)
+                except Exception as e:
+                    logger.warning(
+                        f"Could not wake delegating agent {delegator_agent_id} "
+                        f"for task {task.id}: {e}"
+                    )
 
             # Push structured message to delegating agent's message queue
             message = json.dumps({


### PR DESCRIPTION
## Problem
Multi-level delegation (agent A delegates to B, B delegates to C) never closed the loop: a parent/delegator task hung in `RUNNING` indefinitely and never reported upward. Observed with an orchestrator agent ("Atlas") whose child (a coding agent) finished and even opened a PR, yet the parent task stayed `running` for 75+ minutes and never ran the follow-up steps or notified the user.

## Root cause
When a subtask/delegated task completes, `TaskRouter._notify_parent_agent` and `_notify_delegating_agent` push the result into the recipient agent's Redis message queue (`lpush`) but never wake the recipient's container. The task-dispatch path already does the right thing — it calls `wake_agent(...)` before `push_task`. If the parent had idle-stopped while waiting for its child, the queued completion message was never consumed.

The inline comment assumes the agent picks the message up "in its next chat session or proactive run" — but for task-driven agents with proactive schedules disabled, there is no such wake, so the parent never resumes.

## Fix
Wake the recipient agent before the `lpush` in both notifier methods, mirroring the dispatch path (`if self.docker: await wake_agent(...)`, guarded by try/except so a wake failure can't break the notification).

## Impact / safety
- +24 lines, localized to the two notifier methods; no behavior change other than waking a stopped recipient.
- Mirrors an existing, production-proven pattern (the dispatch wake).
- Tasks already stuck in `RUNNING` from before the fix are auto-recovered on the next orchestrator restart by the existing `recover_stuck_tasks` logic (RUNNING + agent not working -> failed).

## Testing
- `py_compile` clean.
- No automated test added: there is no existing harness/mocks for `TaskRouter` (DB/Redis/Docker). Resolves the real failure scenario above; an integration check (run a 2-level delegation, confirm the parent reaches a terminal state) is recommended post-deploy.

Co-Authored-By: Claude Opus 4.8 (1M context)