### PR TITLE
Fix: job_state table missing on startup (Refs #211)

### DIFF
--- a/orchestrator/app/main.py
+++ b/orchestrator/app/main.py
@@ -791,6 +791,42 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning(f"Could not ensure chat_sessions table: {e}")
 
+    # Ensure the job_state table (long-running-job checkpoints) on every startup,
+    # independent of Alembic. PR #278 shipped the JobState model but no migration —
+    # `alembic upgrade head` is the normal path (create_all only runs as a fallback),
+    # so on an Alembic-provisioned DB the table was never created and the startup
+    # resume hook (recover_jobs_on_startup) logged UndefinedTableError every cycle.
+    # Idempotent, mirrors the oauth_clients/chat_sessions pattern above.
+    try:
+        from app.db.session import engine as _eng_js
+        from sqlalchemy import text as _txt_js
+        async with _eng_js.begin() as conn:
+            await conn.execute(_txt_js(
+                "CREATE TABLE IF NOT EXISTS job_state ("
+                "id varchar PRIMARY KEY, "
+                "kind varchar(100) NOT NULL, "
+                "ref_id varchar, "
+                "step varchar NOT NULL DEFAULT '', "
+                "progress_pct double precision NOT NULL DEFAULT 0.0, "
+                "status varchar(20) NOT NULL DEFAULT 'running', "
+                "last_heartbeat timestamptz NOT NULL DEFAULT now(), "
+                "resume_count integer NOT NULL DEFAULT 0, "
+                "error text, "
+                "job_metadata json NOT NULL DEFAULT '{}'::json, "
+                "created_at timestamptz NOT NULL DEFAULT now(), "
+                "updated_at timestamptz NOT NULL DEFAULT now())"
+            ))
+            await conn.execute(_txt_js(
+                "CREATE INDEX IF NOT EXISTS ix_job_state_status_heartbeat "
+                "ON job_state (status, last_heartbeat)"
+            ))
+            await conn.execute(_txt_js(
+                "CREATE INDEX IF NOT EXISTS ix_job_state_ref_id ON job_state (ref_id)"
+            ))
+        logger.info("job_state table ensured")
+    except Exception as e:
+        logger.warning(f"Could not ensure job_state table: {e}")
+
     # Ensure users.approved (admin-approval gate). Default true so existing users stay
     # usable; new self-registered users get false when require_user_approval is on.
     try:


### PR DESCRIPTION
## Problem

The startup log fires this WARNING every cycle (11:22, 11:40, 11:58, 12:08, 12:10 UTC on 2026-07-02):

```
WARNING app.main: Job-state recovery failed: ... asyncpg.exceptions.UndefinedTableError:
relation "job_state" does not exist
```

## Root cause

PR #278 added the `JobState` model but **no Alembic migration**, on the assumption that `Base.metadata.create_all` at startup would create the table. That assumption is wrong for a normally-provisioned DB:

- The normal startup path runs `alembic upgrade head` (`main.py:724`).
- `_init_db_from_models()` / `create_all` only runs as a **fallback** when Alembic fails (`main.py:731-739`).

So on the Alembic-provisioned production DB, `job_state` was never created, and the resume hook `recover_jobs_on_startup()` (queries `WHERE status='running'`) failed on every startup cycle.

## Fix

Add an idempotent `CREATE TABLE IF NOT EXISTS job_state` block in `lifespan`, independent of Alembic — mirroring the existing `oauth_clients` (`main.py:743`) and `chat_sessions` (`main.py:766`) blocks that ship without a migration.

- DDL verified to match the model-generated PostgreSQL schema exactly (via `CreateTable(...).compile(postgresql.dialect())`).
- Both indexes (`ix_job_state_status_heartbeat`, `ix_job_state_ref_id`) recreated idempotently.
- `pytest tests/test_job_state.py` → 8/8 green (unaffected, they use SQLite create_all).

## Test plan
- [ ] After merge + orchestrator restart, confirm the `job_state does not exist` WARNING stops firing.
- [ ] Confirm `job_state table ensured` appears in startup logs.

Refs #211 (follow-up to PR #278).

🤖 Generated with [Claude Code](https://claude.com/claude-code)