### PR TITLE
fix(skills): resolve UnboundLocalError in skill usage tracking

### DIFF
--- a/orchestrator/app/api/skill_marketplace.py
+++ b/orchestrator/app/api/skill_marketplace.py
@@ -922,7 +922,11 @@ async def agent_search_skills(
         agent_id = auth["agent_id"]
         resolved_task_id = task_id
         if not resolved_task_id:
-            from app.models.task import Task, TaskStatus
+            # NOTE: do NOT import Task here — it is already imported at module
+            # scope. A local `import Task` would make Task a function-local for
+            # the whole scope, so line ~955 (reached when task_id is supplied
+            # and this block is skipped) would raise UnboundLocalError.
+            from app.models.task import TaskStatus
             running = (await db.execute(
                 select(Task.id).where(
                     Task.agent_id == agent_id,

--- a/orchestrator/tests/test_api/test_skill_marketplace_usage.py
+++ b/orchestrator/tests/test_api/test_skill_marketplace_usage.py
@@ -1,0 +1,24 @@
+"""Regression test for the skill-usage UnboundLocalError.
+
+`agent_search_skills` re-imported `Task` inside a conditional block
+(`if not resolved_task_id:`). Because a local import binds the name for the
+whole function scope, the later `select(Task.id)` reference (reached when a
+`task_id` is supplied and the conditional is skipped) raised
+`UnboundLocalError: cannot access local variable 'Task'`.
+
+The fix imports only `TaskStatus` locally and relies on the module-level
+`Task` import. Guard against a regression by asserting `Task` is resolved as a
+global, not a function-local, of the code object.
+"""
+from app.api import skill_marketplace
+
+
+def test_task_is_not_function_local_in_agent_search_skills():
+    code = skill_marketplace.agent_search_skills.__code__
+    assert "Task" not in code.co_varnames, (
+        "Task must resolve to the module-level import; a local `import Task` "
+        "reintroduces the UnboundLocalError when task_id is supplied."
+    )
+    assert "Task" in skill_marketplace.__dict__, (
+        "Task must be imported at module scope for the search path to use it."
+    )


### PR DESCRIPTION
## Summary
Fixes a recurring `UnboundLocalError` observed in the platform logs:

```
WARNING app.api.skill_marketplace: skill usage tracking failed (non-fatal):
cannot access local variable 'Task' where it is not associated with a value
```

**Root cause:** `agent_search_skills` re-imported `Task` inside the
`if not resolved_task_id:` block. A local `import` binds the name as a
function-local for the *entire* scope, so when a `task_id` is supplied (the
block is skipped and the local import never runs), the later
`select(Task.id)` on line ~955 references an unbound local and raises.

**Fix:** import only `TaskStatus` locally and rely on the existing
module-level `from app.models.task import Task` import.

## Test plan
- [x] Added `tests/test_api/test_skill_marketplace_usage.py` — asserts `Task`
      is not a function-local of `agent_search_skills` (bytecode-level guard).
- [x] `pytest tests/test_api/` → 4 passed.
- [x] Module imports cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)