### PR TITLE
feat(voice): cache system prompt for voice LLM turns

### DIFF
--- a/orchestrator/app/services/voice_providers/llm_anthropic.py
+++ b/orchestrator/app/services/voice_providers/llm_anthropic.py
@@ -40,10 +40,19 @@ class AnthropicVoiceLLM(VoiceLLMProvider):
         system_prompt: str,
     ) -> AsyncIterator[str]:
         client = self._client()
+        # Cache the system prompt: voice sessions reuse the same prompt across
+        # many turns, so a single ephemeral breakpoint cuts ~90% of system-prompt
+        # input tokens on every turn after the first within the 5-min TTL.
         async with client.messages.stream(
             model=self.model,
             max_tokens=1024,
-            system=system_prompt,
+            system=[
+                {
+                    "type": "text",
+                    "text": system_prompt,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
             messages=messages,
         ) as stream:
             async for text in stream.text_stream:


### PR DESCRIPTION
## Summary

- `AnthropicVoiceLLM.stream_response` previously sent `system=system_prompt` as a plain string, paying full input-token cost on every voice turn.
- Wraps it as a content block with `cache_control: {type: ephemeral}` so subsequent turns within the 5-min TTL hit the prompt cache.
- Expected impact: ~90% reduction of system-prompt input tokens after turn 1 of a voice session — direct cost + latency win on every back-and-forth.

## Scope

- **Single file:** `orchestrator/app/services/voice_providers/llm_anthropic.py`
- 1 logical change (system-prompt plain string → content block with `cache_control`)
- No changes to message history, no API surface change, no behavioral change

## Replaces

Closes #205 (which was rejected due to branch contamination with unrelated Hermes memory-curator commits). This PR contains only the single caching commit cherry-picked onto a clean base from `main`.

## Test plan
- [ ] Trigger a voice conversation, check `usage.cache_creation_input_tokens` > 0 on turn 1
- [ ] On turn 2 within 5 min: check `usage.cache_read_input_tokens` > 0 and `input_tokens` near-zero for system part
- [ ] Confirm Haiku 4.5 system prompt is ≥ 2048 tokens (min cache size)
- [ ] Smoke-test OAuth-token path still works (header propagation unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)