### PR TITLE
Fix #208: reliable scheduler present_file delivery via Telegram

### DIFF
--- a/agent/app/agent_runner.py
+++ b/agent/app/agent_runner.py
@@ -117,6 +117,7 @@ class AgentRunner:
                     seen_file_paths.add(path)
                     presented_files.append(payload)
                     await self._mirror_present_file_to_chat(task_id, payload)
+                    await self._deliver_present_file_via_telegram(payload)
 
                 # Collect assistant text output
                 if event.get("type") == "assistant":
@@ -331,6 +332,44 @@ class AgentRunner:
             await self.log_publisher.publish_chat(task_id, "file", payload)
         except Exception:
             logger.warning("Failed to mirror present_file to chat channel", exc_info=True)
+
+    async def _deliver_present_file_via_telegram(self, payload: dict) -> None:
+        """Reliably push a scheduler/task present_file to the user via Telegram.
+
+        The chat mirror in _mirror_present_file_to_chat only reaches WebSocket
+        clients that happen to be connected. Scheduled runs (e.g. the 06:00
+        podcast) fire when no client is attached, so the file silently never
+        arrives (issue #208). Telegram's Bot API is a durable push channel, so
+        we also base64-encode the file onto agent:{id}:telegram:send, which the
+        agent bot delivers as a document. It is a no-op for agents that have no
+        authorized Telegram chats, so inter-agent tasks are unaffected.
+        """
+        path = str(payload.get("path") or "")
+        if not path or not os.path.isfile(path):
+            return
+        try:
+            import base64
+
+            size = os.path.getsize(path)
+            # The agent bot decodes the whole file in memory; match the 20 MB
+            # cap used by the send_telegram tool. Larger files stay chat-only.
+            if size <= 0 or size > 20 * 1024 * 1024:
+                return
+            with open(path, "rb") as f:
+                raw = f.read()
+            tg_payload = {
+                "agent_id": self.log_publisher.agent_id,
+                "file_b64": base64.b64encode(raw).decode("ascii"),
+                "media_type": payload.get("media_type") or "application/octet-stream",
+                "filename": payload.get("filename") or os.path.basename(path),
+                "caption": payload.get("caption") or "",
+            }
+            await self.log_publisher.redis.publish(
+                f"agent:{self.log_publisher.agent_id}:telegram:send",
+                json.dumps(tg_payload),
+            )
+        except Exception:
+            logger.warning("Failed to deliver present_file via Telegram", exc_info=True)
 
     async def _publish_scheduler_chat_completion(
         self,

--- a/agent/tests/test_present_file_marker.py
+++ b/agent/tests/test_present_file_marker.py
@@ -1,5 +1,10 @@
 """Tests for present_file marker parsing in scheduler/task runs."""
 
+import base64
+import json
+
+import pytest
+
 from app.agent_runner import AgentRunner
 
 
@@ -65,3 +70,60 @@ def test_parse_present_file_marker_missing_returns_none():
 
 def test_parse_present_file_marker_invalid_json_returns_none():
     assert AgentRunner._parse_present_file_marker("__AI_EMPLOYEE_PRESENT_FILE__{broken json}") is None
+
+
+class _FakeRedis:
+    def __init__(self):
+        self.published: list[tuple[str, str]] = []
+
+    async def publish(self, channel, message):
+        self.published.append((channel, message))
+
+
+class _FakeLogPublisher:
+    def __init__(self, redis, agent_id):
+        self.redis = redis
+        self.agent_id = agent_id
+
+
+@pytest.mark.anyio
+async def test_present_file_delivered_via_telegram(tmp_path):
+    f = tmp_path / "podcast.mp3"
+    f.write_bytes(b"ID3 fake audio bytes")
+    redis = _FakeRedis()
+    runner = AgentRunner(log_publisher=_FakeLogPublisher(redis, "agent-1"))
+
+    await runner._deliver_present_file_via_telegram(
+        {
+            "path": str(f),
+            "filename": "podcast.mp3",
+            "media_type": "audio/mpeg",
+            "caption": "Morgen-Podcast",
+        }
+    )
+
+    assert len(redis.published) == 1
+    channel, raw = redis.published[0]
+    assert channel == "agent:agent-1:telegram:send"
+    payload = json.loads(raw)
+    assert payload["filename"] == "podcast.mp3"
+    assert payload["media_type"] == "audio/mpeg"
+    assert payload["caption"] == "Morgen-Podcast"
+    assert base64.b64decode(payload["file_b64"]) == b"ID3 fake audio bytes"
+
+
+@pytest.mark.anyio
+async def test_telegram_fallback_on_present_file_failure(tmp_path):
+    """A missing or oversized file must not raise and must not publish."""
+    redis = _FakeRedis()
+    runner = AgentRunner(log_publisher=_FakeLogPublisher(redis, "agent-1"))
+
+    # Missing file → silent no-op
+    await runner._deliver_present_file_via_telegram({"path": str(tmp_path / "gone.mp3")})
+    assert redis.published == []
+
+    # Oversized file (> 20 MB) → skipped, chat mirror remains the only path
+    big = tmp_path / "big.bin"
+    big.write_bytes(b"\0" * (20 * 1024 * 1024 + 1))
+    await runner._deliver_present_file_via_telegram({"path": str(big)})
+    assert redis.published == []


### PR DESCRIPTION
Fixes #208

## Problem
`present_file` is the only official way to hand the user a chat attachment (MP3/PDF/MP4). In **scheduled/task runs** the agent only mirrors the file to the chat WebSocket channel (`_mirror_present_file_to_chat`). When no iOS/web client is connected — which is exactly the case at 06:00 for the daily podcast — that event reaches nothing and the file silently never arrives. The user then has to send "???" and re-request it. This matches Daniel's hard correction (`file_delivery_must_be_explicit`, 2026-05-30): finished files must ALWAYS go directly via the Telegram Bot API.

## Fix
Reuse the existing durable delivery path. In the scheduler/task `run()` loop, after mirroring each `present_file` payload to chat, also base64-encode the file and publish it to `agent:{id}:telegram:send`. The agent bot already consumes that channel and sends it as a Telegram `send_document` to every authorized chat (`agent_bot._deliver_telegram_send`).

- Telegram is a durable push channel, so delivery no longer depends on an attached WebSocket client.
- **No-op for agents without authorized Telegram chats** (`tg_auth` empty) → inter-agent/dev/review tasks are unaffected and won't spam anyone.
- 20 MB cap (matches the `send_telegram` tool); larger files stay chat-only. All errors are swallowed with a warning so delivery never breaks task completion.

Scope: `AgentRunner.run()` is the task/scheduler path (`task_consumer.py`), separate from interactive chat (`chat_consumer.py`/`ws.py`), so there is no double-send in normal chat.

## Acceptance criteria addressed
- [x] Schedule runs automatically use the Telegram fallback for file delivery.
- [x] Tests: `test_present_file_delivered_via_telegram`, `test_telegram_fallback_on_present_file_failure`.

Deferred (own follow-up issues, out of scope for this S-fix): server-side per-channel `delivered=True/False` return value, a `target_channel` param on `present_file`, and a per-channel success-rate dashboard.

## Test plan
- [x] `pytest agent/tests/` — 17 passed (2 new).
- [x] `py_compile agent/app/agent_runner.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)