### PR TITLE
security: bind service ports to loopback only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,9 @@ services:
       target: base
     container_name: ai-employee-orchestrator
     ports:
-      - "${ORCHESTRATOR_PORT:-8000}:8000"
+      # Bind to loopback only — external access goes via reverse proxy.
+      # Prevents the orchestrator API being directly reachable on the public IP.
+      - "127.0.0.1:${ORCHESTRATOR_PORT:-8000}:8000"
     environment:
       DATABASE_URL: postgresql+asyncpg://ai_employee:${DB_PASSWORD:-devpassword}@postgres:5432/ai_employee
       REDIS_URL: redis://:${REDIS_PASSWORD:-changeme-redis-password}@redis:6379
@@ -215,7 +217,8 @@ services:
         NEXT_PUBLIC_WS_URL: ${NEXT_PUBLIC_WS_URL:-ws://localhost:8000}
     container_name: ai-employee-frontend
     ports:
-      - "${FRONTEND_PORT:-3000}:3000"
+      # Bind to loopback only — external access goes via reverse proxy.
+      - "127.0.0.1:${FRONTEND_PORT:-3000}:3000"
     depends_on:
       - orchestrator
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- Bind orchestrator port (`${ORCHESTRATOR_PORT:-8000}`) to `127.0.0.1` 
- Bind frontend port (`${FRONTEND_PORT:-3000}`) to `127.0.0.1`

Prevents both services from being directly reachable on the public IP — all external traffic must go through Caddy/Cloudflare Tunnel as intended.

## Why this PR exists

This is a **cherry-pick** of the `docker-compose.yml` changes from PR #247 (`harden/telegram-loopback-auth`). PR #247 is `CONFLICTING` with main because its auth changes (`X-Internal-Secret` / `INTERNAL_HEADERS`) were superseded by PR #254's JWT-based `_bridge_auth.py`. 

The `docker-compose.yml` portion of PR #247 had **zero conflicts** and provides an independent, high-value security fix. PR #247 will be closed in favour of this clean extraction.

## Test plan

- [ ] `docker compose up` locally — confirm orchestrator only listens on `127.0.0.1:8000`
- [ ] Verify Cloudflare Tunnel / Caddy still proxies requests correctly
- [ ] Confirm `curl http://<public-ip>:8000/health` is refused (not just unanswered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)