### PR TITLE
feat(teams): first-class agent teams with lead-routing

### DIFF
--- a/docs/mindCoder/plans/2026-06-30-teams-feature.md
+++ b/docs/mindCoder/plans/2026-06-30-teams-feature.md
@@ -1,0 +1,593 @@
+# Teams Feature Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use mindCoder:subagent-driven-development (recommended) or mindCoder:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add first-class, persistent agent Teams (members + a lead) to the AI-Employee orchestrator: build a team in the Agents tab and delegate a task to it; the lead routes subtasks to the right members and consolidates results.
+
+**Architecture:** A new `teams` table + `/api/v1/teams` router. Delegation reuses the existing machinery: `POST /teams/{id}/tasks` creates a task for the team **lead** via `TaskRouter.create_and_route_task`, prepending the team roster + a lead instruction to the prompt (same idea as `_build_approval_rules_prefix`). The lead routes via the existing `create_task` MCP tool; member completions wake the lead via the existing delegation callback (`_notify_delegating_agent`/`wake_agent`, merged as #251). A team-scoped `list_my_team` tool and an Agents-tab UI complete it. **No new orchestration loop.**
+
+**Tech Stack:** FastAPI, SQLAlchemy 2 (async), Alembic, Pydantic, pytest (orchestrator), Next.js/React + TypeScript (frontend).
+
+---
+
+## File Structure
+
+**Backend (`orchestrator/`):**
+- Create `app/models/team.py` — `Team` ORM model (mirrors `app/models/meeting_room.py`).
+- Create `app/api/teams.py` — `/teams` router (CRUD + members/lead + delegate), mirrors `app/api/meeting_rooms.py`.
+- Modify `app/api/router.py` — import + `include_router(teams.router)`.
+- Create `app/alembic/versions/c1d2e3f4a5b6_add_teams_table.py` — migration (down_revision = current head `b2c3d4e5f6a7`).
+- Modify the orchestrator MCP tool module that defines `list_team`/`create_task` — add `list_my_team` (team-scoped). Find it by grepping the tool registry (Task 5).
+- Create `tests/test_teams.py` — API + invariant + delegate tests (tests live at `orchestrator/tests/*.py`; no shared conftest — each test file is self-contained).
+
+**Frontend (`frontend/src/`):**
+- Create `components/agents/teams-section.tsx` + `components/agents/create-team-modal.tsx` + `components/agents/delegate-to-team-modal.tsx` — mirror `components/agents/create-agent-modal.tsx`.
+- Modify the Agents page (`app/admin/agents/…` or `app/agents/…`) to render the Teams section.
+- Add an API client function set for `/teams` (mirror the existing agents API client).
+
+---
+
+## Task 1: `Team` model + migration
+
+**Files:**
+- Create: `orchestrator/app/models/team.py`
+- Create: `orchestrator/app/alembic/versions/c1d2e3f4a5b6_add_teams_table.py`
+- Test: `orchestrator/tests/test_teams.py`
+
+- [ ] **Step 1: Write the model**
+
+```python
+# orchestrator/app/models/team.py
+"""Team model — a persistent, named group of agents with a designated lead."""
+
+from sqlalchemy import String, Text, Boolean
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+
+class Team(Base, TimestampMixin):
+    __tablename__ = "teams"
+
+    id: Mapped[str] = mapped_column(String(32), primary_key=True)
+    name: Mapped[str] = mapped_column(String(200))
+    description: Mapped[str] = mapped_column(Text, default="")
+    # Agent IDs that belong to this team
+    member_agent_ids: Mapped[list] = mapped_column(JSONB, default=list)
+    # The lead agent (must be one of member_agent_ids); None until set
+    lead_agent_id: Mapped[str | None] = mapped_column(String(36), nullable=True, default=None)
+    created_by: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+```
+
+- [ ] **Step 2: Register the model for metadata**
+
+Confirm `app/models/__init__.py` imports models (grep it). If it lists models, add `from app.models.team import Team  # noqa: F401`. If models are imported elsewhere for Alembic autogenerate, follow that pattern (mirror how `meeting_room` is imported).
+
+Run: `grep -rn "meeting_room" orchestrator/app/models/__init__.py orchestrator/app/alembic/env.py`
+Add the `Team` import in the same place(s) `MeetingRoom` appears.
+
+- [ ] **Step 3: Write the migration**
+
+```python
+# orchestrator/app/alembic/versions/c1d2e3f4a5b6_add_teams_table.py
+"""add teams table
+
+Revision ID: c1d2e3f4a5b6
+Revises: b2c3d4e5f6a7
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "c1d2e3f4a5b6"
+down_revision = "b2c3d4e5f6a7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "teams",
+        sa.Column("id", sa.String(length=32), nullable=False),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("description", sa.Text(), server_default="", nullable=False),
+        sa.Column("member_agent_ids", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default="[]"),
+        sa.Column("lead_agent_id", sa.String(length=36), nullable=True),
+        sa.Column("created_by", sa.String(length=100), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("teams")
+```
+
+> Verify the exact `created_at`/`updated_at` column definitions against `app/models/base.py:TimestampMixin` and match them (server_default / onupdate) so autogenerate stays clean.
+
+- [ ] **Step 4: Run the migration against the DB**
+
+Run (in the orchestrator container): `docker exec ai-employee-orchestrator alembic upgrade head`
+Expected: `Running upgrade b2c3d4e5f6a7 -> c1d2e3f4a5b6, add teams table` then `Done`.
+Verify: `docker exec ai-employee-postgres psql -U ai_employee -d ai_employee -c "\d teams"` shows the table.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orchestrator/app/models/team.py orchestrator/app/alembic/versions/c1d2e3f4a5b6_add_teams_table.py orchestrator/app/models/__init__.py
+git commit -m "feat(teams): add Team model + migration"
+```
+
+---
+
+## Task 2: Team CRUD API + router registration
+
+**Files:**
+- Create: `orchestrator/app/api/teams.py`
+- Modify: `orchestrator/app/api/router.py`
+- Test: `orchestrator/tests/test_teams.py`
+
+- [ ] **Step 1: Write the failing test (create + get)**
+
+```python
+# orchestrator/tests/test_teams.py
+import pytest
+from httpx import AsyncClient, ASGITransport
+from app.main import app  # adjust import to the actual FastAPI app object
+from app.core.auth import create_access_token
+
+# NOTE: mirror auth/db setup from an existing test (e.g. tests/test_oauth_tenant.py).
+# This file assumes a helper that yields an admin Bearer header + a clean DB.
+
+@pytest.mark.asyncio
+async def test_create_and_get_team(admin_headers):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        r = await ac.post("/api/v1/teams", headers=admin_headers,
+                          json={"name": "Dev-Team", "description": "builds tools"})
+        assert r.status_code == 201
+        tid = r.json()["id"]
+        g = await ac.get(f"/api/v1/teams/{tid}", headers=admin_headers)
+        assert g.status_code == 200
+        assert g.json()["name"] == "Dev-Team"
+        assert g.json()["member_agent_ids"] == []
+        assert g.json()["lead_agent_id"] is None
+```
+
+> Before writing, READ `tests/test_oauth_tenant.py` (or another `tests/*.py` that calls the API) to copy the exact app-import, DB-setup, and admin-auth fixture pattern this repo uses. Replace `admin_headers` with that pattern.
+
+- [ ] **Step 2: Run it — expect fail (no /teams route)**
+
+Run: `docker exec ai-employee-orchestrator pytest tests/test_teams.py::test_create_and_get_team -v`
+Expected: FAIL (404 / route missing).
+
+- [ ] **Step 3: Write the router (CRUD), mirroring `app/api/meeting_rooms.py`**
+
+```python
+# orchestrator/app/api/teams.py
+"""Teams API — persistent agent teams with a lead, plus task delegation."""
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.dependencies import require_auth
+from app.models.team import Team
+from app.models.agent import Agent
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/teams", tags=["teams"])
+
+
+class CreateTeam(BaseModel):
+    name: str
+    description: str = ""
+    member_agent_ids: list[str] = []
+    lead_agent_id: str | None = None
+
+
+class UpdateTeam(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    member_agent_ids: list[str] | None = None
+    lead_agent_id: str | None = None
+
+
+def _serialize(t: Team) -> dict:
+    return {
+        "id": t.id, "name": t.name, "description": t.description,
+        "member_agent_ids": t.member_agent_ids or [],
+        "lead_agent_id": t.lead_agent_id, "is_active": t.is_active,
+        "created_by": t.created_by,
+    }
+
+
+def _validate_lead(member_ids: list[str], lead_id: str | None) -> None:
+    if lead_id is not None and lead_id not in (member_ids or []):
+        raise HTTPException(status_code=400, detail="lead_agent_id must be one of member_agent_ids")
+
+
+@router.post("/", status_code=201)
+async def create_team(body: CreateTeam, user=Depends(require_auth), db: AsyncSession = Depends(get_db)):
+    _validate_lead(body.member_agent_ids, body.lead_agent_id)
+    team = Team(
+        id=uuid.uuid4().hex[:32], name=body.name, description=body.description,
+        member_agent_ids=body.member_agent_ids, lead_agent_id=body.lead_agent_id,
+        created_by=getattr(user, "email", None) or str(getattr(user, "id", "")),
+    )
+    db.add(team)
+    await db.commit()
+    await db.refresh(team)
+    return _serialize(team)
+
+
+@router.get("/")
+async def list_teams(user=Depends(require_auth), db: AsyncSession = Depends(get_db)):
+    rows = (await db.execute(select(Team).where(Team.is_active == True))).scalars().all()  # noqa: E712
+    return {"teams": [_serialize(t) for t in rows]}
+
+
+async def _get_team(team_id: str, db: AsyncSession) -> Team:
+    t = (await db.execute(select(Team).where(Team.id == team_id))).scalar_one_or_none()
+    if not t or not t.is_active:
+        raise HTTPException(status_code=404, detail="Team not found")
+    return t
+
+
+@router.get("/{team_id}")
+async def get_team(team_id: str, user=Depends(require_auth), db: AsyncSession = Depends(get_db)):
+    return _serialize(await _get_team(team_id, db))
+
+
+@router.patch("/{team_id}")
+async def update_team(team_id: str, body: UpdateTeam, user=Depends(require_auth), db: AsyncSession = Depends(get_db)):
+    t = await _get_team(team_id, db)
+    if body.name is not None: t.name = body.name
+    if body.description is not None: t.description = body.description
+    if body.member_agent_ids is not None: t.member_agent_ids = body.member_agent_ids
+    if body.lead_agent_id is not None: t.lead_agent_id = body.lead_agent_id
+    _validate_lead(t.member_agent_ids, t.lead_agent_id)
+    await db.commit(); await db.refresh(t)
+    return _serialize(t)
+
+
+@router.delete("/{team_id}")
+async def delete_team(team_id: str, user=Depends(require_auth), db: AsyncSession = Depends(get_db)):
+    t = await _get_team(team_id, db)
+    t.is_active = False
+    await db.commit()
+    return {"status": "deleted", "id": team_id}
+```
+
+- [ ] **Step 4: Register the router**
+
+Modify `orchestrator/app/api/router.py`: add `teams` to the big `from app.api import …` import line, and add `api_router.include_router(teams.router)` next to `meeting_rooms.router`.
+
+- [ ] **Step 5: Run the test — expect pass**
+
+Run: `docker exec ai-employee-orchestrator pytest tests/test_teams.py::test_create_and_get_team -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add orchestrator/app/api/teams.py orchestrator/app/api/router.py orchestrator/tests/test_teams.py
+git commit -m "feat(teams): CRUD API + router registration"
+```
+
+---
+
+## Task 3: Member/lead management + invariant test
+
+**Files:**
+- Modify: `orchestrator/app/api/teams.py`
+- Test: `orchestrator/tests/test_teams.py`
+
+- [ ] **Step 1: Write the failing tests (members + lead invariant)**
+
+```python
+@pytest.mark.asyncio
+async def test_lead_must_be_member(admin_headers):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        tid = (await ac.post("/api/v1/teams", headers=admin_headers,
+               json={"name": "T", "member_agent_ids": ["a1"]})).json()["id"]
+        # setting a lead that is not a member -> 400
+        r = await ac.patch(f"/api/v1/teams/{tid}/lead", headers=admin_headers, json={"lead_agent_id": "ghost"})
+        assert r.status_code == 400
+        # adding the agent then setting it lead -> 200
+        await ac.post(f"/api/v1/teams/{tid}/members", headers=admin_headers, json={"add": ["lead1"]})
+        ok = await ac.patch(f"/api/v1/teams/{tid}/lead", headers=admin_headers, json={"lead_agent_id": "lead1"})
+        assert ok.status_code == 200
+        assert ok.json()["lead_agent_id"] == "lead1"
+```
+
+- [ ] **Step 2: Run — expect fail (routes missing)**
+
+Run: `docker exec ai-employee-orchestrator pytest tests/test_teams.py::test_lead_must_be_member -v`
+Expected: FAIL (404).
+
+- [ ] **Step 3: Add the endpoints to `teams.py`**
+
+```python
+class MembersChange(BaseModel):
+    add: list[str] = []
+    remove: list[str] = []
+
+
+class SetLead(BaseModel):
+    lead_agent_id: str | None
+
+
+@router.post("/{team_id}/members")
+async def change_members(team_id: str, body: MembersChange, user=Depends(require_auth), db: AsyncSession = Depends(get_db)):
+    t = await _get_team(team_id, db)
+    members = list(t.member_agent_ids or [])
+    for a in body.add:
+        if a not in members: members.append(a)
+    members = [m for m in members if m not in body.remove]
+    t.member_agent_ids = members
+    if t.lead_agent_id and t.lead_agent_id not in members:
+        t.lead_agent_id = None  # lead removed -> clear
+    await db.commit(); await db.refresh(t)
+    return _serialize(t)
+
+
+@router.patch("/{team_id}/lead")
+async def set_lead(team_id: str, body: SetLead, user=Depends(require_auth), db: AsyncSession = Depends(get_db)):
+    t = await _get_team(team_id, db)
+    _validate_lead(t.member_agent_ids, body.lead_agent_id)
+    t.lead_agent_id = body.lead_agent_id
+    await db.commit(); await db.refresh(t)
+    return _serialize(t)
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+Run: `docker exec ai-employee-orchestrator pytest tests/test_teams.py -v`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orchestrator/app/api/teams.py orchestrator/tests/test_teams.py
+git commit -m "feat(teams): member + lead management with invariant"
+```
+
+---
+
+## Task 4: Delegate-to-team (roster injection + reuse `create_and_route_task`)
+
+**Files:**
+- Modify: `orchestrator/app/api/teams.py`
+- Test: `orchestrator/tests/test_teams.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_delegate_requires_lead(admin_headers):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        tid = (await ac.post("/api/v1/teams", headers=admin_headers, json={"name": "T"})).json()["id"]
+        r = await ac.post(f"/api/v1/teams/{tid}/tasks", headers=admin_headers,
+                          json={"title": "x", "prompt": "do x"})
+        assert r.status_code == 400  # no lead
+```
+
+- [ ] **Step 2: Run — expect fail (404, route missing)**
+
+Run: `docker exec ai-employee-orchestrator pytest tests/test_teams.py::test_delegate_requires_lead -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the roster builder + delegate endpoint**
+
+Read each member's role from its `knowledge.md` first heading. Use the existing knowledge accessor (grep `def get_knowledge` / how `agents/{id}/knowledge` reads it) and mirror it; if the simplest path is the Agent model, read `Agent.name` for the roster and the role line from the knowledge endpoint helper.
+
+```python
+async def _team_roster(team: Team, db: AsyncSession) -> str:
+    lines = []
+    for aid in (team.member_agent_ids or []):
+        a = (await db.execute(select(Agent).where(Agent.id == aid))).scalar_one_or_none()
+        if not a:
+            continue
+        role = await _role_summary(aid)  # first non-empty line of knowledge.md, else ""
+        tag = " (LEAD)" if aid == team.lead_agent_id else ""
+        lines.append(f"- {a.name} [{aid}]{tag}: {role}")
+    return "\n".join(lines)
+
+
+LEAD_INSTRUCTION = (
+    "Du bist der LEAD dieses Teams. Zerlege die Aufgabe und delegiere sie via "
+    "`create_task` an die passende(n) Rolle(n) im Roster. Warte auf ihre Ergebnisse "
+    "(sie kommen als Delegation-Result zurück), konsolidiere und melde das Gesamtergebnis. "
+    "Passt keine Rolle, sag das ehrlich — rate nicht.\n\n## Team-Roster\n{roster}\n"
+)
+
+
+class DelegateTask(BaseModel):
+    title: str
+    prompt: str
+    priority: int = 5
+
+
+@router.post("/{team_id}/tasks", status_code=201)
+async def delegate_to_team(team_id: str, body: DelegateTask, request: Request,
+                           user=Depends(require_auth), db: AsyncSession = Depends(get_db)):
+    t = await _get_team(team_id, db)
+    if not t.lead_agent_id:
+        raise HTTPException(status_code=400, detail="assign a lead first")
+    if not (t.member_agent_ids or []):
+        raise HTTPException(status_code=400, detail="team has no members")
+    roster = await _team_roster(t, db)
+    prefix = LEAD_INSTRUCTION.format(roster=roster)
+    router_ = _get_task_router(request)  # mirror how tasks.py obtains the TaskRouter
+    task = await router_.create_and_route_task(
+        title=body.title, prompt=prefix + "\n## Aufgabe\n" + body.prompt,
+        priority=body.priority, agent_id=t.lead_agent_id,
+        metadata={"team_id": t.id, "delegated_to_team": True},
+    )
+    return {"task_id": task.id, "lead_agent_id": t.lead_agent_id, "status": task.status}
+```
+
+> READ `app/api/tasks.py` for: (a) the exact `Request`/`Depends` used to get the `TaskRouter` (`_get_task_router`), and (b) how `task.status` is serialized. Mirror it. Implement `_role_summary(aid)` by mirroring the knowledge read used by `GET /agents/{id}/knowledge`; fall back to `""` on any error (never block delegation on a missing role line).
+
+- [ ] **Step 4: Run — expect pass**
+
+Run: `docker exec ai-employee-orchestrator pytest tests/test_teams.py::test_delegate_requires_lead -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orchestrator/app/api/teams.py orchestrator/tests/test_teams.py
+git commit -m "feat(teams): delegate-to-team via lead routing (reuses create_and_route_task)"
+```
+
+---
+
+## Task 5: `list_my_team` orchestrator MCP tool
+
+**Files:**
+- Modify: the orchestrator MCP tool module (find it — see Step 1)
+
+- [ ] **Step 1: Locate the tool registry**
+
+Run: `grep -rln '"list_team"\|name="list_team"\|"create_task"' orchestrator/app | grep -vE 'msgraph|claude_md'`
+Open the file that defines `list_team`/`create_task` as MCP tools (the orchestrator MCP server the agents connect to). READ how one tool (e.g. `list_team`) is declared (schema) AND implemented (handler → calls into the orchestrator/DB).
+
+- [ ] **Step 2: Add `list_my_team`**
+
+Mirror `list_team` exactly, but scope to the caller's team: look up the `Team` whose `member_agent_ids` contains the calling agent's id (the handler already has the agent id from the MCP auth context — mirror how `list_team` gets it). Return members + role + state, marking the lead. Reuse `_team_roster`-style data (members from `Team.member_agent_ids`, names/states from `Agent`).
+
+> If an agent is in multiple teams, return all of them grouped by team. Keep the output shape parallel to `list_team`.
+
+- [ ] **Step 3: Restart orchestrator + verify the tool is offered**
+
+Run: `docker restart ai-employee-orchestrator` then check an agent's tool list / the MCP tool catalog includes `list_my_team` (grep orchestrator logs or call the tool-list endpoint the agents use — mirror how `list_team` is verified).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add orchestrator/app/<tool-module>.py
+git commit -m "feat(teams): list_my_team MCP tool (team-scoped roster)"
+```
+
+---
+
+## Task 6: Frontend — Teams section in the Agents tab
+
+**Files:**
+- Create: `frontend/src/components/agents/teams-section.tsx`, `create-team-modal.tsx`, `delegate-to-team-modal.tsx`
+- Modify: the Agents page that renders agent management (`frontend/src/app/admin/agents/…` or `frontend/src/app/agents/…`)
+- Modify/Create: the API client for `/teams`
+
+- [ ] **Step 1: Read the patterns to mirror**
+
+READ `frontend/src/components/agents/create-agent-modal.tsx` (modal + form + API call + toast patterns) and the existing agents admin page (how lists/cards/tabs are rendered, which UI lib/components, how auth/fetch is done). The Teams UI MUST reuse these components and the existing fetch/auth wrapper — do not introduce new patterns.
+
+- [ ] **Step 2: API client for `/teams`**
+
+Add functions mirroring the existing agents client: `listTeams()`, `createTeam(body)`, `getTeam(id)`, `updateTeam(id, body)`, `deleteTeam(id)`, `changeMembers(id, {add, remove})`, `setLead(id, lead_agent_id)`, `delegateToTeam(id, {title, prompt, priority})`. Use the same base-URL + auth-header helper the agents client uses.
+
+- [ ] **Step 3: `create-team-modal.tsx`**
+
+Mirror `create-agent-modal.tsx`: fields = name, description, multi-select members (from `listAgents()`), lead `<select>` constrained to the selected members. On submit → `createTeam`. Show success/error toast like the existing modals.
+
+- [ ] **Step 4: `teams-section.tsx`**
+
+A list of team cards (name, member avatars via `agent-avatar.tsx`, lead badge), a "New Team" button (opens the create modal), and per-card actions: edit members/lead, and "Delegate task" (opens `delegate-to-team-modal.tsx`).
+
+- [ ] **Step 5: `delegate-to-team-modal.tsx`**
+
+Form: title + prompt (+ optional priority) → `delegateToTeam(teamId, …)`. On success, toast with the returned `task_id` and a link to the Tasks tab.
+
+- [ ] **Step 6: Mount the section**
+
+Render `<TeamsSection/>` in the Agents page (a "Teams" sub-tab or section). Follow the page's existing tab/section structure.
+
+- [ ] **Step 7: Build + smoke test the frontend**
+
+Run: `cd frontend && npm run build` → expect success.
+Manual: load the Agents tab, create a team, assign members + lead, delegate a task, confirm the task appears.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/components/agents/teams-section.tsx frontend/src/components/agents/create-team-modal.tsx frontend/src/components/agents/delegate-to-team-modal.tsx frontend/src/app/<agents-page> frontend/src/<teams-api-client>
+git commit -m "feat(teams): Agents-tab UI — build teams, assign members/lead, delegate"
+```
+
+---
+
+## Task 7: Integration check (delegate → lead task carries roster) + open PR
+
+**Files:**
+- Test: `orchestrator/tests/test_teams.py`
+
+- [ ] **Step 1: Add an integration-ish test (roster reaches the lead task)**
+
+```python
+@pytest.mark.asyncio
+async def test_delegate_creates_lead_task_with_roster(admin_headers, monkeypatch):
+    # Stub create_and_route_task to capture the prompt the lead receives.
+    captured = {}
+    from app.core import task_router as tr
+    async def fake(self, *, title, prompt, priority=1, agent_id=None, metadata=None, **kw):
+        captured.update(prompt=prompt, agent_id=agent_id, metadata=metadata)
+        class _T: id="t1"; status="queued"
+        return _T()
+    monkeypatch.setattr(tr.TaskRouter, "create_and_route_task", fake)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        tid = (await ac.post("/api/v1/teams", headers=admin_headers,
+               json={"name":"T","member_agent_ids":["lead1","m2"],"lead_agent_id":"lead1"})).json()["id"]
+        r = await ac.post(f"/api/v1/teams/{tid}/tasks", headers=admin_headers,
+                          json={"title":"build","prompt":"do x"})
+    assert r.status_code == 201
+    assert captured["agent_id"] == "lead1"
+    assert "Team-Roster" in captured["prompt"] and "do x" in captured["prompt"]
+    assert captured["metadata"]["team_id"] == tid
+```
+
+> Adjust the monkeypatch target/signature to the real `create_and_route_task` location and kwargs.
+
+- [ ] **Step 2: Run the full test file**
+
+Run: `docker exec ai-employee-orchestrator pytest tests/test_teams.py -v`
+Expected: all PASS.
+
+- [ ] **Step 3: Commit + push + open PR**
+
+```bash
+git add orchestrator/tests/test_teams.py
+git commit -m "test(teams): delegate injects roster into the lead task"
+git push -u origin feat/teams
+gh pr create --repo greeves89/AI-Employee --base main --head feat/teams \
+  --title "feat(teams): first-class agent teams with lead-routing" \
+  --body "See docs/mindCoder/specs/2026-06-30-teams-feature-design.md. Persistent named teams (members + lead); delegate a task to a team and the lead routes via create_task; results return via the existing delegation callback. MVP scope; Weikert-over-teams deferred to phase 2."
+```
+
+---
+
+## Self-Review (against the spec)
+
+- **Data model** → Task 1. ✓
+- **CRUD API + member/lead mgmt** → Tasks 2, 3. ✓
+- **Delegate-to-team (roster + reuse create_and_route_task + callback)** → Task 4. ✓
+- **`list_my_team` tool** → Task 5. ✓
+- **Agents-tab UI** → Task 6. ✓
+- **Tests (API, invariant, delegate, integration)** → Tasks 2,3,4,7. ✓
+- **Error handling** (lead-not-member, no-lead, empty-team) → Tasks 3,4. ✓
+- **Non-goals** (MeetingRoom untouched, Weikert phase 2) → respected. ✓
+
+**Known reference points** (the implementer must read-and-mirror, not invent): the test harness (no shared conftest — copy an existing `tests/*.py`), the `TaskRouter` accessor in `app/api/tasks.py`, the `_role_summary` knowledge read, the orchestrator MCP tool module (Task 5 Step 1), and the frontend agents components (Task 6 Step 1). These are explicitly flagged in-task rather than guessed.

--- a/docs/mindCoder/plans/2026-06-30-teams-feature.md
+++ b/docs/mindCoder/plans/2026-06-30-teams-feature.md
@@ -10,6 +10,50 @@
 
 ---
 
+## Testing Convention (READ FIRST — overrides the test style shown in the tasks below)
+
+This repo's tests are **mocked-DB unit tests** (`@pytest.mark.asyncio` + `unittest.mock.AsyncMock`), **not** integration tests against a real Postgres. Mirror `orchestrator/tests/test_feedback_notifications.py`. Do **not** stand up a real DB; do **not** use `httpx.AsyncClient` against the live app.
+
+Every `tests/test_teams.py` test MUST follow this style:
+- **Pure logic** (`_validate_lead`, roster/prefix building, member add/remove logic) → call the function directly; assert the result or that it raises `HTTPException(status_code=400)`.
+- **Route handlers** that touch the DB → call the handler coroutine **directly** (not over HTTP) with an `AsyncMock` `db`, stubbing `db.execute(...)` return values; assert the object built and the calls made. Mock `TaskRouter.create_and_route_task` to capture its kwargs.
+
+Canonical helpers + example:
+```python
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from fastapi import HTTPException
+
+@pytest.fixture
+def db():
+    return AsyncMock()
+
+def _exec_returns(value):
+    """Build a mock result for `await db.execute(select(...))`."""
+    res = MagicMock()
+    res.scalar_one_or_none.return_value = value
+    res.scalars.return_value.all.return_value = value if isinstance(value, list) else []
+    return res
+
+@pytest.mark.asyncio
+async def test_validate_lead_rejects_non_member():
+    from app.api.teams import _validate_lead
+    with pytest.raises(HTTPException) as e:
+        _validate_lead(["a1"], "ghost")
+    assert e.value.status_code == 400
+```
+
+**Run the tests** (ephemeral container — mocked, so no DB env needed; never touches the live instance):
+```bash
+# from ~/Projects/AI-Employee
+rsync -az --delete --exclude __pycache__ --exclude '*.pyc' orchestrator/ openclaw:/home/openclaw/teams-test/orchestrator/
+ssh openclaw "docker run --rm -v /home/openclaw/teams-test/orchestrator:/app -w /app ai-employee-orchestrator pytest tests/test_teams.py -p no:cacheprovider -q"
+```
+
+**Ignore the `docker exec ai-employee-orchestrator pytest …` and `httpx.AsyncClient` lines in the task steps below** — they predate this convention. Use the ephemeral command above, and the mocked-handler style. (Task 1's migration step is the one exception that DOES run against a DB — run it once against the throwaway `ai_employee_test` DB, not live.)
+
+---
+
 ## File Structure
 
 **Backend (`orchestrator/`):**

--- a/docs/mindCoder/specs/2026-06-30-teams-feature-design.md
+++ b/docs/mindCoder/specs/2026-06-30-teams-feature-design.md
@@ -1,0 +1,117 @@
+# Teams — First-Class Agent Teams with Lead-Routing
+
+**Status:** Design approved (MVP scope) · **Date:** 2026-06-30 · **Target:** greeves89/AI-Employee
+
+## Problem & Goal
+
+Today the platform has exactly **one implicit, flat "team"** — all agents, surfaced via `team.json` / the `list_team` tool. Multi-agent collaboration only exists as **MeetingRooms**: ephemeral, discussion-oriented sessions that produce action items / TODOs / follow-ups.
+
+There is no way to:
+- compose a **persistent, named team** of selected agents,
+- give that team a **lead** who knows the members' capabilities,
+- **delegate a unit of work to the team** and have the lead route it to the right role.
+
+This is exactly the pattern we build by hand today (an "Atlas" orchestrator agent + specialist agents wired through `knowledge.md` prompts). This spec makes it a **first-class feature**: persistent Teams for work delegation, reusing the existing `create_task` + delegation-callback machinery.
+
+**Goal:** In the Agents tab, a user can build a Team, assign agents, designate a lead, and delegate a task to the team. The lead receives the task plus the team roster, routes subtasks to the right member(s) via `create_task`, the members' results flow back to the lead via the delegation callback, and the lead consolidates and reports back.
+
+## Scope
+
+**In (this MVP / first PR):**
+- `Team` data model + migration
+- Team CRUD API + member/lead management
+- **Delegate-task-to-team** with lead-routing (reuses `create_task` + delegation callback)
+- Lead context: team-roster injection + a team-scoped `list_my_team` tool
+- Agents-tab UI: create team, assign members + lead, list teams, delegate a task
+
+**Out (later phases):**
+- **Weikert "above all teams"** — a global bridge that picks the right team for a user request. MVP: the user delegates **directly to a chosen team**. (Phase 2)
+- Structured/iterative in-team review loops (the parked "iterative 3-lens review" design can later become a team behavior)
+- Cross-team collaboration, team-level scheduling, team analytics, a dedicated per-agent `capabilities` field
+
+## Data Model
+
+New table `teams` (follows the `MeetingRoom` conventions — JSONB for agent lists, short string id, `TimestampMixin`):
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | `str` (PK, 32) | short id |
+| `name` | `str` (200) | |
+| `description` | `Text` | default `""` |
+| `member_agent_ids` | `JSONB list[str]` | agents in the team |
+| `lead_agent_id` | `str \| None` | must be one of `member_agent_ids` |
+| `created_by` | `str \| None` | |
+| `is_active` | `bool` | default `True` (soft-delete) |
+| `created_at` / `updated_at` | via `TimestampMixin` | |
+
+**Invariants:**
+- `lead_agent_id`, if set, MUST be in `member_agent_ids` (enforced in the API layer).
+- An agent MAY belong to multiple teams.
+- When an agent is deleted, it is removed from every team's `member_agent_ids` (and cleared as lead if applicable). MVP: enforce on agent-delete; defensively filter unknown ids on read.
+
+**Migration:** one Alembic revision adding the `teams` table (head currently `b2c3d4e5f6a7`).
+
+## API (`/api/v1/teams`)
+
+Auth follows existing endpoints: `require_auth` (user JWT) for management, `require_auth_or_agent` where agents call (e.g. the lead's `list_my_team`). Team access mirrors agent-access rules (admin/manager: all; member/viewer: own/assigned).
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/teams` | create `{name, description?, member_agent_ids?, lead_agent_id?}` |
+| GET | `/teams` | list (scoped by role) |
+| GET | `/teams/{id}` | detail, with resolved member info (name, role, state) |
+| PATCH | `/teams/{id}` | update name/description/members/lead |
+| DELETE | `/teams/{id}` | soft-delete (`is_active=False`) |
+| POST | `/teams/{id}/members` | add/remove members `{add?: [...], remove?: [...]}` |
+| PATCH | `/teams/{id}/lead` | set lead (must be a member → 400 otherwise) |
+| POST | `/teams/{id}/tasks` | **delegate a task to the team** (the core) |
+
+Validation errors return 400 with a clear message (lead-not-member, no-lead-on-delegate, empty-team-on-delegate).
+
+## Delegate-to-Team (orchestration — reuse, not rebuild)
+
+`POST /teams/{id}/tasks {title, prompt, priority?}`:
+
+1. Resolve the team; require an **active lead** (`lead_agent_id`) and ≥1 member, else 400.
+2. Build the **team roster context**: for each member, `name` + a short **role summary** (the first non-empty heading of its `knowledge.md`, e.g. `# Rolle: …`), plus which member is the lead.
+3. Create a task **for the lead agent** via the existing `TaskRouter` task-creation path, **prepending** to the prompt:
+   - the roster, and
+   - a short lead instruction: *"You are this team's lead. Route the work to the right member(s) via `create_task`. Wait for their results, consolidate, and report back. If no member fits, say so — don't guess."*
+   This mirrors how the **approval-rules prefix** is already injected into task prompts today (`_build_approval_rules_prefix`).
+4. The lead executes: reads the roster, routes subtasks via `create_task` to the right member(s). Member completions notify the lead through the **existing delegation callback** (`_notify_delegating_agent` → `wake_agent`, the resume fix already in main as #251). The lead consolidates and reports up.
+
+**No new orchestration loop.** The only new orchestration code is the **roster + lead-instruction injection**; routing/convergence reuse `create_task` + the delegation callback.
+
+**New tool `list_my_team` (orchestrator MCP):** returns the **team-scoped** roster (members + roles + states) for the calling lead, so it can re-query mid-task. (The existing `list_team` returns *all* agents; this is the team-filtered variant.)
+
+## Lead "knows the capabilities"
+
+- **MVP:** role summary = the `# Rolle:` / first heading of each member's `knowledge.md`, injected into the lead's task context and available via `list_my_team`.
+- **Future (out of scope):** a dedicated structured `capabilities` field per agent for sharper routing.
+
+## UI — Agents tab → Teams
+
+A **"Teams" section** within the existing Agents view, following the tab's existing components/patterns:
+- **Create Team:** name, description, multi-select members (from existing agents), **lead dropdown** constrained to the selected members.
+- **Team list:** cards with name, member avatars, a lead badge, active state.
+- **Team detail:** edit members/lead; a **"Delegate task"** action (title + prompt → `POST /teams/{id}/tasks`) that surfaces the resulting lead task.
+
+## Error Handling
+
+- `lead_agent_id` not in members → 400.
+- delegate with no lead → 400 ("assign a lead first").
+- delegate to an empty team → 400.
+- a member agent is stopped → handled by the existing wake-on-dispatch (dispatch `wake_agent` + #251 callback wake).
+- lead can't find a suitable member → it **reports back honestly** rather than guessing (enforced via the lead instruction).
+
+## Testing
+
+- **API:** create/list/update/delete; member/lead invariants (lead-must-be-member); delegate creates a lead task carrying the roster; auth/role scoping.
+- **Orchestration (integration):** delegate-to-team → lead task created with roster → lead routes via `create_task` → member completes → callback wakes lead → lead consolidates. Reuse existing task/delegation test patterns under `orchestrator/tests`.
+- **Migration:** `teams` table present after `alembic upgrade head`.
+
+## Non-goals / Risks
+
+- **MeetingRoom is untouched** — Teams (persistent work delegation) and MeetingRooms (ephemeral discussion) are distinct concepts that coexist.
+- **Routing quality is prompt-driven** (the lead reasons over the roster, like the manual Atlas pattern today). Acceptable for MVP; structured capability-matching is a later enhancement.
+- **Weikert integration is deferred** to Phase 2 (global request → team selection).

--- a/docs/mindCoder/specs/2026-07-01-team-in-meeting-room-design.md
+++ b/docs/mindCoder/specs/2026-07-01-team-in-meeting-room-design.md
@@ -1,0 +1,35 @@
+# Team in Meeting-Room einladen (Convenience pre-fill)
+
+**Status:** Design approved · **Date:** 2026-07-01 · **Target:** greeves89/AI-Employee (extends the Teams feature / PR #256)
+
+## Problem & Goal
+A meeting room is created by selecting individual agents (`agent_ids`, 2–6). Now that Teams exist (members + lead), the user wants to invite a **whole team** to a meeting in one click instead of picking each agent. Goal: a team picker in the create-room flow that **pre-fills** the agent selection with the team's members.
+
+## Scope
+**In:** A frontend-only "Team auswählen" picker in the meeting-room create flow that, on selection, fills the existing agent multi-select with the team's `member_agent_ids`.
+
+**Out / not needed:**
+- **No backend or schema change.** The create-room endpoint and `MeetingRoom` model stay as-is (they take `agent_ids`); the team is resolved to agents purely client-side.
+- **Agents carrying meeting TODOs is already implemented** — `meeting_rooms.py:_generate_todo_summary` synthesizes the action-item list and "assigns action items to agents as real tasks" (the v1.85–1.86 work, `AgentTodo` model). No code needed; verify-live optional.
+- The room does **not** remember which team it came from (convenience, not a `team_id` link).
+
+## Design (frontend-only)
+**File:** `frontend/src/app/meeting-rooms/page.tsx` — the create-room flow where `agent_ids` are chosen today.
+
+1. Add an optional **"Team auswählen"** dropdown above/next to the agent selection, populated via the existing `listTeams()` API client (added with the Teams feature).
+2. On selecting a team: set the agent multi-select to the team's `member_agent_ids`. Mark the lead (e.g. a small badge) but it is a normal participant — no special role.
+3. **6-member cap** (the meeting endpoint enforces 2–6 agents): if the team has **>6** members, pre-select the first 6 with the **lead first**, and show an inline note: "Team hat mehr als 6 Mitglieder — 6 vorausgewählt, bitte anpassen." If a team has <2 members the user simply adds more (the existing ≥2 validation still applies).
+4. After pre-fill the user can still add/remove individual agents — the picker only seeds the selection.
+
+Reuse the existing meeting-room page's components, fetch/auth wrapper, and the agent-selection UI. Do not introduce new patterns or libraries.
+
+## Error Handling
+- No teams exist → the picker shows an empty/disabled state ("Keine Teams") and the user selects agents manually as before.
+- A team member agent no longer exists → it's simply absent from the selectable agents (filtered out); never block room creation.
+
+## Testing
+- No component unit tests exist in this repo → validate via `cd frontend && npm run build` (TypeScript + Next build is the authoritative gate) succeeding with no type errors.
+- Manual: open the meeting-room create flow, pick a team, confirm the agent selection fills with its members (lead marked), confirm the >6 cap note, create the room.
+
+## Non-goals
+- `team_id` link on rooms, lead-as-moderator automation, syncing later team changes into existing rooms — all out of scope (could be future).

--- a/frontend/src/app/agents/page.tsx
+++ b/frontend/src/app/agents/page.tsx
@@ -3,17 +3,22 @@
 import { useState, useEffect } from "react";
 import dynamic from "next/dynamic";
 import { motion } from "framer-motion";
-import { Plus, Play, Square, Trash2, Loader2, Bot, LayoutGrid, Network, StopCircle, ArrowUpCircle } from "lucide-react";
+import { Plus, Play, Square, Trash2, Loader2, Bot, LayoutGrid, Network, Users, StopCircle, ArrowUpCircle } from "lucide-react";
 import { useAgents } from "@/hooks/use-agents";
 import { Header } from "@/components/layout/header";
 import { AgentCard } from "@/components/dashboard/agent-card";
 import { cn } from "@/lib/utils";
 import * as api from "@/lib/api";
 import { useConfirm } from "@/components/ui/dialog-provider";
-type ViewMode = "grid" | "network";
+type ViewMode = "grid" | "network" | "teams";
 
 const CreateAgentModal = dynamic(
   () => import("@/components/agents/create-agent-modal").then((m) => m.CreateAgentModal),
+  { ssr: false },
+);
+
+const TeamsSection = dynamic(
+  () => import("@/components/agents/teams-section").then((m) => m.TeamsSection),
   { ssr: false },
 );
 
@@ -172,6 +177,16 @@ export default function AgentsPage() {
               >
                 <Network className="h-4 w-4" />
               </button>
+              <button
+                onClick={() => setViewMode("teams")}
+                className={cn(
+                  "rounded-lg px-2.5 py-2 text-muted-foreground hover:text-foreground hover:bg-foreground/[0.04] transition-all duration-200",
+                  viewMode === "teams" && "bg-foreground/[0.08] text-foreground"
+                )}
+                title="Teams View"
+              >
+                <Users className="h-4 w-4" />
+              </button>
             </div>
 
             {/* Update All — only visible when at least one agent has an update */}
