### PR TITLE
Fix #272 (follow-up): guard reflection result parsing to kill recurring WARNING

### DIFF
--- a/orchestrator/app/core/task_router.py
+++ b/orchestrator/app/core/task_router.py
@@ -64,6 +64,50 @@ def _compute_formula_rating(task: "Task") -> int:  # noqa: F821
     return max(1, min(5, score))
 
 
+def _parse_reflection_stdout(stdout: bytes, stderr: bytes, returncode: "int | None") -> tuple[int, str]:
+    """Parse `claude -p --output-format json` output into (rating, reflection).
+
+    Pure and import-free so it is unit-testable without the app or a live subprocess.
+    Raises ValueError with a descriptive message on any unusable output — empty stdout,
+    a non-JSON envelope, an error envelope, or an empty/non-JSON `result`. Previously the
+    unguarded json.loads(result) raised the generic "Expecting value: line 1 column 1",
+    which masked the real cause (auth/quota failure) in the platform log (#272).
+    """
+    if not stdout.strip():
+        excerpt = stderr.decode(errors="replace")[:300].strip() if stderr else ""
+        raise ValueError(
+            f"claude subprocess exited {returncode} with empty stdout"
+            + (f": {excerpt}" if excerpt else "")
+        )
+    try:
+        envelope = json.loads(stdout.decode())
+    except json.JSONDecodeError as je:
+        raise ValueError(
+            f"claude stdout is not JSON (rc={returncode}): "
+            f"{stdout.decode(errors='replace')[:300]}"
+        ) from je
+    # The envelope carries an error flag plus the model reply in `result`. On auth/quota
+    # failures `result` is a plain-text error (or empty), so guard before json.loads.
+    text = (envelope.get("result") or "").strip()
+    if envelope.get("is_error") or not text:
+        raise ValueError(
+            f"claude reflection unusable (is_error={envelope.get('is_error')}, "
+            f"subtype={envelope.get('subtype')!r}): {text[:300] or '<empty result>'}"
+        )
+    # Strip markdown fences, then extract the JSON object if the model wrapped it in prose.
+    if text.startswith("```"):
+        text = "\n".join(text.split("\n")[1:]).split("```")[0].strip()
+    if not text.startswith("{"):
+        start, end = text.find("{"), text.rfind("}")
+        if start == -1 or end <= start:
+            raise ValueError(f"no JSON object in claude reflection result: {text[:300]}")
+        text = text[start:end + 1]
+    parsed = json.loads(text)
+    rating = max(1, min(5, int(parsed["rating"])))
+    reflection = str(parsed.get("reflection", ""))[:500]
+    return rating, reflection
+
+
 async def _llm_reflect_on_task(task: "Task") -> tuple[int, str]:  # noqa: F821
     """Ask Claude CLI to self-reflect on a completed task and return (rating, reflection).
 
@@ -103,22 +147,7 @@ async def _llm_reflect_on_task(task: "Task") -> tuple[int, str]:  # noqa: F821
             env=env,
         )
         stdout, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=20.0)
-        if not stdout.strip():
-            stderr_excerpt = stderr_bytes.decode(errors="replace")[:300].strip() if stderr_bytes else ""
-            raise ValueError(
-                f"claude subprocess exited {proc.returncode} with empty stdout"
-                + (f": {stderr_excerpt}" if stderr_excerpt else "")
-            )
-        output = json.loads(stdout.decode())
-        text = output.get("result", "")
-        # Strip markdown fences
-        text = text.strip()
-        if text.startswith("```"):
-            text = "\n".join(text.split("\n")[1:]).split("```")[0]
-        parsed = json.loads(text)
-        rating = max(1, min(5, int(parsed["rating"])))
-        reflection = str(parsed.get("reflection", ""))[:500]
-        return rating, reflection
+        return _parse_reflection_stdout(stdout, stderr_bytes, proc.returncode)
     except Exception as exc:
         logger.warning(f"LLM self-reflection failed for task {task.id}, falling back to formula: {exc}")
         return _compute_formula_rating(task), "auto-rated (formula fallback)"

--- a/orchestrator/tests/test_reflection_parse.py
+++ b/orchestrator/tests/test_reflection_parse.py
@@ -1,0 +1,75 @@
+"""Tests for _parse_reflection_stdout — the claude-CLI reflection output parser (#272).
+
+Guards the paths that previously raised the generic "Expecting value: line 1 column 1"
+and masked the real auth/quota failure in the platform log.
+"""
+
+import json
+import unittest
+
+from app.core.task_router import _parse_reflection_stdout
+
+
+def _envelope(result, is_error=False, subtype="success"):
+    return json.dumps(
+        {"type": "result", "subtype": subtype, "is_error": is_error, "result": result}
+    ).encode()
+
+
+class ParseReflectionStdoutTests(unittest.TestCase):
+    def test_clean_json_result(self):
+        out = _envelope('{"rating": 4, "reflection": "Solid run."}')
+        self.assertEqual(_parse_reflection_stdout(out, b"", 0), (4, "Solid run."))
+
+    def test_rating_is_clamped(self):
+        out = _envelope('{"rating": 9, "reflection": "x"}')
+        self.assertEqual(_parse_reflection_stdout(out, b"", 0)[0], 5)
+        out = _envelope('{"rating": -3, "reflection": "x"}')
+        self.assertEqual(_parse_reflection_stdout(out, b"", 0)[0], 1)
+
+    def test_markdown_fenced_json(self):
+        out = _envelope('```json\n{"rating": 3, "reflection": "Ok."}\n```')
+        self.assertEqual(_parse_reflection_stdout(out, b"", 0), (3, "Ok."))
+
+    def test_json_wrapped_in_prose(self):
+        out = _envelope('Sure! Here is my rating: {"rating": 5, "reflection": "Great."} Done.')
+        self.assertEqual(_parse_reflection_stdout(out, b"", 0), (5, "Great."))
+
+    def test_empty_stdout_surfaces_stderr(self):
+        with self.assertRaises(ValueError) as cm:
+            _parse_reflection_stdout(b"", b"Invalid API key", 1)
+        self.assertIn("Invalid API key", str(cm.exception))
+        self.assertIn("empty stdout", str(cm.exception))
+
+    def test_non_json_stdout(self):
+        with self.assertRaises(ValueError) as cm:
+            _parse_reflection_stdout(b"segfault: core dumped", b"", 139)
+        self.assertIn("not JSON", str(cm.exception))
+        # Must NOT be the old cryptic JSONDecodeError message.
+        self.assertNotIn("Expecting value", str(cm.exception))
+
+    def test_error_envelope_surfaces_reason(self):
+        out = _envelope("Credit balance too low", is_error=True, subtype="error_during_execution")
+        with self.assertRaises(ValueError) as cm:
+            _parse_reflection_stdout(out, b"", 0)
+        msg = str(cm.exception)
+        self.assertIn("Credit balance too low", msg)
+        self.assertIn("is_error=True", msg)
+
+    def test_empty_result_field(self):
+        # The exact #272 failure: valid envelope, empty result → used to crash on json.loads("").
+        out = _envelope("")
+        with self.assertRaises(ValueError) as cm:
+            _parse_reflection_stdout(out, b"", 0)
+        self.assertIn("<empty result>", str(cm.exception))
+        self.assertNotIn("Expecting value", str(cm.exception))
+
+    def test_result_without_json_object(self):
+        out = _envelope("I cannot rate this task.")
+        with self.assertRaises(ValueError) as cm:
+            _parse_reflection_stdout(out, b"", 0)
+        self.assertIn("no JSON object", str(cm.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
The `LLM self-reflection failed ... Expecting value: line 1 column 1 (char 0)` WARNING is **still firing** in prod (latest: 2026-07-02 16:17:57Z), even though #272 was auto-closed by #273.

**Why #273 wasn't enough:** #273 only guarded the *empty-stdout* path. But `_llm_reflect_on_task` had two more unguarded `json.loads` calls — the CLI envelope parse and, crucially, `json.loads(result)`. When the `claude -p --output-format json` envelope is valid but `result` is **empty** or a **plain-text auth/quota error**, `json.loads("")` raises exactly `Expecting value: line 1 column 1` — masking the real cause. That's the line still in the log.

## Changes
- Extract parsing into a **pure, import-free** `_parse_reflection_stdout(stdout, stderr, returncode)` helper (unit-testable without the app or a live subprocess).
- Guard the envelope parse → descriptive `claude stdout is not JSON` error incl. a stdout excerpt.
- Treat `is_error` / empty `result` as a descriptive `ValueError` that **surfaces the real reason** (e.g. `Credit balance too low`, `is_error=True`) instead of the cryptic message.
- Extract the JSON object when the model wraps it in prose / markdown fences.

## Tests
`orchestrator/tests/test_reflection_parse.py` — **9 cases, all green** (clean/fenced/prose JSON, rating clamp, empty stdout→stderr surfaced, non-JSON stdout, error envelope, empty result, no-JSON result). Run: `python -m pytest tests/test_reflection_parse.py -v`.

## Satisfies the two open acceptance criteria of #272
- [x] `_llm_reflect_on_task` logs the actual subprocess/API error instead of `Expecting value ...`
- [x] `json.loads('')` is never reached (result guarded)

Note: whether reflection *succeeds* still depends on a valid key in the container env — but now the log will show the **real** reason (auth/quota) rather than a generic decode error, so ops can act on it.

Refs #272