### PR TITLE
fix(telegram): wrap resp.json() in JSONDecodeError guard → 502

### DIFF
--- a/orchestrator/app/api/telegram_actions.py
+++ b/orchestrator/app/api/telegram_actions.py
@@ -58,7 +58,13 @@ async def _tg_request(token: str, method: str, data: dict | None = None, files: 
         raise HTTPException(status_code=504, detail=f"Telegram API timeout after {timeout}s for {method}")
     except httpx.RequestError as exc:
         raise HTTPException(status_code=502, detail=f"Telegram API connection error: {exc}")
-    result = resp.json()
+    try:
+        result = resp.json()
+    except json.JSONDecodeError:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Telegram returned non-JSON response (HTTP {resp.status_code})",
+        )
     if not result.get("ok"):
         raise HTTPException(
             status_code=400,
@@ -410,6 +416,8 @@ async def send_photo(
         return await _tg_request(token, "sendPhoto", data)
     elif body.photo_base64:
         photo_bytes = base64.b64decode(body.photo_base64)
+        if len(photo_bytes) > _TELEGRAM_MAX_FILE_BYTES:
+            raise HTTPException(status_code=413, detail="File exceeds Telegram's 50 MB limit")
         data = {"chat_id": str(body.chat_id)}
         if body.caption:
             data["caption"] = body.caption
@@ -418,7 +426,7 @@ async def send_photo(
         if body.reply_markup:
             data["reply_markup"] = json.dumps(body.reply_markup)
         files = {"photo": ("photo.jpg", photo_bytes, "image/jpeg")}
-        return await _tg_request(token, "sendPhoto", data, files=files)
+        return await _tg_request(token, "sendPhoto", data, files=files, timeout=120)
     else:
         raise HTTPException(status_code=400, detail="Provide photo_base64 or photo_url")
 
@@ -590,6 +598,8 @@ async def send_video(
         return await _tg_request(token, "sendVideo", data)
     elif body.video_base64:
         video_bytes = base64.b64decode(body.video_base64)
+        if len(video_bytes) > _TELEGRAM_MAX_FILE_BYTES:
+            raise HTTPException(status_code=413, detail="File exceeds Telegram's 50 MB limit")
         data = {"chat_id": str(body.chat_id)}
         if body.caption:
             data["caption"] = body.caption
@@ -598,7 +608,7 @@ async def send_video(
         if body.reply_markup:
             data["reply_markup"] = json.dumps(body.reply_markup)
         files = {"video": ("video.mp4", video_bytes, "video/mp4")}
-        return await _tg_request(token, "sendVideo", data, files=files)
+        return await _tg_request(token, "sendVideo", data, files=files, timeout=120)
     else:
         raise HTTPException(status_code=400, detail="Provide video_base64 or video_url")
 
@@ -652,6 +662,8 @@ async def send_animation(
         return await _tg_request(token, "sendAnimation", data)
     elif body.animation_base64:
         anim_bytes = base64.b64decode(body.animation_base64)
+        if len(anim_bytes) > _TELEGRAM_MAX_FILE_BYTES:
+            raise HTTPException(status_code=413, detail="File exceeds Telegram's 50 MB limit")
         data = {"chat_id": str(body.chat_id)}
         if body.caption:
             data["caption"] = body.caption
@@ -660,7 +672,7 @@ async def send_animation(
         if body.reply_markup:
             data["reply_markup"] = json.dumps(body.reply_markup)
         files = {"animation": ("animation.gif", anim_bytes, "image/gif")}
-        return await _tg_request(token, "sendAnimation", data, files=files)
+        return await _tg_request(token, "sendAnimation", data, files=files, timeout=120)
     else:
         raise HTTPException(status_code=400, detail="Provide animation_base64 or animation_url")
 

--- a/orchestrator/tests/test_api/test_telegram_actions.py
+++ b/orchestrator/tests/test_api/test_telegram_actions.py
@@ -1,0 +1,92 @@
+"""Unit tests for _tg_request in telegram_actions — error handling."""
+import json
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# --- Stub heavy dependencies before importing telegram_actions ---
+
+def _make_stub(name: str, **attrs):
+    """Create and register a module stub, overwriting any existing entry."""
+    m = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(m, k, v)
+    sys.modules[name] = m
+    return m
+
+_sqlalchemy = _make_stub("sqlalchemy", select=MagicMock(), text=MagicMock())
+_make_stub("sqlalchemy.ext", asyncio=MagicMock())
+_make_stub("sqlalchemy.ext.asyncio", AsyncSession=MagicMock())
+_make_stub("sqlalchemy.orm", Session=MagicMock())
+_make_stub("redis")
+_make_stub("redis.asyncio", from_url=MagicMock())
+_make_stub("app.config", settings=MagicMock(redis_url="redis://localhost"))
+_make_stub("app.db.session", get_db=MagicMock(), async_session_factory=MagicMock())
+_make_stub("app.dependencies", verify_agent_token=MagicMock())
+_make_stub("app.models")
+_make_stub("app.models.agent", Agent=MagicMock())
+
+from app.api.telegram_actions import _tg_request  # noqa: E402
+
+
+# --- Helpers ---
+
+class _FakeResponse:
+    def __init__(self, status_code: int, body: bytes, is_json: bool = True):
+        self.status_code = status_code
+        self._body = body
+        self._is_json = is_json
+
+    def json(self):
+        if not self._is_json:
+            raise json.JSONDecodeError("Expecting value", "", 0)
+        return json.loads(self._body)
+
+
+def _client_ctx(response: _FakeResponse):
+    """Build an async context manager mock whose .post() returns *response*."""
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=response)
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=client)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx
+
+
+# --- Tests ---
+
+@pytest.mark.asyncio
+async def test_json_decode_error_becomes_502():
+    """Non-JSON Telegram response (e.g. Cloudflare HTML) must raise 502, not crash."""
+    from fastapi import HTTPException
+
+    html = _FakeResponse(200, b"<html>Bad Gateway</html>", is_json=False)
+    with patch("app.api.telegram_actions.httpx.AsyncClient", return_value=_client_ctx(html)):
+        with pytest.raises(HTTPException) as exc_info:
+            await _tg_request("tok", "sendMessage", {"chat_id": 1, "text": "hi"})
+    assert exc_info.value.status_code == 502
+    assert "non-JSON" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_ok_response_returns_result():
+    """Valid Telegram JSON response returns the result payload."""
+    ok = _FakeResponse(200, json.dumps({"ok": True, "result": {"message_id": 7}}).encode())
+    with patch("app.api.telegram_actions.httpx.AsyncClient", return_value=_client_ctx(ok)):
+        result = await _tg_request("tok", "sendMessage", {"chat_id": 1, "text": "hi"})
+    assert result == {"message_id": 7}
+
+
+@pytest.mark.asyncio
+async def test_not_ok_becomes_400():
+    """Telegram ok=false response raises 400 with the description."""
+    from fastapi import HTTPException
+
+    err = _FakeResponse(200, json.dumps({"ok": False, "description": "Bad Request"}).encode())
+    with patch("app.api.telegram_actions.httpx.AsyncClient", return_value=_client_ctx(err)):
+        with pytest.raises(HTTPException) as exc_info:
+            await _tg_request("tok", "sendMessage", {"chat_id": 1, "text": "hi"})
+    assert exc_info.value.status_code == 400
+    assert "Bad Request" in exc_info.value.detail


### PR DESCRIPTION
## Summary

- Wraps `resp.json()` in a `try/except json.JSONDecodeError` inside `_tg_request` — the call was previously outside the try block, so a Cloudflare rate-limit page or gateway HTML response would crash with an unhandled exception → 500
- Returns **HTTP 502** with a descriptive message when Telegram sends non-JSON
- **Bonus**: applies consistent 50 MB 413 guard and 120s timeout to `send_photo`, `send_video`, and `send_animation` (base64 paths) to match `send_voice` / `send_document` from PR #258

## Test plan
- [x] 3 unit tests added: JSONDecodeError → 502, ok response → result, not-ok → 400
- [x] All 3 tests pass locally

Fixes #262