@@ -235,7 +250,9 @@ export default function AgentsPage() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.3 }}
       >
-        {loading && agents.length === 0 ? (
+        {viewMode === "teams" ? (
+          <TeamsSection agents={agents} />
+        ) : loading && agents.length === 0 ? (
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
             {[1, 2, 3].map((i) => (
               <div

--- a/frontend/src/app/meeting-rooms/page.tsx
+++ b/frontend/src/app/meeting-rooms/page.tsx
@@ -26,6 +26,7 @@ import { Header } from "@/components/layout/header";
 import * as api from "@/lib/api";
 import { useConfirm, useToast } from "@/components/ui/dialog-provider";
 import type { MeetingRoom, Agent, AIAccount } from "@/lib/types";
+import type { Team } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
 const STATE_COLORS: Record<string, string> = {
@@ -41,6 +42,7 @@ export default function MeetingRoomsPage() {
   const toast = useToast();
   const [rooms, setRooms] = useState<MeetingRoom[]>([]);
   const [agents, setAgents] = useState<Agent[]>([]);
+  const [teams, setTeams] = useState<Team[]>([]);
   const [loading, setLoading] = useState(true);
   const [showCreate, setShowCreate] = useState(false);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
@@ -49,6 +51,8 @@ export default function MeetingRoomsPage() {
   const [name, setName] = useState("");
   const [topic, setTopic] = useState("");
   const [selectedAgents, setSelectedAgents] = useState<string[]>([]);
+  const [selectedTeamId, setSelectedTeamId] = useState("");
+  const [teamOverflow, setTeamOverflow] = useState(false);
   const [maxRounds, setMaxRounds] = useState(5);
   const [creating, setCreating] = useState(false);
   // Advanced settings
@@ -93,6 +97,7 @@ export default function MeetingRoomsPage() {
   useEffect(() => {
     fetchRooms();
     api.getAgents().then((d) => setAgents(d.agents)).catch(() => {});
+    api.listTeams().then((d) => setTeams(d.teams)).catch(() => {});
     api.listAIAccounts(true).then(setAiAccounts).catch(() => {});
     const interval = setInterval(fetchRooms, 5000);
     return () => clearInterval(interval);
@@ -125,6 +130,7 @@ export default function MeetingRoomsPage() {
       });
       setShowCreate(false);
       setName(""); setTopic(""); setSelectedAgents([]);
+      setSelectedTeamId(""); setTeamOverflow(false);
       setMaxRounds(5); setShowAdvanced(false);
       setCustomStages([{ name: "Eröffnung", rounds: 1 }, { name: "Analyse", rounds: 2 }, { name: "Synthese", rounds: 1 }]);
       router.push(`/meeting-rooms/${room.id}`);
@@ -180,6 +186,30 @@ export default function MeetingRoomsPage() {
           ? [...prev, agentId]
           : prev,
     );
+  };
+
+  // Lead of the currently picked team (for the "Lead" badge in the agent list)
+  const selectedTeamLeadId = teams.find((t) => t.id === selectedTeamId)?.lead_agent_id ?? null;
+
+  // Picking a team pre-fills the agent selection with its members (lead first),
+  // filtered to selectable agents and capped at the 6-member meeting limit.
+  const handleSelectTeam = (teamId: string) => {
+    setSelectedTeamId(teamId);
+    if (!teamId) {
+      setTeamOverflow(false);
+      return;
+    }
+    const team = teams.find((t) => t.id === teamId);
+    if (!team) return;
+    const selectable = new Set(runningAgents.map((a) => a.id));
+    const ordered = [
+      ...(team.lead_agent_id && selectable.has(team.lead_agent_id) ? [team.lead_agent_id] : []),
+      ...team.member_agent_ids.filter(
+        (id) => id !== team.lead_agent_id && selectable.has(id),
+      ),
+    ];
+    setTeamOverflow(ordered.length > 6);
+    setSelectedAgents(ordered.slice(0, 6));
   };
 
   const handleSummaryPDF = (room: MeetingRoom) => {
@@ -297,6 +327,27 @@ export default function MeetingRoomsPage() {
                   )}
                 </div>
 
+                {/* Team picker — pre-fills the agent selection below */}
+                <div>
+                  <label className="text-[11px] font-medium text-muted-foreground/70 uppercase tracking-wider">
+                    Team auswählen <span className="normal-case">(optional)</span>
+                  </label>
+                  <select
+                    value={selectedTeamId}
+                    onChange={(e) => handleSelectTeam(e.target.value)}
+                    disabled={teams.length === 0}
+                    className="mt-1 w-full rounded-lg border border-foreground/[0.08] bg-card px-3.5 py-2.5 text-sm outline-none focus:ring-2 focus:ring-primary/50 disabled:opacity-50"
+                  >
+                    <option value="">{teams.length === 0 ? "Keine Teams" : "Kein Team (manuell wählen)"}</option>
+                    {teams.map((t) => (
+                      <option key={t.id} value={t.id}>{t.name}</option>
+                    ))}
+                  </select>
+                  <p className="mt-1 text-[10px] text-muted-foreground/60">
+                    Ein Team füllt die Agenten-Auswahl vor — du kannst sie danach anpassen.
+                  </p>
+                </div>
+
                 {/* Agents */}
                 <div>
                   <label className="text-[11px] font-medium text-muted-foreground/70 uppercase tracking-wider">
@@ -321,10 +372,20 @@ export default function MeetingRoomsPage() {
                         >
                           <Bot className="h-3.5 w-3.5 shrink-0" />
                           <span className="truncate">{agent.name}</span>
+                          {selectedAgents.includes(agent.id) && agent.id === selectedTeamLeadId && (
+                            <span className="ml-auto shrink-0 rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-amber-400">
+                              Lead
+                            </span>
+                          )}
                         </button>
                       ))
                     )}
                   </div>
+                  {teamOverflow && (
+                    <p className="mt-1.5 text-[11px] text-amber-400">
+                      Team hat mehr als 6 Mitglieder — 6 vorausgewählt, bitte anpassen.
+                    </p>
+                  )}
                   {selectedAgents.length > 0 && (
                     <p className="mt-1 text-xs text-muted-foreground">{selectedAgents.length} ausgewählt</p>
                   )}

--- a/frontend/src/components/agents/create-team-modal.tsx
+++ b/frontend/src/components/agents/create-team-modal.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { motion, AnimatePresence } from "framer-motion";
+import { X, Plus, Loader2, Check, Crown, Users } from "lucide-react";
+import * as api from "@/lib/api";
+import type { Agent } from "@/lib/types";
+import type { Team } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { AgentAvatar } from "@/components/agents/agent-avatar";
+import { useToast } from "@/components/ui/dialog-provider";
+
+interface CreateTeamModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSaved: () => void;
+  agents: Agent[];
+  /** When provided, the modal edits this team instead of creating a new one. */
+  team?: Team | null;
+}
+
+export function CreateTeamModal({
+  open,
+  onOpenChange,
+  onSaved,
+  agents,
+  team,
+}: CreateTeamModalProps) {
+  const toast = useToast();
+  const isEdit = Boolean(team);
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [memberIds, setMemberIds] = useState<string[]>([]);
+  const [leadAgentId, setLeadAgentId] = useState<string>("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset / prefill on open
+  useEffect(() => {
+    if (open) {
+      setName(team?.name ?? "");
+      setDescription(team?.description ?? "");
+      setMemberIds(team?.member_agent_ids ?? []);
+      setLeadAgentId(team?.lead_agent_id ?? "");
+      setError(null);
+    }
+  }, [open, team]);
+
+  const toggleMember = (id: string) => {
+    setMemberIds((prev) => {
+      if (prev.includes(id)) {
+        // Removing the current lead clears the lead selection
+        if (leadAgentId === id) setLeadAgentId("");
+        return prev.filter((m) => m !== id);
+      }
+      return [...prev, id];
+    });
+  };
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      setError("Name ist erforderlich");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const body = {
+        name: name.trim(),
+        description: description.trim() || undefined,
+        member_agent_ids: memberIds,
+        lead_agent_id: leadAgentId || null,
+      };
+      if (isEdit && team) {
+        await api.updateTeam(team.id, body);
+        toast.success("Team aktualisiert", name.trim());
+      } else {
+        await api.createTeam(body);
+        toast.success("Team erstellt", name.trim());
+      }
+      onOpenChange(false);
+      onSaved();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Team konnte nicht gespeichert werden");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const memberAgents = agents.filter((a) => memberIds.includes(a.id));
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <AnimatePresence>
+        {open && (
+          <Dialog.Portal forceMount>
+            <Dialog.Overlay asChild>
+              <motion.div
+                className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.15 }}
+              />
+            </Dialog.Overlay>
+
+            <Dialog.Content asChild>
+              <motion.div
+                className="fixed inset-0 z-50 flex items-center justify-center p-4"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.2, ease: "easeOut" }}
+              >
+                <motion.div
+                  className="w-full max-w-2xl rounded-2xl border border-foreground/[0.08] bg-card shadow-2xl shadow-black/40 overflow-hidden max-h-[90vh] overflow-y-auto"
+                  initial={{ scale: 0.95, y: 10 }}
+                  animate={{ scale: 1, y: 0 }}
+                  exit={{ scale: 0.95, y: 10 }}
+                  transition={{ duration: 0.2, ease: "easeOut" }}
+                >
+                  {/* Header */}
+                  <div className="flex items-center justify-between border-b border-foreground/[0.06] px-6 py-4">
+                    <Dialog.Title className="text-lg font-semibold">
+                      {isEdit ? "Team bearbeiten" : "Team erstellen"}
+                    </Dialog.Title>
+                    <Dialog.Close className="rounded-lg p-1.5 text-muted-foreground hover:text-foreground hover:bg-foreground/[0.06] transition-colors">
+                      <X className="h-4 w-4" />
+                    </Dialog.Close>
+                  </div>
+
+                  {/* Body */}
+                  <div className="px-6 py-5 space-y-5">
+                    {/* Name */}
+                    <div>
+                      <label className="block text-xs font-medium text-muted-foreground mb-1.5">
+                        Name <span className="text-red-400">*</span>
+                      </label>
+                      <input
+                        type="text"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        onKeyDown={(e) => e.key === "Enter" && !saving && handleSave()}
+                        placeholder="z.B. Research-Team, Delivery-Squad..."
+                        autoFocus
+                        className="w-full rounded-lg border border-foreground/[0.1] bg-background/80 px-4 py-2.5 text-sm outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all"
+                      />
+                    </div>
+
+                    {/* Description */}
+                    <div>
+                      <label className="block text-xs font-medium text-muted-foreground mb-1.5">
+                        Beschreibung <span className="text-muted-foreground/40">(optional)</span>
+                      </label>
+                      <textarea
+                        value={description}
+                        onChange={(e) => setDescription(e.target.value)}
+                        placeholder="Wofuer ist dieses Team zustaendig?"
+                        rows={2}
+                        className="w-full rounded-lg border border-foreground/[0.1] bg-background/80 px-4 py-2.5 text-sm outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all resize-none"
+                      />
+                    </div>
+
+                    {/* Members */}
+                    <div>
+                      <label className="block text-xs font-medium text-muted-foreground mb-2.5">
+                        Mitglieder <span className="text-muted-foreground/40">({memberIds.length})</span>
+                      </label>
+                      <div className="space-y-2">
+                        {agents.map((agent) => {
+                          const isSelected = memberIds.includes(agent.id);
+                          return (
+                            <button
+                              key={agent.id}
+                              type="button"
+                              onClick={() => toggleMember(agent.id)}
+                              className={cn(
+                                "w-full flex items-center gap-3 rounded-xl border p-3 text-left transition-all duration-200",
+                                isSelected
+                                  ? "border-primary/40 bg-primary/[0.08]"
+                                  : "border-foreground/[0.06] bg-foreground/[0.02] hover:bg-foreground/[0.04]"
+                              )}
+                            >
+                              <AgentAvatar config={agent.config} size="sm" />
+                              <div className="flex-1 min-w-0">
+                                <p className={cn("text-sm font-medium truncate", isSelected ? "text-foreground" : "text-muted-foreground")}>
+                                  {agent.name}
+                                </p>
+                                {agent.role && (
+                                  <p className="text-xs text-muted-foreground/70 truncate">{agent.role}</p>
+                                )}
+                              </div>
+                              <div
+                                className={cn(
+                                  "flex h-5 w-5 shrink-0 items-center justify-center rounded-md border transition-all",
+                                  isSelected ? "border-primary bg-primary text-white" : "border-foreground/20"
+                                )}
+                              >
+                                {isSelected && <Check className="h-3 w-3" />}
+                              </div>
+                            </button>
+                          );
+                        })}
+
+                        {agents.length === 0 && (
+                          <p className="text-xs text-muted-foreground/50 text-center py-3">
+                            Keine Agents vorhanden — lege zuerst einen Agent an.
+                          </p>
+                        )}
+                      </div>
+                    </div>
+
+                    {/* Lead */}
+                    <div>
+                      <label className="block text-xs font-medium text-muted-foreground mb-1.5">
+                        <span className="inline-flex items-center gap-1.5">
+                          <Crown className="h-3.5 w-3.5 text-amber-400" /> Lead
+                        </span>{" "}
+                        <span className="text-muted-foreground/40">(optional)</span>
+                      </label>
+                      <select
+                        value={leadAgentId}
+                        onChange={(e) => setLeadAgentId(e.target.value)}
+                        disabled={memberAgents.length === 0}
+                        className="w-full rounded-lg border border-foreground/[0.1] bg-background/80 px-4 py-2.5 text-sm outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all disabled:opacity-50"
+                      >
+                        <option value="">Kein Lead</option>
+                        {memberAgents.map((agent) => (
+                          <option key={agent.id} value={agent.id}>
+                            {agent.name}
+                          </option>
+                        ))}
+                      </select>
+                      <p className="text-[11px] text-muted-foreground/50 mt-1">
+                        Der Lead muss Mitglied des Teams sein und erhaelt delegierte Tasks.
+                      </p>
+                    </div>
+
+                    {/* Error */}
+                    {error && (
+                      <div className="rounded-lg border border-red-500/20 bg-red-500/10 px-4 py-2.5 text-sm text-red-400">
+                        {error}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Footer */}
+                  <div className="flex items-center justify-end gap-3 border-t border-foreground/[0.06] px-6 py-4 bg-foreground/[0.02]">
+                    <Dialog.Close className="rounded-lg px-4 py-2.5 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-foreground/[0.04] transition-all">
+                      Abbrechen
+                    </Dialog.Close>
+                    <button
+                      onClick={handleSave}
+                      disabled={saving || !name.trim()}
+                      className="inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground disabled:opacity-50 transition-all shadow-lg shadow-primary/20 hover:bg-primary/90"
+                    >
+                      {saving ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : isEdit ? (
+                        <Users className="h-4 w-4" />
+                      ) : (
+                        <Plus className="h-4 w-4" />
+                      )}
+                      {saving ? "Speichere..." : isEdit ? "Speichern" : "Team erstellen"}
+                    </button>
+                  </div>
+                </motion.div>
+              </motion.div>
+            </Dialog.Content>
+          </Dialog.Portal>
+        )}
+      </AnimatePresence>
+    </Dialog.Root>
+  );
+}

--- a/frontend/src/components/agents/delegate-to-team-modal.tsx
+++ b/frontend/src/components/agents/delegate-to-team-modal.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { motion, AnimatePresence } from "framer-motion";
+import { X, Send, Loader2 } from "lucide-react";
+import * as api from "@/lib/api";
+import type { Team } from "@/lib/api";
+import { useToast } from "@/components/ui/dialog-provider";
+
+interface DelegateToTeamModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  team: Team | null;
+  onDelegated?: () => void;
+}
+
+export function DelegateToTeamModal({
+  open,
+  onOpenChange,
+  team,
+  onDelegated,
+}: DelegateToTeamModalProps) {
+  const toast = useToast();
+
+  const [title, setTitle] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [priority, setPriority] = useState("5");
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setTitle("");
+      setPrompt("");
+      setPriority("5");
+      setError(null);
+    }
+  }, [open]);
+
+  const handleDelegate = async () => {
+    if (!team) return;
+    if (!title.trim() || !prompt.trim()) {
+      setError("Titel und Prompt sind erforderlich");
+      return;
+    }
+    setSending(true);
+    setError(null);
+    try {
+      const res = await api.delegateToTeam(team.id, {
+        title: title.trim(),
+        prompt: prompt.trim(),
+        priority: parseInt(priority) || undefined,
+      });
+      toast.success("Task delegiert", `Task ${res.task_id}`);
+      onOpenChange(false);
+      onDelegated?.();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Task konnte nicht delegiert werden");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <AnimatePresence>
+        {open && (
+          <Dialog.Portal forceMount>
+            <Dialog.Overlay asChild>
+              <motion.div
+                className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.15 }}
+              />
+            </Dialog.Overlay>
+
+            <Dialog.Content asChild>
+              <motion.div
+                className="fixed inset-0 z-50 flex items-center justify-center p-4"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.2, ease: "easeOut" }}
+              >
+                <motion.div
+                  className="w-full max-w-lg rounded-2xl border border-foreground/[0.08] bg-card shadow-2xl shadow-black/40 overflow-hidden max-h-[90vh] overflow-y-auto"
+                  initial={{ scale: 0.95, y: 10 }}
+                  animate={{ scale: 1, y: 0 }}
+                  exit={{ scale: 0.95, y: 10 }}
+                  transition={{ duration: 0.2, ease: "easeOut" }}
+                >
+                  {/* Header */}
+                  <div className="flex items-center justify-between border-b border-foreground/[0.06] px-6 py-4">
+                    <Dialog.Title className="text-lg font-semibold">
+                      Task delegieren{team ? ` — ${team.name}` : ""}
+                    </Dialog.Title>
+                    <Dialog.Close className="rounded-lg p-1.5 text-muted-foreground hover:text-foreground hover:bg-foreground/[0.06] transition-colors">
+                      <X className="h-4 w-4" />
+                    </Dialog.Close>
+                  </div>
+
+                  {/* Body */}
+                  <div className="px-6 py-5 space-y-5">
+                    {!team?.lead_agent_id && (
+                      <div className="rounded-lg border border-amber-500/20 bg-amber-500/10 px-4 py-2.5 text-xs text-amber-400">
+                        Dieses Team hat keinen Lead. Lege zuerst einen Lead fest, damit der Task zugewiesen werden kann.
+                      </div>
+                    )}
+
+                    {/* Title */}
+                    <div>
+                      <label className="block text-xs font-medium text-muted-foreground mb-1.5">
+                        Titel <span className="text-red-400">*</span>
+                      </label>
+                      <input
+                        type="text"
+                        value={title}
+                        onChange={(e) => setTitle(e.target.value)}
+                        placeholder="z.B. Marktanalyse erstellen"
+                        autoFocus
+                        className="w-full rounded-lg border border-foreground/[0.1] bg-background/80 px-4 py-2.5 text-sm outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all"
+                      />
+                    </div>
+
+                    {/* Prompt */}
+                    <div>
+                      <label className="block text-xs font-medium text-muted-foreground mb-1.5">
+                        Prompt <span className="text-red-400">*</span>
+                      </label>
+                      <textarea
+                        value={prompt}
+                        onChange={(e) => setPrompt(e.target.value)}
+                        placeholder="Beschreibe die Aufgabe fuer das Team..."
+                        rows={5}
+                        className="w-full rounded-lg border border-foreground/[0.1] bg-background/80 px-4 py-2.5 text-sm outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all resize-none"
+                      />
+                    </div>
+
+                    {/* Priority */}
+                    <div>
+                      <label className="block text-xs font-medium text-muted-foreground mb-1.5">
+                        Prioritaet <span className="text-muted-foreground/40">(optional)</span>
+                      </label>
+                      <select
+                        value={priority}
+                        onChange={(e) => setPriority(e.target.value)}
+                        className="w-full rounded-lg border border-foreground/[0.1] bg-background/80 px-4 py-2.5 text-sm outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all"
+                      >
+                        <option value="1">1 — Niedrig</option>
+                        <option value="5">5 — Normal</option>
+                        <option value="10">10 — Hoch</option>
+                      </select>
+                    </div>
+
+                    {/* Error */}
+                    {error && (
+                      <div className="rounded-lg border border-red-500/20 bg-red-500/10 px-4 py-2.5 text-sm text-red-400">
+                        {error}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Footer */}
+                  <div className="flex items-center justify-end gap-3 border-t border-foreground/[0.06] px-6 py-4 bg-foreground/[0.02]">
+                    <Dialog.Close className="rounded-lg px-4 py-2.5 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-foreground/[0.04] transition-all">
+                      Abbrechen
+                    </Dialog.Close>
+                    <button
+                      onClick={handleDelegate}
+                      disabled={sending || !title.trim() || !prompt.trim()}
+                      className="inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground disabled:opacity-50 transition-all shadow-lg shadow-primary/20 hover:bg-primary/90"
+                    >
+                      {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+                      {sending ? "Delegiere..." : "Delegieren"}
+                    </button>
+                  </div>
+                </motion.div>
+              </motion.div>
+            </Dialog.Content>
+          </Dialog.Portal>
+        )}
+      </AnimatePresence>
+    </Dialog.Root>
+  );
+}

