### PR TITLE
Fix #206: DST-aware cron scheduling via per-schedule timezone

### DIFF
--- a/agent/mcp/orchestrator-server.mjs
+++ b/agent/mcp/orchestrator-server.mjs
@@ -325,6 +325,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
               "'*/15 * * * *'=every 15 minutes, '0 9 * * 1'=Mondays at 09:00. " +
               "Use this instead of interval_seconds when the time of day matters.",
           },
+          timezone: {
+            type: "string",
+            description:
+              "IANA timezone the cron_expression is evaluated in (DST-aware). Default 'UTC'. " +
+              "Example: 'Europe/Berlin' so '0 6 * * *' fires at 06:00 local time year-round. " +
+              "Ignored for interval_seconds schedules.",
+          },
         },
         required: ["name", "prompt"],
       },
@@ -971,6 +978,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       if (args.cron_expression) {
         body.cron_expression = args.cron_expression;
         body.interval_seconds = 0;
+        if (args.timezone) body.timezone = args.timezone;
       } else {
         body.interval_seconds = args.interval_seconds;
       }

--- a/orchestrator/alembic/versions/c3d4e5f6a7b8_schedule_timezone.py
+++ b/orchestrator/alembic/versions/c3d4e5f6a7b8_schedule_timezone.py
@@ -1,0 +1,30 @@
+"""Add timezone to schedules (DST-aware cron evaluation)
+
+Revision ID: c3d4e5f6a7b8
+Revises: b1c2d3e4f5g6
+Create Date: 2026-07-02
+
+Adds an IANA timezone column to the schedules table. When a
+cron_expression is set, next_run_at is computed in this zone so that
+"0 6 * * *" fires at 06:00 wall-clock time (DST-aware) rather than
+06:00 UTC. Existing rows default to "UTC" → 100% backwards-compatible
+(cron was previously evaluated in UTC).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "c3d4e5f6a7b8"
+down_revision = "b1c2d3e4f5g6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "schedules",
+        sa.Column("timezone", sa.String(), nullable=False, server_default="UTC"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("schedules", "timezone")

--- a/orchestrator/alembic/versions/c3d4e5f6a7b8_schedule_timezone.py
+++ b/orchestrator/alembic/versions/c3d4e5f6a7b8_schedule_timezone.py
@@ -14,7 +14,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = "c3d4e5f6a7b8"
-down_revision = "b1c2d3e4f5g6"
+down_revision = "c1d2e3f4a5b7"
 branch_labels = None
 depends_on = None
 

--- a/orchestrator/alembic/versions/c3d4e5f6a7b8_schedule_timezone.py
+++ b/orchestrator/alembic/versions/c3d4e5f6a7b8_schedule_timezone.py
@@ -1,7 +1,7 @@
 """Add timezone to schedules (DST-aware cron evaluation)
 
 Revision ID: c3d4e5f6a7b8
-Revises: b1c2d3e4f5g6
+Revises: c1d2e3f4a5b7
 Create Date: 2026-07-02
 
 Adds an IANA timezone column to the schedules table. When a

