### PR TITLE
fix(telegram): authenticate in-process bridge against the orchestrator API

### DIFF
--- a/orchestrator/app/telegram/_bridge_auth.py
+++ b/orchestrator/app/telegram/_bridge_auth.py
@@ -9,7 +9,14 @@ client.
 We mint a short-lived JWT for the platform admin and attach it to the bridge's
 HTTP clients. ``require_auth`` resolves it to a real user, so the bot keeps the
 internal access it had before without re-introducing a shared static secret.
+
+Token caching: JWTs are valid for 30 minutes (per create_access_token default).
+We cache the token for 25 minutes so at most one DB round-trip occurs per
+refresh cycle regardless of how many concurrent bot commands fire.
 """
+
+import asyncio
+import time
 
 import httpx
 from sqlalchemy import select
@@ -18,24 +25,50 @@ from app.core.auth import create_access_token
 from app.db.session import async_session_factory
 from app.models.user import User, UserRole
 
+_TOKEN_CACHE: str | None = None
+_TOKEN_EXPIRY: float = 0.0
+_TOKEN_TTL_SECONDS = 25 * 60  # 25 min — JWT valid 30 min, 5 min safety margin
+_cache_lock = asyncio.Lock()
 
-async def bridge_token() -> str | None:
-    """Mint a short-lived admin JWT for in-process bridge API calls.
 
-    Returns ``None`` if no approved admin exists (caller falls back to an
-    unauthenticated client, which will simply get the usual 401).
+async def bridge_token() -> str:
+    """Mint (or return cached) short-lived admin JWT for bridge API calls.
+
+    Raises RuntimeError if no approved admin exists so callers surface a clear
+    error instead of silently sending unauthenticated requests that produce the
+    same 401/KeyError the PR was meant to fix.
     """
-    async with async_session_factory() as session:
-        result = await session.execute(
-            select(User)
-            .where(User.role == UserRole.ADMIN, User.approved == True)  # noqa: E712
-            .limit(1)
-        )
-        user = result.scalar_one_or_none()
+    global _TOKEN_CACHE, _TOKEN_EXPIRY
+
+    now = time.monotonic()
+    if _TOKEN_CACHE and now < _TOKEN_EXPIRY:
+        return _TOKEN_CACHE
+
+    async with _cache_lock:
+        # Re-check inside the lock to avoid a thundering herd on expiry
+        now = time.monotonic()
+        if _TOKEN_CACHE and now < _TOKEN_EXPIRY:
+            return _TOKEN_CACHE
+
+        async with async_session_factory() as session:
+            result = await session.execute(
+                select(User)
+                .where(User.role == UserRole.ADMIN, User.approved == True)  # noqa: E712
+                .order_by(User.created_at)
+                .limit(1)
+            )
+            user = result.scalar_one_or_none()
+
         if user is None:
-            return None
-        role = user.role.value if hasattr(user.role, "value") else str(user.role)
-        return create_access_token(str(user.id), role)
+            raise RuntimeError(
+                "No approved admin user found — cannot mint bridge token. "
+                "Ensure at least one admin account is approved in the platform."
+            )
+
+        token = create_access_token(str(user.id), user.role.value)
+        _TOKEN_CACHE = token
+        _TOKEN_EXPIRY = time.monotonic() + _TOKEN_TTL_SECONDS
+        return token
 
 
 async def authed_client(**kwargs) -> httpx.AsyncClient:
@@ -48,9 +81,9 @@ async def authed_client(**kwargs) -> httpx.AsyncClient:
             resp = await client.get(f"{API_BASE}/agents/")
 
     Any ``headers`` passed in are preserved and merged with the Bearer token.
