### PR TITLE
Fix #274: add exc_info to background-service loop catch-alls

### DIFF
--- a/orchestrator/app/services/disk_monitor.py
+++ b/orchestrator/app/services/disk_monitor.py
@@ -33,7 +33,7 @@ class DiskMonitorService:
             try:
                 await self._check_all_agents()
             except Exception as exc:
-                logger.error("Disk monitor cycle failed: %s", exc)
+                logger.error("Disk monitor cycle failed: %s", exc, exc_info=True)
             await asyncio.sleep(_CHECK_INTERVAL)
 
     def stop(self) -> None:

--- a/orchestrator/app/services/embedding_backfill.py
+++ b/orchestrator/app/services/embedding_backfill.py
@@ -164,5 +164,5 @@ async def run_backfill_loop(db_factory) -> None:
                 )
                 await asyncio.sleep(2)
         except Exception as e:
-            logger.error(f"[EmbeddingBackfill] Error: {e}")
+            logger.error("[EmbeddingBackfill] Error: %s", e, exc_info=True)
             await asyncio.sleep(300)

--- a/orchestrator/app/services/improvement_engine.py
+++ b/orchestrator/app/services/improvement_engine.py
@@ -114,7 +114,7 @@ class ImprovementEngine:
             except asyncio.CancelledError:
                 break
             except Exception as e:
-                logger.error(f"[ImprovementEngine] Analysis error: {e}")
+                logger.error("[ImprovementEngine] Analysis error: %s", e, exc_info=True)
 
             await asyncio.sleep(interval)
 

--- a/orchestrator/app/services/self_test_service.py
+++ b/orchestrator/app/services/self_test_service.py
@@ -76,7 +76,7 @@ class SelfTestService:
             except asyncio.CancelledError:
                 break
             except Exception as e:
-                logger.error(f"[SelfTest] Unhandled error: {e}")
+                logger.error("[SelfTest] Unhandled error: %s", e, exc_info=True)
 
             await asyncio.sleep(RUN_INTERVAL_SECONDS)
 

--- a/orchestrator/app/services/skill_crawler.py
+++ b/orchestrator/app/services/skill_crawler.py
@@ -84,7 +84,7 @@ class SkillCrawlerService:
             try:
                 await self.crawl()
             except Exception as e:
-                logger.error(f"Skill crawler error: {e}")
+                logger.error("Skill crawler error: %s", e, exc_info=True)
             await asyncio.sleep(CRAWL_INTERVAL)
 
     async def crawl(self) -> list[dict]:

--- a/orchestrator/app/services/user_lifecycle.py
+++ b/orchestrator/app/services/user_lifecycle.py
@@ -60,7 +60,7 @@ class UserLifecycleService:
             try:
                 await self._sweep()
             except Exception as e:
-                logger.error(f"[UserLifecycle] Sweep error: {e}")
+                logger.error("[UserLifecycle] Sweep error: %s", e, exc_info=True)
             await asyncio.sleep(CHECK_INTERVAL_SECONDS)
 
     def stop(self) -> None:


### PR DESCRIPTION
## Summary
- Six background-service main-loop `except Exception` handlers logged only `str(e)`. For `TimeoutError` (raised on asyncpg DB-connect timeouts) `str()` is empty, so log lines like `[UserLifecycle] Sweep error:` and `Disk monitor cycle failed:` carried **no detail and no traceback** — invisible for post-mortem despite firing recurrently in prod.
- Added `exc_info=True` (and converted f-strings to lazy `%s`) so a full traceback is captured, per the logging convention from PR #270 (ERROR+exc_info for top-level catch-alls).

## Files
- `user_lifecycle.py:63`, `disk_monitor.py:36`, `embedding_backfill.py:167`, `improvement_engine.py:117`, `self_test_service.py:79`, `skill_crawler.py:87`

Targeted error logs that already include response text / status codes were intentionally left unchanged.

## Test plan
- [x] `python -m py_compile` on all six files
- [ ] CodeReview: confirm scope (loop catch-alls only) and lazy-formatting

Fixes #274