--- a/orchestrator/app/api/schedules.py
+++ b/orchestrator/app/api/schedules.py
@@ -122,8 +122,10 @@ async def update_schedule(
     for field, value in data.model_dump(exclude_unset=True).items():
         setattr(schedule, field, value)
 
-    # Recalculate next_run if timing changed
-    if data.interval_seconds is not None or data.cron_expression is not None:
+    # Recalculate next_run if timing or timezone changed
+    if (data.interval_seconds is not None
+            or data.cron_expression is not None
+            or data.timezone is not None):
         now = datetime.now(timezone.utc)
         schedule.next_run_at = _calc_next_run(schedule, now)
 

--- a/orchestrator/app/api/schedules.py
+++ b/orchestrator/app/api/schedules.py
@@ -89,6 +89,7 @@ async def create_schedule(data: ScheduleCreate, user=Depends(require_auth_or_age
         prompt=data.prompt,
         interval_seconds=data.interval_seconds,
         cron_expression=data.cron_expression,
+        timezone=data.timezone,
         priority=data.priority,
         agent_id=data.agent_id,
         model=data.model,

--- a/orchestrator/app/models/schedule.py
+++ b/orchestrator/app/models/schedule.py
@@ -15,6 +15,7 @@ class Schedule(Base, TimestampMixin):
     prompt: Mapped[str] = mapped_column(Text, nullable=False)
     interval_seconds: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     cron_expression: Mapped[str | None] = mapped_column(String, nullable=True)  # e.g. "0 9 * * 1" = every Monday 9am
+    timezone: Mapped[str] = mapped_column(String, nullable=False, default="UTC")  # IANA name; cron is evaluated in this zone (DST-aware)
     priority: Mapped[int] = mapped_column(Integer, default=1)
     agent_id: Mapped[str | None] = mapped_column(
         String, ForeignKey("agents.id"), nullable=True

--- a/orchestrator/app/schemas/schedule.py
+++ b/orchestrator/app/schemas/schedule.py
@@ -24,11 +24,22 @@ def _validate_cron(expr: str) -> str:
     return expr
 
 
+def _validate_timezone(tz: str) -> str:
+    """Validate an IANA timezone name (e.g. 'Europe/Berlin')."""
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+    try:
+        ZoneInfo(tz)
+    except (ZoneInfoNotFoundError, ValueError, KeyError):
+        raise ValueError(f"Invalid timezone: {tz!r}")
+    return tz
+
+
 class ScheduleCreate(BaseModel):
     name: str
     prompt: str
     interval_seconds: int = 0
     cron_expression: str | None = None
+    timezone: str = "UTC"
     priority: int = 1
     agent_id: str | None = None
     model: str | None = None
@@ -39,6 +50,7 @@ class ScheduleCreate(BaseModel):
             raise ValueError("Provide either a valid cron_expression or interval_seconds >= 60")
         if self.cron_expression:
             self.cron_expression = _validate_cron(self.cron_expression)
+        self.timezone = _validate_timezone(self.timezone)
         return self
 
 
@@ -47,9 +59,17 @@ class ScheduleUpdate(BaseModel):
     prompt: str | None = None
     interval_seconds: int | None = None
     cron_expression: str | None = None
+    timezone: str | None = None
     priority: int | None = None
     agent_id: str | None = None
     model: str | None = None
+
+    @field_validator("timezone")
+    @classmethod
+    def validate_timezone(cls, v: str | None) -> str | None:
+        if v is not None:
+            return _validate_timezone(v)
+        return v
 
     @field_validator("interval_seconds")
     @classmethod
@@ -72,6 +92,7 @@ class ScheduleResponse(BaseModel):
     prompt: str
     interval_seconds: int
     cron_expression: str | None
+    timezone: str
     priority: int
     agent_id: str | None
     model: str | None
@@ -98,6 +119,7 @@ class ScheduleResponse(BaseModel):
             prompt=schedule.prompt,
             interval_seconds=schedule.interval_seconds,
             cron_expression=getattr(schedule, "cron_expression", None),
+            timezone=getattr(schedule, "timezone", None) or "UTC",
             priority=schedule.priority,
             agent_id=schedule.agent_id,
             model=schedule.model,

--- a/orchestrator/app/services/scheduler_service.py
+++ b/orchestrator/app/services/scheduler_service.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 try:
     from croniter import croniter
@@ -578,15 +579,24 @@ class SchedulerService:
 
 
 def _calc_next_run(schedule: "Schedule", now: datetime) -> datetime:
-    """Return the next fire time for a schedule.
+    """Return the next fire time (UTC) for a schedule.
 
-    If cron_expression is set and croniter is available, use it.
+    If cron_expression is set and croniter is available, the expression is
+    evaluated in the schedule's IANA timezone so "0 6 * * *" fires at 06:00
+    wall-clock time year-round (DST-aware), then converted back to UTC.
     Otherwise fall back to interval_seconds.
     """
     if schedule.cron_expression and _CRONITER_AVAILABLE:
         try:
-            cron = croniter(schedule.cron_expression, now)
-            return cron.get_next(datetime).replace(tzinfo=timezone.utc)
+            tz_name = getattr(schedule, "timezone", None) or "UTC"
+            try:
+                tz = ZoneInfo(tz_name)
+            except Exception:
+                print(f"[Scheduler] Unknown timezone '{tz_name}' — evaluating cron in UTC")
+                tz = timezone.utc
+            base = now.astimezone(tz)
+            cron = croniter(schedule.cron_expression, base)
+            return cron.get_next(datetime).astimezone(timezone.utc)
         except Exception as e:
             print(f"[Scheduler] Invalid cron expression '{schedule.cron_expression}': {e} — falling back to interval")
     return now + timedelta(seconds=max(schedule.interval_seconds, 60))

--- a/orchestrator/tests/test_schedule_cron_timezone.py
+++ b/orchestrator/tests/test_schedule_cron_timezone.py
@@ -1,0 +1,104 @@
+"""Tests for DST-aware cron scheduling (issue #206).
+
+A cron_expression must fire at wall-clock time in the schedule's IANA
+timezone, not in UTC. "0 6 * * *" with timezone="Europe/Berlin" fires at
+04:00 UTC in summer (CEST, +02:00) and 05:00 UTC in winter (CET, +01:00).
+next_run_at is always stored in UTC.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.services.scheduler_service import _calc_next_run
+
+
+class _Sched:
+    """Minimal duck-typed stand-in for a Schedule row."""
+
+    def __init__(self, cron_expression=None, timezone="UTC", interval_seconds=0):
+        self.cron_expression = cron_expression
+        self.timezone = timezone
+        self.interval_seconds = interval_seconds
+
+
+def test_cron_schedule_dispatches_at_expected_time():
+    """06:00 Europe/Berlin in summer → 04:00 UTC (CEST is +02:00)."""
+    now = datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)  # already past today's 06:00
+    sched = _Sched(cron_expression="0 6 * * *", timezone="Europe/Berlin")
+
+    nxt = _calc_next_run(sched, now)
+
+    assert nxt.tzinfo is not None
+    assert nxt.utcoffset().total_seconds() == 0  # stored in UTC
+    assert nxt == datetime(2026, 7, 2, 4, 0, tzinfo=timezone.utc)
+
+
+def test_utc_default_is_backwards_compatible():
+    """With timezone='UTC', cron is evaluated in UTC (prior behavior)."""
+    now = datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)
+    sched = _Sched(cron_expression="0 6 * * *", timezone="UTC")
+
+    nxt = _calc_next_run(sched, now)
+
+    assert nxt == datetime(2026, 7, 2, 6, 0, tzinfo=timezone.utc)
+
+
+def test_dst_transition_handled_correctly():
+    """Same cron fires 05:00 UTC in winter (CET +01:00) vs 04:00 UTC in summer."""
+    sched = _Sched(cron_expression="0 6 * * *", timezone="Europe/Berlin")
+
+    # Winter: base in January
+    winter = _calc_next_run(sched, datetime(2026, 1, 10, 12, 0, tzinfo=timezone.utc))
+    assert winter == datetime(2026, 1, 11, 5, 0, tzinfo=timezone.utc)
+
+    # Summer: base in July
+    summer = _calc_next_run(sched, datetime(2026, 7, 10, 12, 0, tzinfo=timezone.utc))
+    assert summer == datetime(2026, 7, 11, 4, 0, tzinfo=timezone.utc)
+
+
+def test_failed_run_does_not_skip_next():
+    """Backend re-computes the very next slot regardless of run outcome.
+
+    Called at 06:05 (just after a fire that may have failed), the next run
+    is tomorrow 06:00 — the slot is never lost to a self-reschedule gap.
+    """
+    sched = _Sched(cron_expression="0 6 * * *", timezone="Europe/Berlin")
+    # 06:05 Berlin summer == 04:05 UTC
+    now = datetime(2026, 7, 2, 4, 5, tzinfo=timezone.utc)
+
+    nxt = _calc_next_run(sched, now)
+
+    assert nxt == datetime(2026, 7, 3, 4, 0, tzinfo=timezone.utc)
+
+
+def test_invalid_timezone_falls_back_to_utc():
+    """An unknown tz must not crash the scheduler — evaluate cron in UTC."""
+    sched = _Sched(cron_expression="0 6 * * *", timezone="Mars/Olympus")
+    now = datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)
+
+    nxt = _calc_next_run(sched, now)
+
+    assert nxt == datetime(2026, 7, 2, 6, 0, tzinfo=timezone.utc)
+
+
+def test_missing_timezone_attr_defaults_utc():
+    """Legacy rows without a timezone attribute default to UTC."""
+    class _Legacy:
+        cron_expression = "0 6 * * *"
+        interval_seconds = 0
+
+    now = datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)
+    nxt = _calc_next_run(_Legacy(), now)
+
+    assert nxt == datetime(2026, 7, 2, 6, 0, tzinfo=timezone.utc)
+
+
+def test_interval_schedule_unaffected():
+    """Interval schedules ignore timezone entirely."""
+    sched = _Sched(cron_expression=None, timezone="Europe/Berlin", interval_seconds=3600)
+    now = datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)
+
+    nxt = _calc_next_run(sched, now)
+
+    assert nxt == datetime(2026, 7, 1, 13, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
Closes the remaining timezone/DST gap of #206. The scheduler already had `cron_expression` + a backend tick loop, but cron was evaluated in **UTC** — so `"0 6 * * *"` fired at 06:00 UTC (08:00 CEST) and DST transitions were ignored.

This PR adds a per-schedule **IANA `timezone`** and evaluates the cron in that zone (DST-aware), storing `next_run_at` back in UTC.

## Changes
- **model**: new `schedules.timezone` column (`String`, NOT NULL, default `"UTC"`).
- **migration** `c3d4e5f6a7b8`: adds the column with `server_default="UTC"` → existing rows unchanged (100% backwards-compatible; UTC preserves prior behavior).
- **scheduler_service._calc_next_run**: converts `now` into the schedule's `ZoneInfo`, runs croniter there, converts result back to UTC. Unknown tz → warns and falls back to UTC (never crashes).
- **schema**: `timezone` on `ScheduleCreate` (default `"UTC"`, validated via zoneinfo), `ScheduleUpdate`, and `ScheduleResponse`.
- **REST API**: `create_schedule` persists `timezone`.
- **MCP tool**: `create_schedule` exposes an optional `timezone` arg so agents can set e.g. `Europe/Berlin`.

## Acceptance criteria (#206)
- [x] `cron_expression` exists + migration applied (already present)
- [x] Schedule with `cron_expression="0 6 * * *"`, `timezone="Europe/Berlin"` fires at 06:00 local
- [x] DST transition handled (05:00 UTC winter / 04:00 UTC summer — tested)
- [x] Aborted run does not skip next slot (backend tick re-computes — tested)
- [x] Existing interval schedules unchanged
- [x] Tests: cron dispatch time, failed-run-no-skip, DST transition (+ UTC default, invalid-tz fallback, legacy-row fallback, interval-unaffected)

Note: `fail_count > 0` alerting acceptance item is already covered by the merged failure-watchdog (`test_schedule_failure_alerts.py`).

## Test plan
- [x] `pytest tests/test_schedule_cron_timezone.py tests/test_schedule_failure_alerts.py` → 18 passed
- [x] `node --check agent/mcp/orchestrator-server.mjs`
- [x] schema smoke test (valid/preset/invalid-tz/update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)