--- a/frontend/src/components/agents/teams-section.tsx
+++ b/frontend/src/components/agents/teams-section.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { motion } from "framer-motion";
+import { Plus, Users, Crown, Pencil, Send, Trash2, Loader2 } from "lucide-react";
+import * as api from "@/lib/api";
+import type { Team } from "@/lib/api";
+import type { Agent } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { AgentAvatar } from "@/components/agents/agent-avatar";
+import { CreateTeamModal } from "@/components/agents/create-team-modal";
+import { DelegateToTeamModal } from "@/components/agents/delegate-to-team-modal";
+import { useConfirm, useToast } from "@/components/ui/dialog-provider";
+
+export function TeamsSection({ agents }: { agents: Agent[] }) {
+  const confirm = useConfirm();
+  const toast = useToast();
+
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showCreate, setShowCreate] = useState(false);
+  const [editTeam, setEditTeam] = useState<Team | null>(null);
+  const [delegateTeam, setDelegateTeam] = useState<Team | null>(null);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+
+  const agentById = useCallback(
+    (id: string) => agents.find((a) => a.id === id) ?? null,
+    [agents],
+  );
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await api.listTeams();
+      setTeams(data.teams);
+    } catch {
+      setTeams([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleDelete = async (team: Team) => {
+    const ok = await confirm({
+      title: `Team "${team.name}" loeschen?`,
+      message: "Das Team wird entfernt. Die zugehoerigen Agents bleiben erhalten.",
+      variant: "destructive",
+      confirmLabel: "Loeschen",
+    });
+    if (!ok) return;
+    setActionLoading(team.id);
+    try {
+      await api.deleteTeam(team.id);
+      toast.success("Team geloescht", team.name);
+      await refresh();
+    } catch (e) {
+      toast.error("Loeschen fehlgeschlagen", e instanceof Error ? e.message : undefined);
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  return (
+    <div>
+      {/* Section header */}
+      <div className="flex items-center justify-between mb-5">
+        <div className="flex items-center gap-2.5">
+          <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            <Users className="h-5 w-5" />
+          </div>
+          <div>
+            <h2 className="text-base font-semibold leading-tight">Teams</h2>
+            <p className="text-xs text-muted-foreground">Agents buendeln, Lead festlegen, Tasks delegieren</p>
+          </div>
+        </div>
+        <button
+          onClick={() => setShowCreate(true)}
+          className="inline-flex items-center gap-2 rounded-xl bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground shadow-lg shadow-primary/20 hover:bg-primary/90 transition-all duration-200"
+        >
+          <Plus className="h-4 w-4" />
+          New Team
+        </button>
+      </div>
+
+      {/* Create / Edit / Delegate modals */}
+      <CreateTeamModal
+        open={showCreate}
+        onOpenChange={setShowCreate}
+        onSaved={refresh}
+        agents={agents}
+      />
+      <CreateTeamModal
+        open={editTeam !== null}
+        onOpenChange={(o) => !o && setEditTeam(null)}
+        onSaved={refresh}
+        agents={agents}
+        team={editTeam}
+      />
+      <DelegateToTeamModal
+        open={delegateTeam !== null}
+        onOpenChange={(o) => !o && setDelegateTeam(null)}
+        team={delegateTeam}
+      />
+
+      {/* Content */}
+      {loading && teams.length === 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="rounded-xl border border-foreground/[0.06] bg-card/50 p-5 h-40 animate-shimmer bg-[length:200%_100%] bg-gradient-to-r from-foreground/[0.03] via-foreground/[0.06] to-foreground/[0.03]"
+            />
+          ))}
+        </div>
+      ) : teams.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-foreground/[0.1] bg-card/30 p-16 text-center">
+          <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-foreground/[0.06] mb-4">
+            <Users className="h-7 w-7 text-muted-foreground" />
+          </div>
+          <h3 className="text-lg font-semibold mb-1.5">Noch keine Teams</h3>
+          <p className="text-sm text-muted-foreground mb-5">
+            Buendle deine Agents zu einem Team und delegiere Tasks an den Lead.
+          </p>
+          <button
+            onClick={() => setShowCreate(true)}
+            className="inline-flex items-center gap-2 rounded-xl bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground shadow-lg shadow-primary/20 hover:bg-primary/90 transition-all"
+          >
+            <Plus className="h-4 w-4" />
+            Team erstellen
+          </button>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+          {teams.map((team, i) => {
+            const lead = team.lead_agent_id ? agentById(team.lead_agent_id) : null;
+            return (
+              <motion.div
+                key={team.id}
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: i * 0.06, duration: 0.25 }}
+                className="group relative flex flex-col rounded-xl border border-foreground/[0.06] bg-card/50 p-5 transition-colors hover:border-foreground/[0.12]"
+              >
+                {/* Title row */}
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <h3 className="text-sm font-semibold truncate">{team.name}</h3>
+                      <span
+                        className={cn(
+                          "inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider",
+                          team.is_active
+                            ? "bg-emerald-500/10 text-emerald-400"
+                            : "bg-foreground/[0.06] text-muted-foreground"
+                        )}
+                      >
+                        <span className={cn("h-1.5 w-1.5 rounded-full", team.is_active ? "bg-emerald-400" : "bg-muted-foreground")} />
+                        {team.is_active ? "aktiv" : "inaktiv"}
+                      </span>
+                    </div>
+                    {team.description && (
+                      <p className="mt-1 text-xs text-muted-foreground/80 line-clamp-2">{team.description}</p>
+                    )}
+                  </div>
+
+                  {/* Card actions */}
+                  <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+                    {actionLoading === team.id ? (
+                      <div className="flex h-7 w-7 items-center justify-center">
+                        <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+                      </div>
+                    ) : (
+                      <>
+                        <button
+                          onClick={() => setEditTeam(team)}
+                          className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-foreground/[0.06] transition-colors"
+                          title="Mitglieder & Lead bearbeiten"
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                        </button>
+                        <button
+                          onClick={() => setDelegateTeam(team)}
+                          className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground hover:text-primary hover:bg-primary/10 transition-colors"
+                          title="Task delegieren"
+                        >
+                          <Send className="h-3.5 w-3.5" />
+                        </button>
+                        <button
+                          onClick={() => handleDelete(team)}
+                          className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground hover:text-red-400 hover:bg-red-500/15 transition-colors"
+                          title="Team loeschen"
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </button>
+                      </>
+                    )}
+                  </div>
+                </div>
+
+                {/* Members */}
+                <div className="mt-4 flex items-center gap-3">
+                  {team.member_agent_ids.length > 0 ? (
+                    <div className="flex -space-x-2">
+                      {team.member_agent_ids.slice(0, 6).map((id) => {
+                        const agent = agentById(id);
+                        return (
+                          <div key={id} className="rounded-xl ring-2 ring-card" title={agent?.name ?? id}>
+                            <AgentAvatar config={agent?.config} size="sm" />
+                          </div>
+                        );
+                      })}
+                      {team.member_agent_ids.length > 6 && (
+                        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-foreground/[0.06] text-[10px] font-medium text-muted-foreground ring-2 ring-card">
+                          +{team.member_agent_ids.length - 6}
+                        </div>
+                      )}
+                    </div>
+                  ) : (
+                    <p className="text-xs text-muted-foreground/60">Keine Mitglieder</p>
+                  )}
+                  <span className="text-xs text-muted-foreground/70">
+                    {team.member_agent_ids.length} {team.member_agent_ids.length === 1 ? "Mitglied" : "Mitglieder"}
+                  </span>
+                </div>
+
+                {/* Lead badge */}
+                <div className="mt-4 border-t border-foreground/[0.06] pt-3">
+                  {lead ? (
+                    <span className="inline-flex items-center gap-1.5 rounded-lg bg-amber-500/10 px-2.5 py-1 text-xs font-medium text-amber-400">
+                      <Crown className="h-3.5 w-3.5" />
+                      Lead: {lead.name}
+                    </span>
+                  ) : (
+                    <span className="inline-flex items-center gap-1.5 rounded-lg bg-foreground/[0.04] px-2.5 py-1 text-xs text-muted-foreground/70">
+                      <Crown className="h-3.5 w-3.5" />
+                      Kein Lead
+                    </span>
+                  )}
+                </div>
+              </motion.div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2286,3 +2286,75 @@ export async function provisionVerticalPack(slug: string): Promise<{
 }> {
   return fetchJSON(`${getBase()}/vertical-packs/${slug}/provision`, { method: "POST" });
 }
+
+// Teams
+export interface Team {
+  id: string;
+  name: string;
+  description: string | null;
+  member_agent_ids: string[];
+  lead_agent_id: string | null;
+  is_active: boolean;
+  created_by: string | null;
+}
+
+export async function listTeams(): Promise<{ teams: Team[] }> {
+  return fetchJSON(`${getBase()}/teams/`);
+}
+
+export async function createTeam(body: {
+  name: string;
+  description?: string;
+  member_agent_ids?: string[];
+  lead_agent_id?: string | null;
+}): Promise<Team> {
+  return fetchJSON(`${getBase()}/teams/`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function getTeam(id: string): Promise<Team> {
+  return fetchJSON(`${getBase()}/teams/${id}`);
+}
+
+export async function updateTeam(
+  id: string,
+  body: { name?: string; description?: string; member_agent_ids?: string[]; lead_agent_id?: string | null },
+): Promise<Team> {
+  return fetchJSON(`${getBase()}/teams/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function deleteTeam(id: string): Promise<void> {
+  await fetchJSON(`${getBase()}/teams/${id}`, { method: "DELETE" });
+}
+
+export async function changeTeamMembers(
+  id: string,
+  changes: { add?: string[]; remove?: string[] },
+): Promise<Team> {
+  return fetchJSON(`${getBase()}/teams/${id}/members`, {
+    method: "POST",
+    body: JSON.stringify(changes),
+  });
+}
+
+export async function setTeamLead(id: string, leadAgentId: string | null): Promise<Team> {
+  return fetchJSON(`${getBase()}/teams/${id}/lead`, {
+    method: "PATCH",
+    body: JSON.stringify({ lead_agent_id: leadAgentId }),
+  });
+}
+
+export async function delegateToTeam(
+  id: string,
+  body: { title: string; prompt: string; priority?: number },
+): Promise<{ task_id: string; lead_agent_id: string; status: string }> {
+  return fetchJSON(`${getBase()}/teams/${id}/tasks`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}

--- a/orchestrator/alembic/versions/c1d2e3f4a5b7_add_teams_table.py
+++ b/orchestrator/alembic/versions/c1d2e3f4a5b7_add_teams_table.py
@@ -1,0 +1,45 @@
+"""add teams table
+
+Revision ID: c1d2e3f4a5b7
+Revises: b2c3d4e5f6a7
+Create Date: 2026-06-30
+
+Creates the teams table — a persistent, named group of agents with a
+designated lead (Teams feature, Task 1).
+
+Note: the originally-specified revision id c1d2e3f4a5b6 was already taken by
+c1d2e3f4a5b6_add_autonomy_level_to_agents.py, so a unique id is used here.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "c1d2e3f4a5b7"
+down_revision = "b2c3d4e5f6a7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "teams",
+        sa.Column("id", sa.String(length=32), nullable=False),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("description", sa.Text(), server_default="", nullable=False),
+        sa.Column(
+            "member_agent_ids",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default="[]",
+        ),
+        sa.Column("lead_agent_id", sa.String(length=36), nullable=True),
+        sa.Column("created_by", sa.String(length=100), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("teams")

--- a/orchestrator/app/api/mcp_agent.py
+++ b/orchestrator/app/api/mcp_agent.py
@@ -27,6 +27,7 @@ from app.db.session import get_db
 from app.dependencies import get_redis_service
 from app.models.agent import Agent
 from app.models.task import Task, TaskStatus
+from app.models.team import Team
 from app.services.redis_service import RedisService
 
 router = APIRouter(prefix="/mcp", tags=["mcp-agent"])
@@ -85,6 +86,18 @@ AGENT_TOOLS = [
                     "description": "Number of tasks to return (default: 10, max: 50).",
                 },
             },
+        },
+    },
+    {
+        "name": "list_my_team",
+        "description": (
+            "List the team(s) YOU belong to, with each team's members (name, id, role) "
+            "and which member is the lead. The team-scoped counterpart to list_team "
+            "(which lists ALL agents). Use this to see only your own teams."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
         },
     },
     {
@@ -239,8 +252,65 @@ async def _handle_rpc(req: dict, agent: Agent, db: AsyncSession, redis: RedisSer
     return _mcp_error(rpc_id, -32601, f"Method not found: {method}")
 
 
+def _teams_for_agent(teams: list, agent_id: str) -> list:
+    """Pure selection: the subset of teams whose member roster includes agent_id.
+
+    JSONB containment queries vary across drivers, so membership is filtered in
+    Python on the (already active-filtered) team list — clear and portable.
+    """
+    return [t for t in teams if agent_id in (t.member_agent_ids or [])]
+
+
+async def _list_my_team(agent: Agent, db: AsyncSession) -> list[dict]:
+    """Return the active teams the calling agent belongs to, each with its roster.
+
+    Team-scoped counterpart to list_team (which returns ALL agents). For each team
+    the calling agent is a member of, returns:
+        {team_id, name, lead_agent_id, members: [{id, name, role, is_lead}]}
+    Member names/roles are resolved from the Agent model in a single query.
+    """
+    teams_res = await db.execute(select(Team).where(Team.is_active.is_(True)))
+    my_teams = _teams_for_agent(list(teams_res.scalars().all()), agent.id)
+    if not my_teams:
+        return []
+
+    member_ids = sorted({mid for t in my_teams for mid in (t.member_agent_ids or [])})
+    name_by_id: dict[str, str] = {}
+    role_by_id: dict[str, str | None] = {}
+    if member_ids:
+        agents_res = await db.execute(select(Agent).where(Agent.id.in_(member_ids)))
+        for a in agents_res.scalars().all():
+            name_by_id[a.id] = a.name
+            role_by_id[a.id] = (a.config or {}).get("role")
+
+    out: list[dict] = []
+    for t in my_teams:
+        members = [
+            {
+                "id": mid,
+                "name": name_by_id.get(mid, mid),
+                "role": role_by_id.get(mid),
+                "is_lead": mid == t.lead_agent_id,
+            }
+            for mid in (t.member_agent_ids or [])
+        ]
+        out.append({
+            "team_id": t.id,
+            "name": t.name,
+            "lead_agent_id": t.lead_agent_id,
+            "members": members,
+        })
+    return out
+
+
 async def _call_tool(name: str, args: dict, agent: Agent, db: AsyncSession, redis: RedisService) -> dict:
     """Execute an agent tool and return an MCP tool result."""
+
+    if name == "list_my_team":
+        teams = await _list_my_team(agent, db)
+        if not teams:
+            return _tool_result("You are not a member of any active team.")
+        return _tool_result(json.dumps({"teams": teams}, ensure_ascii=False))
 
     if name == "send_task":
         prompt = args.get("prompt", "").strip()

--- a/orchestrator/app/api/router.py
+++ b/orchestrator/app/api/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api import admin, agents, ai_accounts, analytics, approval_rules, approvals, audit, auth, brain, brain_mcp, brains, command_policies, computer_use, docker_apps, downloads, event_triggers, features, feedback, health, integrations, knowledge, knowledge_feeds, license as license_api, meeting_rooms, memory, mcp_agent, mcp_exchange, mcp_msgraph, mcp_msgraph_external, mcp_servers, notifications, oauth_as, ratings, roles, schedules, secrets, skill_marketplace, skills_catalog, tasks, telegram_actions, templates, todos, url_allowlist, user_profiles, version, vertical_packs, webhooks, ws, settings
+from app.api import admin, agents, ai_accounts, analytics, approval_rules, approvals, audit, auth, brain, brain_mcp, brains, command_policies, computer_use, docker_apps, downloads, event_triggers, features, feedback, health, integrations, knowledge, knowledge_feeds, license as license_api, meeting_rooms, memory, mcp_agent, mcp_exchange, mcp_msgraph, mcp_msgraph_external, mcp_servers, notifications, oauth_as, ratings, roles, schedules, secrets, skill_marketplace, skills_catalog, tasks, teams, telegram_actions, templates, todos, url_allowlist, user_profiles, version, vertical_packs, webhooks, ws, settings
 
 api_router = APIRouter()
 api_router.include_router(admin.router)
@@ -45,6 +45,7 @@ api_router.include_router(version.router)
 api_router.include_router(ws.router)
 api_router.include_router(settings.router)
 api_router.include_router(meeting_rooms.router)
+api_router.include_router(teams.router)
 api_router.include_router(approval_rules.router)
 api_router.include_router(command_policies.router)
 api_router.include_router(url_allowlist.router)

--- a/orchestrator/app/api/teams.py
+++ b/orchestrator/app/api/teams.py
@@ -2,13 +2,16 @@
 import logging
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.tasks import _get_task_router
+from app.core.task_router import TaskRouter
 from app.db.session import get_db
 from app.dependencies import require_auth
+from app.models.agent import Agent
 from app.models.team import Team
 
 logger = logging.getLogger(__name__)
@@ -128,3 +131,78 @@ async def set_lead(team_id: str, body: SetLead, user=Depends(require_auth), db: 
     await db.commit()
     await db.refresh(t)
     return _serialize(t)
+
+
+# ─── Task 4: delegate a task to a team via its lead ──────────────
+
+
+async def _role_summary(agent: Agent, request: Request) -> str:
+    """Best-effort first heading of the member's knowledge.md.
+
+    Mirrors agents.py: reads /workspace/knowledge.md via a container exec.
+    Returns the first non-empty line (leading '#' / 'Rolle:' stripped) or ""
+    on ANY failure (no docker, stopped container, exec error). A missing role
+    must never block delegation — keep this standalone + patchable in tests.
+    """
+    try:
+        docker = getattr(request.app.state, "docker", None)
+        if not docker or not getattr(agent, "container_id", None):
+            return ""
+        _, content = docker.exec_in_container(agent.container_id, "cat /workspace/knowledge.md")
+        for line in (content or "").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            line = line.lstrip("#").strip()  # drop leading heading markers
+            if line.lower().startswith("rolle:"):
+                line = line[len("rolle:"):].strip()
+            return line
+    except Exception:
+        return ""
+    return ""
+
+
+async def _team_roster(team: Team, db: AsyncSession, request: Request) -> str:
+    """Render the team's members as a roster string (one line per member)."""
+    lines: list[str] = []
+    for aid in (team.member_agent_ids or []):
+        agent = (await db.execute(select(Agent).where(Agent.id == aid))).scalar_one_or_none()
+        if not agent:
+            continue
+        role = await _role_summary(agent, request)
+        suffix = " (LEAD)" if aid == team.lead_agent_id else ""
+        lines.append(f"- {agent.name} [{aid}]{suffix}: {role}")
+    return "\n".join(lines)
+
+
+LEAD_INSTRUCTION = (
+    "Du bist der LEAD dieses Teams. Zerlege die Aufgabe und delegiere sie via "
+    "`create_task` an die passende(n) Rolle(n) im Roster. Warte auf ihre Ergebnisse "
+    "(sie kommen als Delegation-Result zurück), konsolidiere und melde das Gesamtergebnis. "
+    "Passt keine Rolle, sag das ehrlich — rate nicht.\n\n## Team-Roster\n{roster}\n"
+)
+
+
+class DelegateTask(BaseModel):
+    title: str
+    prompt: str
+    priority: int = 5
+
+
+@router.post("/{team_id}/tasks", status_code=201)
+async def delegate_to_team(team_id: str, body: DelegateTask, request: Request,
+                           router_: TaskRouter = Depends(_get_task_router),
+                           user=Depends(require_auth), db: AsyncSession = Depends(get_db)):
+    t = await _get_team(team_id, db)
+    if not t.lead_agent_id:
+        raise HTTPException(status_code=400, detail="assign a lead first")
+    if not (t.member_agent_ids or []):
+        raise HTTPException(status_code=400, detail="team has no members")
+    roster = await _team_roster(t, db, request)
+    prefix = LEAD_INSTRUCTION.format(roster=roster)
+    task = await router_.create_and_route_task(
+        title=body.title, prompt=prefix + "\n## Aufgabe\n" + body.prompt,
+        priority=body.priority, agent_id=t.lead_agent_id,
+        metadata={"team_id": t.id, "delegated_to_team": True},
+    )
+    return {"task_id": task.id, "lead_agent_id": t.lead_agent_id, "status": task.status}

--- a/orchestrator/app/api/teams.py
+++ b/orchestrator/app/api/teams.py
@@ -93,3 +93,38 @@ async def delete_team(team_id: str, user=Depends(require_auth), db: AsyncSession
     t.is_active = False
     await db.commit()
     return {"status": "deleted", "id": team_id}
+
+
+class MembersChange(BaseModel):
+    add: list[str] = []
+    remove: list[str] = []
+
+
+class SetLead(BaseModel):
+    lead_agent_id: str | None
+
+
+@router.post("/{team_id}/members")
+async def change_members(team_id: str, body: MembersChange, user=Depends(require_auth), db: AsyncSession = Depends(get_db)):
+    t = await _get_team(team_id, db)
+    members = list(t.member_agent_ids or [])
+    for a in body.add:
+        if a not in members:
+            members.append(a)
+    members = [m for m in members if m not in body.remove]
+    t.member_agent_ids = members
+    if t.lead_agent_id and t.lead_agent_id not in members:
+        t.lead_agent_id = None  # lead removed -> clear
+    await db.commit()
+    await db.refresh(t)
+    return _serialize(t)
+
+
+@router.patch("/{team_id}/lead")
+async def set_lead(team_id: str, body: SetLead, user=Depends(require_auth), db: AsyncSession = Depends(get_db)):
+    t = await _get_team(team_id, db)
+    _validate_lead(t.member_agent_ids, body.lead_agent_id)
+    t.lead_agent_id = body.lead_agent_id
+    await db.commit()
+    await db.refresh(t)
+    return _serialize(t)

--- a/orchestrator/app/api/teams.py
+++ b/orchestrator/app/api/teams.py
@@ -1,0 +1,95 @@
+"""Teams API — persistent agent teams with a lead, plus task delegation."""
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.dependencies import require_auth
+from app.models.team import Team
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/teams", tags=["teams"])
+
+
+class CreateTeam(BaseModel):
+    name: str
+    description: str = ""
+    member_agent_ids: list[str] = []
+    lead_agent_id: str | None = None
+
+
+class UpdateTeam(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    member_agent_ids: list[str] | None = None
+    lead_agent_id: str | None = None
+
+
+def _serialize(t: Team) -> dict:
+    return {
+        "id": t.id, "name": t.name, "description": t.description,
+        "member_agent_ids": t.member_agent_ids or [],
+        "lead_agent_id": t.lead_agent_id, "is_active": t.is_active,
+        "created_by": t.created_by,
+    }
+
+
+def _validate_lead(member_ids: list[str], lead_id: str | None) -> None:
+    if lead_id is not None and lead_id not in (member_ids or []):
+        raise HTTPException(status_code=400, detail="lead_agent_id must be one of member_agent_ids")
+
+
+async def _get_team(team_id: str, db: AsyncSession) -> Team:
+    t = (await db.execute(select(Team).where(Team.id == team_id))).scalar_one_or_none()
+    if not t or not t.is_active:
+        raise HTTPException(status_code=404, detail="Team not found")
+    return t
+
+
+@router.post("/", status_code=201)
+async def create_team(body: CreateTeam, user=Depends(require_auth), db: AsyncSession = Depends(get_db)):
+    _validate_lead(body.member_agent_ids, body.lead_agent_id)
+    team = Team(
+        id=uuid.uuid4().hex[:32], name=body.name, description=body.description,
+        member_agent_ids=body.member_agent_ids, lead_agent_id=body.lead_agent_id,
+        created_by=getattr(user, "email", None) or str(getattr(user, "id", "")),
+    )
+    db.add(team)
+    await db.commit()
+    await db.refresh(team)
+    return _serialize(team)
+
+
+@router.get("/")
+async def list_teams(user=Depends(require_auth), db: AsyncSession = Depends(get_db)):
+    rows = (await db.execute(select(Team).where(Team.is_active == True))).scalars().all()  # noqa: E712
+    return {"teams": [_serialize(t) for t in rows]}
+
+
+@router.get("/{team_id}")
+async def get_team(team_id: str, user=Depends(require_auth), db: AsyncSession = Depends(get_db)):
+    return _serialize(await _get_team(team_id, db))
+
+
+@router.patch("/{team_id}")
+async def update_team(team_id: str, body: UpdateTeam, user=Depends(require_auth), db: AsyncSession = Depends(get_db)):
+    t = await _get_team(team_id, db)
+    if body.name is not None: t.name = body.name
+    if body.description is not None: t.description = body.description
+    if body.member_agent_ids is not None: t.member_agent_ids = body.member_agent_ids
+    if body.lead_agent_id is not None: t.lead_agent_id = body.lead_agent_id
+    _validate_lead(t.member_agent_ids, t.lead_agent_id)
+    await db.commit(); await db.refresh(t)
+    return _serialize(t)
+
+
+@router.delete("/{team_id}")
+async def delete_team(team_id: str, user=Depends(require_auth), db: AsyncSession = Depends(get_db)):
+    t = await _get_team(team_id, db)
+    t.is_active = False
+    await db.commit()
+    return {"status": "deleted", "id": team_id}

--- a/orchestrator/app/models/__init__.py
+++ b/orchestrator/app/models/__init__.py
@@ -24,6 +24,7 @@ from app.models.agent_message import AgentMessage
 from app.models.task_rating import TaskRating
 from app.models.test_run import TestRun
 from app.models.meeting_room import MeetingRoom
+from app.models.team import Team  # noqa: F401
 from app.models.approval_rule import ApprovalRule
 from app.models.knowledge_feed import KnowledgeFeed, KnowledgeFeedItem
 from app.models.event_trigger import EventTrigger
@@ -51,6 +52,7 @@ __all__ = [
     "TaskRating",
     "TestRun",
     "MeetingRoom",
+    "Team",
     "ApprovalRule",
     "KnowledgeFeed", "KnowledgeFeedItem",
     "EventTrigger",

--- a/orchestrator/app/models/team.py
+++ b/orchestrator/app/models/team.py
@@ -1,0 +1,23 @@
+"""Team model — a persistent, named group of agents with a designated lead."""
+
+from sqlalchemy import String, Text, Boolean
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+
+class Team(Base, TimestampMixin):
+    __tablename__ = "teams"
+
+    id: Mapped[str] = mapped_column(String(32), primary_key=True)
+    name: Mapped[str] = mapped_column(String(200))
+    description: Mapped[str] = mapped_column(Text, default="")
+    # List of agent IDs that belong to the team
+    member_agent_ids: Mapped[list] = mapped_column(JSONB, default=list)
+    # Designated lead agent (one of the members) — None until assigned
+    lead_agent_id: Mapped[str | None] = mapped_column(String(36), nullable=True, default=None)
+    # Creator
+    created_by: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    # Active flag
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)

--- a/orchestrator/tests/test_teams.py
+++ b/orchestrator/tests/test_teams.py
@@ -1,0 +1,27 @@
+"""Tests for the Team model (Teams feature — Task 1)."""
+
+
+def test_team_imports_and_constructs():
+    """The Team model imports and can be constructed with minimal args."""
+    from app.models.team import Team
+
+    t = Team(id="x", name="Dev")
+    assert t.id == "x"
+    assert t.name == "Dev"
+
+
+def test_team_defaults():
+    """Column defaults are applied on flush; pre-flush the instance may carry None."""
+    from app.models.team import Team
+
+    t = Team(id="x", name="Dev")
+    # member_agent_ids default=list applies on flush; pre-flush it is None
+    assert t.member_agent_ids in (None, [])
+    assert t.lead_agent_id is None
+
+
+def test_team_tablename():
+    """The Team model maps to the 'teams' table."""
+    from app.models.team import Team
+
+    assert Team.__tablename__ == "teams"

--- a/orchestrator/tests/test_teams.py
+++ b/orchestrator/tests/test_teams.py
@@ -149,3 +149,84 @@ async def test_delegate_creates_lead_task_with_roster(monkeypatch):
     assert captured["agent_id"] == "lead1"
     assert "Team-Roster" in captured["prompt"] and "do x" in captured["prompt"]
     assert captured["metadata"]["team_id"] == "t1"
+
+
+# ─── Task 5: list_my_team MCP tool (team-scoped roster) ──────────
+
+
+def test_list_my_team_registered():
+    """The list_my_team tool is declared in the agent MCP tool registry."""
+    from app.api.mcp_agent import AGENT_TOOLS
+
+    names = [t["name"] for t in AGENT_TOOLS]
+    assert "list_my_team" in names
+
+
+def test_teams_for_agent_filters_membership():
+    """Pure selection helper keeps only teams whose roster includes the agent."""
+    from app.api.mcp_agent import _teams_for_agent
+    from app.models.team import Team
+
+    t1 = Team(id="t1", name="A", member_agent_ids=["me", "x"], lead_agent_id="me", is_active=True)
+    t2 = Team(id="t2", name="B", member_agent_ids=["y"], lead_agent_id="y", is_active=True)
+    t3 = Team(id="t3", name="C", member_agent_ids=None, lead_agent_id=None, is_active=True)
+
+    selected = _teams_for_agent([t1, t2, t3], "me")
+    assert [t.id for t in selected] == ["t1"]
+
+
+@pytest.mark.asyncio
+async def test_list_my_team_filters_to_membership():
+    """Handler returns only the team(s) the calling agent belongs to, with roster + lead."""
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+    from app.api.mcp_agent import _list_my_team
+    from app.models.team import Team
+
+    # t1 contains the calling agent "me" (and is its lead); t2 does not
+    t1 = Team(id="t1", name="A", member_agent_ids=["me", "x"], lead_agent_id="me", is_active=True)
+    t2 = Team(id="t2", name="B", member_agent_ids=["y"], lead_agent_id="y", is_active=True)
+
+    teams_res = MagicMock()
+    teams_res.scalars.return_value.all.return_value = [t1, t2]
+    agents_res = MagicMock()
+    agents_res.scalars.return_value.all.return_value = [
+        SimpleNamespace(id="me", name="Me", config={"role": "dev"}),
+        SimpleNamespace(id="x", name="Xavier", config={}),
+    ]
+    db = AsyncMock()
+    db.execute.side_effect = [teams_res, agents_res]
+
+    agent = SimpleNamespace(id="me")
+    out = await _list_my_team(agent, db)
+
+    assert len(out) == 1
+    team = out[0]
+    assert team["team_id"] == "t1"
+    assert team["name"] == "A"
+    assert team["lead_agent_id"] == "me"
+    members = {m["id"]: m for m in team["members"]}
+    assert set(members) == {"me", "x"}
+    assert members["me"]["is_lead"] is True
+    assert members["me"]["name"] == "Me"
+    assert members["me"]["role"] == "dev"
+    assert members["x"]["is_lead"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_my_team_empty_when_no_membership():
+    """An agent in no team yields an empty list (no second agent query needed)."""
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+    from app.api.mcp_agent import _list_my_team
+    from app.models.team import Team
+
+    t2 = Team(id="t2", name="B", member_agent_ids=["y"], lead_agent_id="y", is_active=True)
+    teams_res = MagicMock()
+    teams_res.scalars.return_value.all.return_value = [t2]
+    db = AsyncMock()
+    db.execute.side_effect = [teams_res]
+
+    out = await _list_my_team(SimpleNamespace(id="me"), db)
+    assert out == []
+    db.execute.assert_awaited_once()

--- a/orchestrator/tests/test_teams.py
+++ b/orchestrator/tests/test_teams.py
@@ -109,3 +109,43 @@ async def test_remove_member_clears_lead():
     out = await change_members("t1", MembersChange(remove=["lead1"]), user=MagicMock(), db=db)
     assert "lead1" not in out["member_agent_ids"]
     assert out["lead_agent_id"] is None
+
+
+# ─── Task 4: delegate-to-team via lead routing (mocked-DB unit tests) ──
+
+
+@pytest.mark.asyncio
+async def test_delegate_requires_lead():
+    from app.api.teams import delegate_to_team, DelegateTask
+    from app.models.team import Team
+    from unittest.mock import AsyncMock, MagicMock
+    t = Team(id="t1", name="T", member_agent_ids=["a1"], lead_agent_id=None, is_active=True)
+    db = AsyncMock(); db.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=t))
+    with pytest.raises(HTTPException) as e:
+        await delegate_to_team("t1", DelegateTask(title="x", prompt="do"),
+                               request=MagicMock(), router_=AsyncMock(), user=MagicMock(), db=db)
+    assert e.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_delegate_creates_lead_task_with_roster(monkeypatch):
+    import app.api.teams as teams_mod
+    from app.api.teams import delegate_to_team, DelegateTask
+    from app.models.team import Team
+    from unittest.mock import AsyncMock, MagicMock
+    t = Team(id="t1", name="T", member_agent_ids=["lead1", "m2"], lead_agent_id="lead1", is_active=True)
+    db = AsyncMock(); db.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=t))
+    # avoid real container/agent lookups
+    async def fake_roster(team, db_, request): return "- Lead [lead1] (LEAD): builds\n- M2 [m2]: tests"
+    monkeypatch.setattr(teams_mod, "_team_roster", fake_roster)
+    captured = {}
+    class _Task: id = "task1"; status = "queued"
+    router_ = AsyncMock()
+    async def fake_create(**kw): captured.update(kw); return _Task()
+    router_.create_and_route_task = fake_create
+    out = await delegate_to_team("t1", DelegateTask(title="build", prompt="do x"),
+                                 request=MagicMock(), router_=router_, user=MagicMock(), db=db)
+    assert out["task_id"] == "task1" and out["lead_agent_id"] == "lead1"
+    assert captured["agent_id"] == "lead1"
+    assert "Team-Roster" in captured["prompt"] and "do x" in captured["prompt"]
+    assert captured["metadata"]["team_id"] == "t1"

--- a/orchestrator/tests/test_teams.py
+++ b/orchestrator/tests/test_teams.py
@@ -71,3 +71,41 @@ async def test_get_team_404_when_missing():
     with pytest.raises(HTTPException) as e:
         await get_team("nope", user=MagicMock(), db=db)
     assert e.value.status_code == 404
+
+
+# ─── Task 3: member + lead management (mocked-DB unit tests) ──────
+
+
+@pytest.mark.asyncio
+async def test_set_lead_rejects_non_member():
+    from app.api.teams import set_lead, SetLead, Team
+    from unittest.mock import AsyncMock, MagicMock
+    t = Team(id="t1", name="T", member_agent_ids=["a1"], lead_agent_id=None, is_active=True)
+    db = AsyncMock()
+    db.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=t))
+    with pytest.raises(HTTPException) as e:
+        await set_lead("t1", SetLead(lead_agent_id="ghost"), user=MagicMock(), db=db)
+    assert e.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_set_lead_ok_for_member():
+    from app.api.teams import set_lead, SetLead, Team
+    from unittest.mock import AsyncMock, MagicMock
+    t = Team(id="t1", name="T", member_agent_ids=["a1", "lead1"], lead_agent_id=None, is_active=True)
+    db = AsyncMock()
+    db.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=t))
+    out = await set_lead("t1", SetLead(lead_agent_id="lead1"), user=MagicMock(), db=db)
+    assert out["lead_agent_id"] == "lead1"
+
+
+@pytest.mark.asyncio
+async def test_remove_member_clears_lead():
+    from app.api.teams import change_members, MembersChange, Team
+    from unittest.mock import AsyncMock, MagicMock
+    t = Team(id="t1", name="T", member_agent_ids=["a1", "lead1"], lead_agent_id="lead1", is_active=True)
+    db = AsyncMock()
+    db.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=t))
+    out = await change_members("t1", MembersChange(remove=["lead1"]), user=MagicMock(), db=db)
+    assert "lead1" not in out["member_agent_ids"]
+    assert out["lead_agent_id"] is None

--- a/orchestrator/tests/test_teams.py
+++ b/orchestrator/tests/test_teams.py
@@ -25,3 +25,49 @@ def test_team_tablename():
     from app.models.team import Team
 
     assert Team.__tablename__ == "teams"
+
+
+# ─── Task 2: /teams CRUD API (mocked-DB unit tests) ──────────────
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from fastapi import HTTPException
+
+
+def _exec_returns(value):
+    res = MagicMock()
+    res.scalar_one_or_none.return_value = value
+    res.scalars.return_value.all.return_value = value if isinstance(value, list) else []
+    return res
+
+
+@pytest.mark.asyncio
+async def test_create_team_builds_object():
+    from app.api.teams import create_team, CreateTeam
+    db = AsyncMock()
+    user = MagicMock(email="me@x.de")
+    out = await create_team(CreateTeam(name="Dev", member_agent_ids=["a1"]), user=user, db=db)
+    assert out["name"] == "Dev"
+    assert out["member_agent_ids"] == ["a1"]
+    assert out["created_by"] == "me@x.de"
+    db.add.assert_called_once()
+    db.commit.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_team_rejects_bad_lead():
+    from app.api.teams import create_team, CreateTeam
+    with pytest.raises(HTTPException) as e:
+        await create_team(CreateTeam(name="D", member_agent_ids=["a1"], lead_agent_id="ghost"),
+                          user=MagicMock(email="m"), db=AsyncMock())
+    assert e.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_get_team_404_when_missing():
+    from app.api.teams import get_team
+    db = AsyncMock()
+    db.execute.return_value = _exec_returns(None)
+    with pytest.raises(HTTPException) as e:
+        await get_team("nope", user=MagicMock(), db=db)
+    assert e.value.status_code == 404


### PR DESCRIPTION
## Was

Persistente, benannte **Teams** (Mitglieder + ein **Lead**), die man im Agents-Tab baut und an die man **Arbeit delegiert**: Der Lead bekommt die Aufgabe samt Team-Roster und routet Subtasks via `create_task` an die passende(n) Rolle(n); Ergebnisse fließen über den bestehenden Delegation-Callback (`_notify_delegating_agent`/`wake_agent`, #251) zurück, der Lead konsolidiert und meldet hoch. Produktisiert das bisher manuell (Orchestrator-Agent + Spezialisten via knowledge.md) gebaute Muster.

Design + Plan: `docs/mindCoder/specs/2026-06-30-teams-feature-design.md`, `docs/mindCoder/plans/2026-06-30-teams-feature.md`.

## Umfang (MVP)
- **Modell** `teams` (`member_agent_ids` JSONB, `lead_agent_id`) + Alembic-Migration `c1d2e3f4a5b7` (down_revision = aktueller Head `b2c3d4e5f6a7`).
- **API** `/api/v1/teams`: CRUD, `POST /{id}/members`, `PATCH /{id}/lead` (Invariante: Lead muss Member sein → 400), **`POST /{id}/tasks`** (Delegate).
- **Delegate-Orchestrierung**: Roster + Lead-Instruktion in den Lead-Task-Prompt injiziert (wie `_build_approval_rules_prefix`), Lead-Task via `create_and_route_task` — **kein neuer Loop**, nutzt die bestehende Mechanik.
- **`list_my_team`** MCP-Tool (team-scoped Roster).
- **Frontend** Agents-Tab: Team anlegen, Members + Lead zuweisen, Aufgabe delegieren.

## Tests
Mocked-DB Unit-Tests (Repo-Konvention, gespiegelt von `tests/test_feedback_notifications.py`) in `orchestrator/tests/test_teams.py` — **15 passing** (Modell, CRUD, Lead-Invariante, Delegate-Roster-Injektion, list_my_team-Scoping). Frontend: `npm run build` grün, keine TS-Fehler.

## Bewusst out of scope (Follow-ups)
- **Weikert „über allen Teams"** (globale Anfrage → Team-Auswahl) — Phase 2.
- **`list_my_team` als In-Task-Agent-Tool**: liegt hier auf der orchestrator-seitigen MCP-Fläche (`mcp_agent.py`, für externe Clients). Die In-Task-Tools (`list_team` etc.) leben im separaten `agent/`-Service (`agent/app/tools/`); echte In-Task-Parität bräuchte dort eine Ergänzung + einen Backing-Endpoint. **Nicht blockierend**, weil der Delegate-Endpoint den Roster bereits in den Lead-Prompt injiziert.
- Strukturierter iterativer Review-Loop (separat designt, geparkt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)