### PR TITLE
feat(skills): plateau detection in the A/B improvement loop (#210)

### DIFF
--- a/orchestrator/app/services/improvement_engine.py
+++ b/orchestrator/app/services/improvement_engine.py
@@ -24,6 +24,7 @@ from app.models.agent import Agent
 from app.models.notification import Notification
 from app.models.task_rating import TaskRating
 from app.models.skill import Skill, SkillTaskUsage
+from app.services.skill_plateau import is_plateaued
 
 logger = logging.getLogger(__name__)
 
@@ -495,6 +496,118 @@ async def _generate_skill_improvement(
         return None
 
 
+async def _skill_helpfulness_history(db: AsyncSession, skill_id: int, limit: int = 4) -> list[float]:
+    """Return the most recent per-version avg helpfulness snapshots, chronological."""
+    from app.models.skill import SkillVersion
+
+    rows = (await db.execute(
+        select(SkillVersion.avg_helpfulness_at_snapshot)
+        .where(SkillVersion.skill_id == skill_id)
+        .order_by(SkillVersion.version_number.desc())
+        .limit(limit)
+    )).scalars().all()
+    # rows come newest-first; reverse to chronological and drop NULL snapshots
+    return [float(h) for h in reversed(rows) if h is not None]
+
+
+async def _skill_changed_dimensions(db: AsyncSession, skill_id: int, limit: int = 4) -> list[str]:
+    """Best-effort extraction of dimensions changed in recent versions.
+
+    Dimensions are read from SkillVersion.change_reason when it carries a JSON
+    payload with a "changed_dimensions" list (written by the plateau-aware
+    improvement path). Older/plain change_reason strings contribute nothing —
+    the recommendation then just steers toward any unchanged dimension.
+    """
+    from app.models.skill import SkillVersion
+
+    rows = (await db.execute(
+        select(SkillVersion.change_reason)
+        .where(SkillVersion.skill_id == skill_id)
+        .order_by(SkillVersion.version_number.desc())
+        .limit(limit)
+    )).scalars().all()
+    dims: list[str] = []
+    for reason in rows:
+        if not reason:
+            continue
+        try:
+            payload = json.loads(reason)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if isinstance(payload, dict):
+            for d in payload.get("changed_dimensions", []) or []:
+                if isinstance(d, str):
+                    dims.append(d)
+    return dims
+
+
+async def _handle_skill_plateau(db: AsyncSession, skill: "Skill") -> None:
+    """Emit an alternative-strategy alert + KB entry when a skill has plateaued.
+
+    Called instead of generating yet another generic rewrite once the last few
+    versions show no significant rating gain.
+    """
+    from app.services.skill_plateau import recommend_alternative_strategy
+    from app.models.knowledge import KnowledgeEntry
+
+    dims = await _skill_changed_dimensions(db, skill.id)
+    rec = recommend_alternative_strategy(dims)
+
+    db.add(Notification(
+        agent_id="system",
+        type="warning",
+        title=f"Skill-Plateau: '{skill.name}' verbessert sich nicht mehr",
+        message=(
+            f"Mehrere Versionen ohne signifikante Verbesserung. {rec['message']} "
+            f"Empfohlene nächste Dimension: {rec['recommended_dimension']}."
+        )[:240],
+        priority="high",
+        action_url=f"/skills/{skill.id}",
+        meta={
+            "type": "skill_plateau",
+            "skill_id": skill.id,
+            "skill_name": skill.name,
+            "recommended_dimension": rec["recommended_dimension"],
+            "tried_dimensions": rec["tried"],
+        },
+    ))
+
+    title = f"Skill-Plateau: {skill.name}"
+    body = (
+        f"# {title}\n\n"
+        f"Der Skill **{skill.name}** (id {skill.id}) steckt in einem "
+        f"Verbesserungs-Plateau: die letzten Versionen brachten keine "
+        f"signifikante Rating-Steigerung (< 0.2).\n\n"
+        f"## Empfehlung\n{rec['message']}\n\n"
+        f"- Bereits (erfolglos) geänderte Dimensionen: "
+        f"{', '.join(rec['tried']) or '—'}\n"
+        f"- Nächste zu testende Dimension (nur EINE ändern): "
+        f"**{rec['recommended_dimension']}**\n"
+        f"- Weitere Kandidaten: {', '.join(rec['candidates'])}\n\n"
+        f"#skill-improvement #plateau [[Skill improvement plateau]]\n"
+    )
+    existing = (await db.execute(
+        select(KnowledgeEntry).where(KnowledgeEntry.title == title)
+    )).scalar_one_or_none()
+    if existing:
+        existing.content = body
+        existing.updated_by = "improvement_engine"
+    else:
+        db.add(KnowledgeEntry(
+            title=title,
+            content=body,
+            tags=["skill-improvement", "plateau"],
+            created_by="improvement_engine",
+            updated_by="improvement_engine",
+        ))
+
+    skill.improvement_status = "plateau"
+    logger.info(
+        "[ImprovementEngine] Skill '%s' (id=%s) PLATEAU — recommended dimension '%s'",
+        skill.name, skill.id, rec["recommended_dimension"],
+    )
+
+
 async def _improve_poorly_rated_skills(db: AsyncSession) -> None:
     """Find skills with low helpfulness ratings and create improvement *proposals*.
 
@@ -544,6 +657,15 @@ async def _improve_poorly_rated_skills(db: AsyncSession) -> None:
 
         avg_h = float(row.avg_helpfulness)
         rated_count = int(row.rated_count)
+
+        # Plateau guard: if the last few versions produced no real gain, stop
+        # generating another same-flavour rewrite and instead recommend a
+        # different strategy (alternative dimension). Runs at most once per
+        # plateau — the "plateau" status is cleared when a new version lands.
+        history = await _skill_helpfulness_history(db, skill.id)
+        if is_plateaued(history + [avg_h]) and skill.improvement_status != "plateau":
+            await _handle_skill_plateau(db, skill)
+            continue
 
         new_content = await _generate_skill_improvement(skill, avg_h, rated_count)
         if not new_content or new_content.strip() == (skill.content or "").strip():

--- a/orchestrator/app/services/improvement_engine.py
+++ b/orchestrator/app/services/improvement_engine.py
@@ -663,8 +663,9 @@ async def _improve_poorly_rated_skills(db: AsyncSession) -> None:
         # different strategy (alternative dimension). Runs at most once per
         # plateau — the "plateau" status is cleared when a new version lands.
         history = await _skill_helpfulness_history(db, skill.id)
-        if is_plateaued(history + [avg_h]) and skill.improvement_status != "plateau":
-            await _handle_skill_plateau(db, skill)
+        if is_plateaued(history + [avg_h]):
+            if skill.improvement_status != "plateau":
+                await _handle_skill_plateau(db, skill)
             continue
 
         new_content = await _generate_skill_improvement(skill, avg_h, rated_count)

--- a/orchestrator/app/services/skill_plateau.py
+++ b/orchestrator/app/services/skill_plateau.py
@@ -1,0 +1,98 @@
+"""Plateau detection for the A/B skill-improvement loop (issue #210).
+
+The improvement engine keeps rewriting low-rated skills, but real loops get
+stuck at a mediocre rating (e.g. daily-standup skill: 6 rewrites all at 2.4/5).
+The engine never noticed the rewrites were ineffective and kept changing the
+*same* kind of thing (more rules, more examples, more templates).
+
+This module is pure, dependency-light detection logic so it can be unit-tested
+without the DB/LLM/redis import chain. The engine owns persistence + alerting;
+this module owns the "are we plateaued, and what should we try instead?"
+decision.
+"""
+
+# Improvement dimensions we recognise. Split into two opposing clusters: piling
+# on more "control" (structure/rules/examples) vs. shifting to "expressive"
+# levers (tone, audience adaptation, brevity). The observed failure mode is
+# hammering the control cluster forever, so once that is exhausted we steer the
+# next attempt to the expressive cluster.
+_CONTROL_DIMENSIONS = ("examples", "rules", "templates", "structure", "length")
+_EXPRESSIVE_DIMENSIONS = ("tone", "audience_adaptation", "brevity", "data_sources")
+ALL_DIMENSIONS = _CONTROL_DIMENSIONS + _EXPRESSIVE_DIMENSIONS
+
+# A rating gain smaller than this over the plateau window counts as "no
+# significant improvement".
+_MIN_IMPROVEMENT_DELTA = 0.2
+# Number of consecutive versions inspected for a plateau.
+_PLATEAU_WINDOW = 3
+
+
+def is_plateaued(
+    helpfulness_history: list[float],
+    window: int = _PLATEAU_WINDOW,
+    min_delta: float = _MIN_IMPROVEMENT_DELTA,
+) -> bool:
+    """True when the last `window` versions produced no net improvement.
+
+    `helpfulness_history` is the chronological list of a skill's per-version
+    avg helpfulness. We look at the most recent `window` snapshots and treat it
+    as a plateau when the net gain (newest − oldest in the window) is below
+    `min_delta`. Regressions (negative gain) also count — they are not
+    improvements either.
+    """
+    clean = [h for h in helpfulness_history if h is not None]
+    if len(clean) < window:
+        return False
+    recent = clean[-window:]
+    return (recent[-1] - recent[0]) < min_delta
+
+
+def is_single_dimension_change(dimensions: list[str]) -> bool:
+    """Enforce the single-change constraint: a version may touch ≤1 dimension.
+
+    Multivariate rewrites make it impossible to attribute a rating shift to a
+    specific change, so each new version should vary exactly one dimension.
+    """
+    return len({d for d in dimensions if d}) <= 1
+
+
+def recommend_alternative_strategy(changed_dimensions: list[str]) -> dict:
+    """Suggest a different dimension to try after a plateau.
+
+    Given the dimensions that were changed across the plateaued versions, pick
+    an untried dimension — and if the loop has only ever pushed the "control"
+    cluster, explicitly steer it to the opposing "expressive" cluster (the
+    "try LESS control" lesson).
+    """
+    tried = {d for d in changed_dimensions if d}
+    hammered_control = bool(tried & set(_CONTROL_DIMENSIONS)) and not (
+        tried & set(_EXPRESSIVE_DIMENSIONS)
+    )
+
+    if hammered_control:
+        candidates = [d for d in _EXPRESSIVE_DIMENSIONS if d not in tried]
+        message = (
+            "Die Kontroll-Dimensionen ("
+            + ", ".join(sorted(tried & set(_CONTROL_DIMENSIONS)))
+            + ") wurden mehrfach erfolglos geändert. Probiere das Gegenteil: "
+            "weniger Struktur/Regeln, mehr Tonalität und Zielgruppen-Anpassung."
+        )
+    else:
+        candidates = [d for d in ALL_DIMENSIONS if d not in tried]
+        message = (
+            "Die bisher geänderten Dimensionen ("
+            + (", ".join(sorted(tried)) or "—")
+            + ") zeigen keinen Effekt. Teste eine bislang unveränderte Dimension."
+        )
+
+    if not candidates:
+        candidates = [d for d in ALL_DIMENSIONS if d not in tried] or list(ALL_DIMENSIONS)
+
+    return {
+        "tried": sorted(tried),
+        "recommended_dimension": candidates[0],
+        "candidates": candidates,
+        "message": message,
+        # The engine must apply this as a single-dimension change.
+        "single_dimension_constraint": True,
+    }

--- a/orchestrator/tests/test_skill_plateau.py
+++ b/orchestrator/tests/test_skill_plateau.py
@@ -1,0 +1,73 @@
+"""Tests for the A/B improvement-loop plateau detection (issue #210).
+
+Covers the two acceptance-criteria tests:
+  - test_plateau_detection_after_3_no_improvement
+  - test_single_dimension_change_recommendation
+"""
+
+import unittest
+
+from app.services.skill_plateau import (
+    _CONTROL_DIMENSIONS,
+    _EXPRESSIVE_DIMENSIONS,
+    is_plateaued,
+    is_single_dimension_change,
+    recommend_alternative_strategy,
+)
+
+
+class PlateauDetectionTests(unittest.TestCase):
+    def test_plateau_detection_after_3_no_improvement(self):
+        """3 consecutive versions stuck at the same rating → plateau."""
+        # daily-standup skill: v2-v4 all at 2.4/5
+        self.assertTrue(is_plateaued([2.2, 2.4, 2.4, 2.4]))
+        self.assertTrue(is_plateaued([2.4, 2.4, 2.4]))
+
+    def test_real_improvement_is_not_plateau(self):
+        self.assertFalse(is_plateaued([2.2, 2.6, 3.0]))
+        self.assertFalse(is_plateaued([2.0, 2.4, 2.9]))
+
+    def test_too_few_versions_is_not_plateau(self):
+        self.assertFalse(is_plateaued([2.4, 2.4]))
+        self.assertFalse(is_plateaued([2.4]))
+        self.assertFalse(is_plateaued([]))
+
+    def test_regression_counts_as_no_improvement(self):
+        # Getting worse is also "no improvement" → still triggers a rethink.
+        self.assertTrue(is_plateaued([2.8, 2.5, 2.4]))
+
+    def test_none_values_are_ignored(self):
+        self.assertTrue(is_plateaued([None, 2.4, 2.4, 2.4]))
+        self.assertFalse(is_plateaued([None, 2.4, 2.4]))  # only 2 real points
+
+    def test_custom_window_and_delta(self):
+        self.assertTrue(is_plateaued([3.0, 3.0], window=2, min_delta=0.2))
+        self.assertFalse(is_plateaued([3.0, 3.3], window=2, min_delta=0.2))
+
+
+class SingleDimensionRecommendationTests(unittest.TestCase):
+    def test_single_dimension_change_recommendation(self):
+        """After hammering the control cluster, recommend the opposite cluster."""
+        rec = recommend_alternative_strategy(["examples", "rules", "templates"])
+
+        # Must not recommend an already-exhausted dimension.
+        self.assertNotIn(rec["recommended_dimension"], {"examples", "rules", "templates"})
+        # Should steer toward the expressive cluster (the "try LESS control" lesson).
+        self.assertIn(rec["recommended_dimension"], _EXPRESSIVE_DIMENSIONS)
+        # And it must be applied as a single-dimension change.
+        self.assertTrue(rec["single_dimension_constraint"])
+        self.assertTrue(is_single_dimension_change([rec["recommended_dimension"]]))
+
+    def test_recommends_untried_dimension_when_mixed(self):
+        rec = recommend_alternative_strategy(["examples", "tone"])
+        self.assertNotIn(rec["recommended_dimension"], {"examples", "tone"})
+        self.assertIn(rec["recommended_dimension"], set(_CONTROL_DIMENSIONS) | set(_EXPRESSIVE_DIMENSIONS))
+
+    def test_single_dimension_constraint_helper(self):
+        self.assertTrue(is_single_dimension_change(["examples"]))
+        self.assertTrue(is_single_dimension_change([]))
+        self.assertFalse(is_single_dimension_change(["examples", "rules"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The improvement engine kept generating same-flavour rewrites for low-rated skills stuck at a mediocre rating (the daily-standup skill went through 6 rewrites all at 2.4/5). It never noticed the rewrites were ineffective and kept changing the *same kind* of thing (more rules, more examples, more templates).

- **New dependency-light `app/services/skill_plateau.py`** (pure logic, unit-testable in isolation):
  - `is_plateaued(history)` — flags no net rating gain (<0.2) over the last 3 versions
  - `recommend_alternative_strategy(changed_dimensions)` — steers the next attempt to an untried dimension; once the **control** cluster (examples/rules/templates/structure/length) is exhausted it explicitly recommends the opposing **expressive** cluster (tone/audience/brevity), encoding the "try LESS control" lesson from the issue
  - `is_single_dimension_change()` — enforces one changed dimension per version so a rating shift is attributable
- **Wired into `_improve_poorly_rated_skills`**: before generating another generic rewrite, the engine checks the skill's per-version helpfulness history; on a plateau it emits a high-priority UI notification **+ upserts a Knowledge-Base entry** recommending an alternative strategy, and sets `improvement_status="plateau"` (cleared when a new version lands) instead of rewriting the same way again.

## Scope note

Covers acceptance criteria 2 & 4 (alternative-strategy suggestion after 3 plateau versions + the two required tests). Detection reuses the existing `SkillVersion.avg_helpfulness_at_snapshot`, so **no migration** is needed. Criterion 1 (persistent per-version `improvement_hypothesis` / `changed_dimensions` columns + write-time single-change enforcement) is a follow-up requiring a schema migration; criterion 3 (actually lifting skill 158 >3.0) depends on live ratings. Kept as `Refs #210`, not `Fixes`.

## Test plan

- [x] `test_plateau_detection_after_3_no_improvement` — 3 versions stuck at 2.4 → plateau
- [x] `test_single_dimension_change_recommendation` — after control cluster exhausted, recommends an expressive-cluster dimension, single-change enforced
- [x] real improvement / too-few-versions / regression / None-handling / custom window edge cases
- [x] 9/9 plateau tests pass; `improvement_engine.py` imports clean

Refs #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)