### PR TITLE
fix: apply user_id→None normalisation to store_pat and store_auth_json

### DIFF
--- a/orchestrator/app/services/oauth_service.py
+++ b/orchestrator/app/services/oauth_service.py
@@ -328,6 +328,8 @@ class OAuthService:
     async def store_pat(self, provider_name: str, token: str, user_id: str | None = None) -> OAuthIntegration:
         """Store a Personal Access Token (e.g., GitHub PAT)."""
         provider_enum = OAuthProvider(provider_name)
+        if not _is_per_user(provider_name):
+            user_id = None
         provider = get_provider(provider_name)
         account_label = None
         if provider.userinfo_url:
@@ -396,6 +398,8 @@ class OAuthService:
             raise ValueError("Codex auth.json is missing tokens.access_token")
 
         provider_enum = OAuthProvider(provider_name)
+        if not _is_per_user(provider_name):
+            user_id = None
         result = await self.db.execute(
             select(OAuthIntegration).where(_provider_filter(provider_enum, user_id))
         )

--- a/orchestrator/tests/test_oauth_reauth.py
+++ b/orchestrator/tests/test_oauth_reauth.py
@@ -91,6 +91,21 @@ class PersistTokensGlobalProviderTests(unittest.IsolatedAsyncioTestCase):
         assert len(inserted) == 1, "Expected exactly one INSERT"
         assert inserted[0].user_id is None, "Global provider row must have user_id=NULL"
 
+    @patch("app.services.oauth_service.encrypt_token", side_effect=_mock_encrypt)
+    @patch("app.services.oauth_service.httpx.AsyncClient")
+    async def test_reauth_per_user_provider_preserves_user_id(self, _http, _enc):
+        """persist_tokens for a per-user provider (Microsoft) must keep user_id."""
+        service = await self._make_service(existing_row=None)
+
+        inserted = []
+        service.db.add = MagicMock(side_effect=inserted.append)
+
+        token_data = {"access_token": "ms-token", "token_type": "Bearer"}
+        await service.persist_tokens("microsoft", "user-xyz", token_data)
+
+        assert len(inserted) == 1, "Expected exactly one INSERT"
+        assert inserted[0].user_id == "user-xyz", "Per-user provider must preserve user_id"
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- `store_pat` and `store_auth_json` had the same `UniqueViolation` gap as `persist_tokens` (fixed in PR #259): `_provider_filter` was called with a non-`None` `user_id` for global providers (GitHub, Codex), causing a SELECT miss → INSERT → unique constraint violation on re-auth.
- Added `if not _is_per_user(provider_name): user_id = None` guard to both methods, mirroring the `persist_tokens` fix.
- Added a 4th regression test: per-user providers (Microsoft) still preserve the caller's `user_id`.

## Test plan

- [x] `test_reauth_global_provider_updates_existing_row` — re-auth with non-None user_id hits UPDATE path
- [x] `test_reauth_global_provider_no_insert_when_row_exists` — `db.add` never called for global provider
- [x] `test_first_auth_global_provider_inserts_with_null_user_id` — first-time auth inserts `user_id=NULL`
- [x] `test_reauth_per_user_provider_preserves_user_id` — Microsoft keeps caller's `user_id` (new)
- [x] All 14 tests pass (`test_oauth_reauth.py`, `test_bridge_auth.py`, `test_oauth_tenant.py`)

Fixes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)