### PR TITLE
feat(reliability): watchdog for stale tasks + missed-schedule alerts (#211)

### DIFF
--- a/orchestrator/app/services/scheduler_service.py
+++ b/orchestrator/app/services/scheduler_service.py
@@ -19,6 +19,13 @@ from app.db.session import async_session_factory
 from app.models.schedule import Schedule
 from app.models.task import Task
 from app.services.redis_service import RedisService
+from app.services.watchdog import (
+    as_utc,
+    find_missed_schedules,
+    find_stale_tasks,
+    mark_task_stale,
+    md_escape,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +50,9 @@ class SchedulerService:
         # Per-schedule drift value at which we last alerted; prevents hourly spam
         # for a stuck schedule — only re-alerts when drift increases.
         self._watchdog_alerted: dict[str, int] = {}
+        # Per-schedule missed slot (next_run_at iso) already alerted; prevents
+        # re-alerting the same missed window every 30s tick.
+        self._missed_alerted: dict[str, str] = {}
 
     async def run(self) -> None:
         """Main loop - checks every 30s. Runs schedules always, GC every 60s,
@@ -56,7 +66,18 @@ class SchedulerService:
 
         while True:
             try:
+                # Missed-schedule watchdog runs BEFORE _check_due_schedules, which
+                # would otherwise fire+advance the slipped run and hide the miss.
+                try:
+                    await self._tick_missed_schedule_watchdog()
+                except Exception as e:
+                    logger.warning("[Scheduler] MissedScheduleWatchdog error: %s", e)
                 await self._check_due_schedules()
+                # Stale-task watchdog: flag RUNNING tasks with no heartbeat >30min.
+                try:
+                    await self._tick_stale_task_watchdog()
+                except Exception as e:
+                    logger.warning("[Scheduler] StaleTaskWatchdog error: %s", e)
                 try:
                     started = await self._start_due_followups()
                     if started:
@@ -421,6 +442,91 @@ class SchedulerService:
                     self._watchdog_alerted[s.id] = drift
                 except Exception as e:
                     logger.warning("[Scheduler] FailureWatchdog publish error: %s", e)
+
+    async def _tick_stale_task_watchdog(self) -> None:
+        """Mark RUNNING tasks that stopped heart-beating (>30min) as stale.
+
+        A worker that crashes mid-job (container OOM, network drop) leaves its
+        task pinned in RUNNING forever. updated_at stops advancing, so we flip
+        such tasks to FAILED with a `stale` metadata flag and alert the owner —
+        instead of the operator discovering a missing artifact hours later.
+        """
+        import json as _json
+
+        now = datetime.now(timezone.utc)
+        async with async_session_factory() as db:
+            stale = await find_stale_tasks(db, now)
+            if not stale:
+                return
+            from app.models.notification import Notification
+
+            for task in stale:
+                mark_task_stale(task, now)
+                db.add(
+                    Notification(
+                        agent_id=task.agent_id or "system",
+                        type="error",
+                        title="Task stale (kein Heartbeat)",
+                        message=(
+                            f'Task "{task.title}" hat seit über 30min kein '
+                            "Lebenszeichen gesendet und wurde als stale markiert."
+                        )[:240],
+                        priority="high",
+                        action_url=f"/tasks/{task.id}",
+                        meta={"type": "task_stale", "task_id": task.id},
+                    )
+                )
+                if self.redis and self.redis.client:
+                    payload = {
+                        "text": (
+                            f"⚠️ Task *{md_escape(task.title)}* stale — kein "
+                            f"Heartbeat >30min (id `{task.id}`), als fehlgeschlagen markiert."
+                        ),
+                        "parse_mode": "Markdown",
+                    }
+                    try:
+                        await self.redis.client.publish(
+                            "telegram:notification", _json.dumps(payload)
+                        )
+                    except Exception as e:
+                        logger.warning("[Scheduler] StaleTaskWatchdog publish error: %s", e)
+            await db.commit()
+            logger.info("[Scheduler] StaleTaskWatchdog: marked %s task(s) stale", len(stale))
+
+    async def _tick_missed_schedule_watchdog(self) -> None:
+        """Alert on enabled schedules whose fire window was missed (>5min late).
+
+        Under normal operation the main loop fires due schedules every 30s, so
+        next_run_at is always in the future. A next_run_at that slipped well
+        into the past means the scheduler was down during the window (container
+        restart) — the run is caught up late, but the owner is told it slipped.
+        """
+        import json as _json
+
+        now = datetime.now(timezone.utc)
+        async with async_session_factory() as db:
+            missed = await find_missed_schedules(db, now)
+            for s in missed:
+                slot_key = as_utc(s.next_run_at).isoformat()
+                if self._missed_alerted.get(s.id) == slot_key:
+                    continue
+                self._missed_alerted[s.id] = slot_key
+                if not self.redis or not self.redis.client:
+                    continue
+                late_min = int((now - as_utc(s.next_run_at)).total_seconds() // 60)
+                payload = {
+                    "text": (
+                        f"⚠️ Schedule *{md_escape(s.name)}* verpasst — geplant "
+                        f"{slot_key} (überfällig {late_min} min). Wird nachgeholt."
+                    ),
+                    "parse_mode": "Markdown",
+                }
+                try:
+                    await self.redis.client.publish(
+                        "telegram:notification", _json.dumps(payload)
+                    )
+                except Exception as e:
+                    logger.warning("[Scheduler] MissedScheduleWatchdog publish error: %s", e)
 
     async def _stop_idle_agents(self) -> int:
         """Stop agents that have been idle longer than their configured limit.

--- a/orchestrator/app/services/watchdog.py
+++ b/orchestrator/app/services/watchdog.py
@@ -1,0 +1,99 @@
+"""Watchdog detection helpers (issue #211).
+
+Pure, dependency-light detection logic for stale tasks and missed schedules,
+kept out of scheduler_service so it can be unit-tested without pulling in the
+docker/redis import chain. The SchedulerService owns the loop, DB sessions and
+alerting; this module owns the "is it stale / missed?" decision.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+
+from app.models.schedule import Schedule
+from app.models.task import Task, TaskStatus
+
+# A RUNNING task bumps updated_at (TimestampMixin onupdate) on every status/step
+# write, so no bump for this long means the worker died silently. A schedule
+# whose next_run_at slipped past the grace window means the scheduler was down
+# during its fire time (container restart).
+_STALE_TASK_THRESHOLD = timedelta(minutes=30)
+_MISSED_SCHEDULE_GRACE = timedelta(minutes=5)
+
+
+def md_escape(s: str) -> str:
+    """Escape Telegram-Markdown metacharacters in a free-text value."""
+    return (
+        s.replace("\\", "\\\\")
+        .replace("_", "\\_")
+        .replace("*", "\\*")
+        .replace("`", "\\`")
+        .replace("[", "\\[")
+    )
+
+
+def as_utc(dt: datetime | None) -> datetime | None:
+    """Normalise a possibly naive datetime to timezone-aware UTC."""
+    if dt is None:
+        return None
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+def is_task_stale(task: Task, now: datetime, threshold: timedelta = _STALE_TASK_THRESHOLD) -> bool:
+    """A RUNNING task is stale when its last heartbeat (updated_at) is older than threshold."""
+    if task.status != TaskStatus.RUNNING:
+        return False
+    updated = as_utc(task.updated_at)
+    if updated is None:
+        return False
+    return (now - updated) > threshold
+
+
+def is_schedule_missed(
+    schedule: Schedule, now: datetime, grace: timedelta = _MISSED_SCHEDULE_GRACE
+) -> bool:
+    """An enabled schedule is missed when next_run_at slipped past the grace window."""
+    if not schedule.enabled:
+        return False
+    nra = as_utc(schedule.next_run_at)
+    if nra is None:
+        return False
+    return (now - nra) > grace
+
+
+def mark_task_stale(task: Task, now: datetime) -> Task:
+    """Flip a stale task to FAILED with a diagnostic error + metadata flag."""
+    minutes = int(_STALE_TASK_THRESHOLD.total_seconds() // 60)
+    task.status = TaskStatus.FAILED
+    task.completed_at = now
+    task.error = f"Watchdog: no heartbeat for over {minutes} min — task marked stale."
+    meta = dict(task.metadata_ or {})
+    meta["stale"] = True
+    meta["stale_detected_at"] = now.isoformat()
+    task.metadata_ = meta
+    return task
+
+
+async def find_stale_tasks(
+    db, now: datetime, threshold: timedelta = _STALE_TASK_THRESHOLD
+) -> list[Task]:
+    """Return RUNNING tasks whose heartbeat is older than the threshold."""
+    cutoff = now - threshold
+    result = await db.execute(
+        select(Task).where(Task.status == TaskStatus.RUNNING, Task.updated_at < cutoff)
+    )
+    return [t for t in result.scalars().all() if is_task_stale(t, now, threshold)]
+
+
+async def find_missed_schedules(
+    db, now: datetime, grace: timedelta = _MISSED_SCHEDULE_GRACE
+) -> list[Schedule]:
+    """Return enabled schedules whose next_run_at slipped past the grace window."""
+    cutoff = now - grace
+    result = await db.execute(
+        select(Schedule).where(
+            Schedule.enabled == True,  # noqa: E712
+            Schedule.next_run_at < cutoff,
+        )
+    )
+    return [s for s in result.scalars().all() if is_schedule_missed(s, now, grace)]

--- a/orchestrator/tests/test_watchdog.py
+++ b/orchestrator/tests/test_watchdog.py
@@ -1,0 +1,114 @@
+"""Watchdog tests for issue #211: stale-task + missed-schedule detection.
+
+Covers the two acceptance-criteria tests:
+  - test_watchdog_detects_stale_task
+  - test_watchdog_detects_missed_schedule
+
+The detection functions apply a defensive Python-side predicate on top of the
+SQL WHERE clause, so these tests exercise the real staleness/miss logic with an
+AsyncMock db (no Postgres needed).
+"""
+
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+from app.models.schedule import Schedule
+from app.models.task import Task, TaskStatus
+from app.services.watchdog import (
+    find_missed_schedules,
+    find_stale_tasks,
+    is_schedule_missed,
+    is_task_stale,
+    mark_task_stale,
+)
+
+
+def _mock_db(rows):
+    db = AsyncMock()
+    result = MagicMock()
+    scalars = MagicMock()
+    scalars.all.return_value = rows
+    result.scalars.return_value = scalars
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+def _task(task_id, status, updated_minutes_ago, now):
+    t = Task()
+    t.id = task_id
+    t.title = f"Task {task_id}"
+    t.status = status
+    t.updated_at = now - timedelta(minutes=updated_minutes_ago)
+    t.metadata_ = {}
+    return t
+
+
+def _schedule(sid, enabled, next_run_offset_min, now):
+    s = Schedule()
+    s.id = sid
+    s.name = f"Schedule {sid}"
+    s.enabled = enabled
+    s.next_run_at = now + timedelta(minutes=next_run_offset_min)
+    return s
+
+
+class StaleTaskWatchdogTests(unittest.IsolatedAsyncioTestCase):
+    async def test_watchdog_detects_stale_task(self):
+        now = datetime.now(timezone.utc)
+        stale = _task("t1", TaskStatus.RUNNING, updated_minutes_ago=40, now=now)
+        fresh = _task("t2", TaskStatus.RUNNING, updated_minutes_ago=5, now=now)
+        done = _task("t3", TaskStatus.COMPLETED, updated_minutes_ago=99, now=now)
+
+        db = _mock_db([stale, fresh, done])
+        found = await find_stale_tasks(db, now)
+
+        ids = {t.id for t in found}
+        self.assertEqual(ids, {"t1"}, "only the RUNNING task with no >30min heartbeat is stale")
+
+    async def test_mark_task_stale_flips_to_failed(self):
+        now = datetime.now(timezone.utc)
+        task = _task("t1", TaskStatus.RUNNING, updated_minutes_ago=45, now=now)
+
+        mark_task_stale(task, now)
+
+        self.assertEqual(task.status, TaskStatus.FAILED)
+        self.assertTrue(task.metadata_["stale"])
+        self.assertEqual(task.completed_at, now)
+        self.assertIn("heartbeat", (task.error or "").lower())
+
+    def test_is_task_stale_predicate(self):
+        now = datetime.now(timezone.utc)
+        self.assertTrue(is_task_stale(_task("a", TaskStatus.RUNNING, 31, now), now))
+        self.assertFalse(is_task_stale(_task("b", TaskStatus.RUNNING, 29, now), now))
+        self.assertFalse(is_task_stale(_task("c", TaskStatus.PENDING, 99, now), now))
+
+    def test_is_task_stale_handles_naive_datetime(self):
+        now = datetime.now(timezone.utc)
+        t = _task("a", TaskStatus.RUNNING, 40, now)
+        t.updated_at = t.updated_at.replace(tzinfo=None)  # simulate naive DB value
+        self.assertTrue(is_task_stale(t, now))
+
+
+class MissedScheduleWatchdogTests(unittest.IsolatedAsyncioTestCase):
+    async def test_watchdog_detects_missed_schedule(self):
+        now = datetime.now(timezone.utc)
+        missed = _schedule("s1", enabled=True, next_run_offset_min=-10, now=now)
+        upcoming = _schedule("s2", enabled=True, next_run_offset_min=+30, now=now)
+        disabled = _schedule("s3", enabled=False, next_run_offset_min=-60, now=now)
+
+        db = _mock_db([missed, upcoming, disabled])
+        found = await find_missed_schedules(db, now)
+
+        ids = {s.id for s in found}
+        self.assertEqual(ids, {"s1"}, "only the enabled, overdue schedule is missed")
+
+    def test_is_schedule_missed_predicate(self):
+        now = datetime.now(timezone.utc)
+        self.assertTrue(is_schedule_missed(_schedule("a", True, -6, now), now))
+        self.assertFalse(is_schedule_missed(_schedule("b", True, -4, now), now))
+        self.assertFalse(is_schedule_missed(_schedule("c", False, -60, now), now))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the **watchdog** portion of #211 so silently-dropped work is surfaced automatically instead of being noticed hours later via a missing artifact (e.g. the morning podcast that never rendered).

- **Stale-task watchdog** — RUNNING tasks whose `updated_at` heartbeat hasn't advanced for **>30min** are flipped to `FAILED` with a `stale` metadata flag; the owner gets a high-priority UI notification + Telegram alert. Guards against a worker that crashed mid-job (OOM, network drop) leaving the task pinned in RUNNING forever.
- **Missed-schedule watchdog** — enabled schedules whose `next_run_at` slipped **>5min** into the past (scheduler was down during the fire window, e.g. container restart) are alerted once per missed slot. Runs **before** `_check_due_schedules` so the miss is observed before the late catch-up run advances `next_run_at`.

Detection logic lives in a new dependency-light `app/services/watchdog.py` (no docker/redis imports) so it's unit-testable in isolation; `SchedulerService` owns the loop, DB sessions and alerting.

## Scope note

This PR covers acceptance criteria 2 & 3 of #211 (missed-schedule alerting + stale-task detection). **Job-state persistence + auto-resume** (criterion 1, `test_long_job_resumes_after_container_restart`) is a larger DB-migration change and is intentionally left for a follow-up — this issue is estimated M/3-5 days and splitting keeps the watchdog shippable now.

## Test plan

- [x] `test_watchdog_detects_stale_task` — only the RUNNING task with no >30min heartbeat is returned
- [x] `test_watchdog_detects_missed_schedule` — only the enabled, >5min-overdue schedule is returned
- [x] `test_mark_task_stale_flips_to_failed` — status→FAILED, `metadata.stale=True`, error + completed_at set
- [x] predicate + naive-datetime tests
- [x] All 6 watchdog tests pass; `scheduler_service.py` compiles clean

Refs #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)