+    Raises RuntimeError (propagated from bridge_token) if no admin exists.
     """
     token = await bridge_token()
     headers = dict(kwargs.pop("headers", {}) or {})
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
+    headers["Authorization"] = f"Bearer {token}"
     return httpx.AsyncClient(headers=headers, **kwargs)

--- a/orchestrator/app/telegram/_bridge_auth.py
+++ b/orchestrator/app/telegram/_bridge_auth.py
@@ -1,0 +1,56 @@
+"""Authentication helper for the in-process Telegram bridge.
+
+The Telegram bot runs inside the orchestrator container and talks to the
+orchestrator HTTP API over localhost. Since v1.84.0 those endpoints require
+authentication (the previous ``X-Internal-Secret`` header was removed in the
+auth refactor), so the bridge must present a Bearer token like any other API
+client.
+
+We mint a short-lived JWT for the platform admin and attach it to the bridge's
+HTTP clients. ``require_auth`` resolves it to a real user, so the bot keeps the
+internal access it had before without re-introducing a shared static secret.
+"""
+
+import httpx
+from sqlalchemy import select
+
+from app.core.auth import create_access_token
+from app.db.session import async_session_factory
+from app.models.user import User, UserRole
+
+
+async def bridge_token() -> str | None:
+    """Mint a short-lived admin JWT for in-process bridge API calls.
+
+    Returns ``None`` if no approved admin exists (caller falls back to an
+    unauthenticated client, which will simply get the usual 401).
+    """
+    async with async_session_factory() as session:
+        result = await session.execute(
+            select(User)
+            .where(User.role == UserRole.ADMIN, User.approved == True)  # noqa: E712
+            .limit(1)
+        )
+        user = result.scalar_one_or_none()
+        if user is None:
+            return None
+        role = user.role.value if hasattr(user.role, "value") else str(user.role)
+        return create_access_token(str(user.id), role)
+
+
+async def authed_client(**kwargs) -> httpx.AsyncClient:
+    """Return an ``httpx.AsyncClient`` pre-authenticated as the platform admin.
+
+    Use exactly like ``httpx.AsyncClient(...)`` but for calls against the
+    orchestrator's own API:
+
+        async with await authed_client() as client:
+            resp = await client.get(f"{API_BASE}/agents/")
+
+    Any ``headers`` passed in are preserved and merged with the Bearer token.
+    """
+    token = await bridge_token()
+    headers = dict(kwargs.pop("headers", {}) or {})
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return httpx.AsyncClient(headers=headers, **kwargs)

--- a/orchestrator/app/telegram/agent_bot.py
+++ b/orchestrator/app/telegram/agent_bot.py
@@ -247,9 +247,9 @@ class TelegramAgentBot:
             )
             return
 
-        import httpx
+        from app.telegram._bridge_auth import authed_client
         try:
-            async with httpx.AsyncClient() as client:
+            async with await authed_client() as client:
                 resp = await client.get(f"http://127.0.0.1:8000/api/v1/agents/{self.agent_id}")
                 data = resp.json()
                 state = data.get("state", "unknown")

--- a/orchestrator/app/telegram/handlers/commands.py
+++ b/orchestrator/app/telegram/handlers/commands.py
@@ -1,12 +1,12 @@
 import asyncio
 import json
 
-import httpx
 import redis.asyncio as aioredis
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
 
 from app.config import settings
+from app.telegram._bridge_auth import authed_client
 
 # Use localhost since the bot runs INSIDE the orchestrator container
 API_BASE = "http://127.0.0.1:8000/api/v1"
@@ -36,7 +36,7 @@ async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 async def cmd_status(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    async with httpx.AsyncClient() as client:
+    async with await authed_client() as client:
         try:
             resp = await client.get(f"{API_BASE}/agents/")
             data = resp.json()
@@ -79,7 +79,7 @@ async def cmd_task(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
     prompt = " ".join(context.args)
 
-    async with httpx.AsyncClient() as client:
+    async with await authed_client() as client:
         try:
             resp = await client.post(
                 f"{API_BASE}/tasks/",
@@ -107,7 +107,7 @@ async def cmd_task(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 async def cmd_agents(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    async with httpx.AsyncClient() as client:
+    async with await authed_client() as client:
         try:
             resp = await client.get(f"{API_BASE}/agents/")
             data = resp.json()
@@ -145,7 +145,7 @@ async def cmd_chat(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         return
 
     # Otherwise show agent selection
-    async with httpx.AsyncClient() as client:
+    async with await authed_client() as client:
         try:
             resp = await client.get(f"{API_BASE}/agents/")
             data = resp.json()
@@ -231,7 +231,7 @@ async def _handle_rating_callback(query, data: str) -> None:
             return
 
         # Save rating via internal API
-        async with httpx.AsyncClient() as client:
+        async with await authed_client() as client:
             resp = await client.post(
                 f"{API_BASE}/ratings/tasks/{task_id}/rate",
                 json={"rating": rating},

--- a/orchestrator/tests/test_bridge_auth.py
+++ b/orchestrator/tests/test_bridge_auth.py
@@ -1,0 +1,100 @@
+"""Unit tests for app.telegram._bridge_auth (review findings PR #254)."""
+
+import asyncio
+import sys
+import time
+import types
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Stub the DB session before importing bridge_auth so it never tries to connect
+_db_session_stub = types.ModuleType("app.db.session")
+_db_session_stub.async_session_factory = MagicMock()
+sys.modules.setdefault("app.db.session", _db_session_stub)
+
+from app.telegram._bridge_auth import (  # noqa: E402
+    authed_client,
+    bridge_token,
+)
+import app.telegram._bridge_auth as _ba  # noqa: E402
+
+
+def _patch_factory(user):
+    """Patch async_session_factory on the module under test; return (patcher, session)."""
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = user
+    session.execute = AsyncMock(return_value=result)
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return patch.object(_ba, "async_session_factory", MagicMock(return_value=ctx)), session
+
+
+class BridgeTokenTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        _ba._TOKEN_CACHE = None
+        _ba._TOKEN_EXPIRY = 0.0
+        _ba._cache_lock = asyncio.Lock()
+
+    async def test_raises_when_no_admin(self):
+        """RuntimeError must be raised (not None returned) when no admin exists."""
+        patcher, _ = _patch_factory(user=None)
+        with patcher:
+            with self.assertRaises(RuntimeError):
+                await bridge_token()
+
+    async def test_token_cached_on_second_call(self):
+        """DB must be hit only once; second call returns the cached token."""
+        from app.models.user import UserRole
+
+        user = MagicMock()
+        user.id = "u1"
+        user.role = UserRole.ADMIN  # real enum; .value already == "admin"
+
+        patcher, session = _patch_factory(user=user)
+        with patcher:
+            t1 = await bridge_token()
+            t2 = await bridge_token()
+
+        self.assertEqual(t1, t2)
+        self.assertEqual(session.execute.call_count, 1, "DB queried more than once")
+
+    async def test_expired_cache_re_fetches(self):
+        """Expired token must trigger a fresh DB query."""
+        _ba._TOKEN_CACHE = "old-token"
+        _ba._TOKEN_EXPIRY = time.monotonic() - 1
+
+        from app.models.user import UserRole
+
+        user = MagicMock()
+        user.id = "u2"
+        user.role = UserRole.ADMIN  # real enum; .value already == "admin"
+
+        patcher, session = _patch_factory(user=user)
+        with patcher:
+            token = await bridge_token()
+
+        self.assertNotEqual(token, "old-token")
+        self.assertEqual(session.execute.call_count, 1)
+
+    async def test_authed_client_sets_auth_header(self):
+        """authed_client must always include an Authorization header."""
+        _ba._TOKEN_CACHE = "cached-tok"
+        _ba._TOKEN_EXPIRY = time.monotonic() + 9999
+
+        client = await authed_client()
+        self.assertIn("authorization", client.headers)
+        self.assertIn("cached-tok", client.headers["authorization"])
+        await client.aclose()
+
+    async def test_authed_client_propagates_runtime_error(self):
+        """authed_client must NOT silently send unauthed requests when no admin exists."""
+        patcher, _ = _patch_factory(user=None)
+        with patcher:
+            with self.assertRaises(RuntimeError):
+                await authed_client()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
Since **v1.84.0** the orchestrator API endpoints require authentication (the `X-Internal-Secret` header was removed in the auth refactor). The in-process Telegram bot, however, still calls the API on localhost with a plain, unauthenticated `httpx.AsyncClient()`.

Every bot command that hits the API therefore gets a **401**, whose JSON body has no `"agents"` key, and the handler's `data["agents"]` raises `KeyError: 'agents'` — surfacing to the user as:

```
/chat
Error: 'agents'
```

Affected: `/chat`, `/agents`, `/status`, `/task`, and the per-agent `/status`.

## Fix
Add a small helper `app/telegram/_bridge_auth.py`:
- `bridge_token()` mints a short-lived admin JWT (first approved `UserRole.ADMIN`).
- `authed_client(**kwargs)` returns an `httpx.AsyncClient` pre-authenticated with that Bearer token.

The bot's calls **to the orchestrator's own API** now use `await authed_client()` instead of a bare client. `require_auth` resolves the token to a real user, so the bridge keeps the internal access it had before — without re-introducing a shared static secret.

Calls to **external services** (OpenAI, STT/TTS) are deliberately left untouched.

## Scope
- `app/telegram/_bridge_auth.py` (new helper)
- `app/telegram/handlers/commands.py` (5 API call sites)
- `app/telegram/agent_bot.py` (1 API call site; STT/TTS calls untouched)
- `voice.py` unchanged (only external calls)

## Verification
On a deployed v1.84.0 instance, the exact path `/chat` uses now returns:
```
GET /agents via authed_client -> HTTP 200, 'agents'-key=True, count=9
```
`py_compile` clean on all three files.

Co-Authored-By: Claude Opus 4.8 (1M context)