### PR TITLE
Fix #282: wire job-state checkpoints into task lifecycle + re-launch resumable jobs

### DIFF
--- a/orchestrator/app/core/task_router.py
+++ b/orchestrator/app/core/task_router.py
@@ -363,6 +363,29 @@ class TaskRouter:
         await self.db.commit()
         logger.info(f"Task {task_id} is now running on agent {data.get('agent_id')}")
 
+        # Persist a job-state checkpoint so a task interrupted mid-run by a
+        # container restart can be re-enqueued instead of silently lost (#211/#282).
+        # Non-blocking: a checkpoint failure must never prevent the task from running.
+        try:
+            from app.services.job_state import checkpoint
+
+            await checkpoint(
+                self.db,
+                f"task:{task_id}",
+                kind="agent_task",
+                ref_id=task_id,
+                status="running",
+                metadata={
+                    "agent_id": data.get("agent_id") or task.agent_id,
+                    "title": task.title,
+                    "prompt": task.prompt,
+                    "priority": task.priority,
+                    "model": task.model,
+                },
+            )
+        except Exception as e:
+            logger.warning(f"job_state checkpoint (start) failed for {task_id}: {e}")
+
     async def delete_task(self, task_id: str) -> bool:
         """Delete a task. Only non-running tasks can be deleted."""
         result = await self.db.execute(select(Task).where(Task.id == task_id))
@@ -459,6 +482,15 @@ class TaskRouter:
                     _td.completed_at = datetime.now(timezone.utc)
 
         await self.db.commit()
+
+        # The run finished (success or failure): drop its job-state checkpoint so
+        # startup recovery only ever sees genuinely in-flight jobs (#211/#282).
+        try:
+            from app.services.job_state import delete_job
+
+            await delete_job(self.db, f"task:{task_id}")
+        except Exception as e:
+            logger.warning(f"job_state cleanup failed for {task_id}: {e}")
 
         # Auto-rate the task based on outcome metrics
         await self._auto_rate_task(task)

--- a/orchestrator/app/main.py
+++ b/orchestrator/app/main.py
@@ -1211,14 +1211,82 @@ clean Markdown; you don't need to commit.
     # Resume long-running jobs that were checkpointing before shutdown (issue #211).
     # Jobs with a fresh heartbeat are resumable; stale ones are marked crashed and
     # the user is alerted so no long job silently dies across a container restart.
+    async def _resume_agent_task(job):
+        """Re-enqueue an agent task interrupted mid-run by a container restart (#282).
+
+        The original task (if still present) is marked failed and its stale queue
+        entry dropped so it cannot also be picked up — the replacement is the only
+        executor. The job row is deleted so a second restart never re-launches it.
+        """
+        from app.core.load_balancer import LoadBalancer
+        from app.core.task_router import TaskRouter
+        from app.db.session import async_session_factory as _sf_resume
+        from app.models.task import Task, TaskStatus, is_terminal_task_status
+        from app.services.job_state import delete_job
+        from sqlalchemy import select as _sel
+
+        meta = dict(job.job_metadata or {})
+        prompt = meta.get("prompt")
+        if not prompt:
+            logger.warning(f"[Resume] Job {job.id} has no persisted prompt — cannot re-launch")
+            async with _sf_resume() as db:
+                await delete_job(db, job.id)
+            return
+
+        async with _sf_resume() as db:
+            lb = LoadBalancer(app.state.redis)
+            router = TaskRouter(db, app.state.redis, lb, docker_service=app.state.docker)
+
+            orig = None
+            if job.ref_id:
+                orig = (await db.execute(_sel(Task).where(Task.id == job.ref_id))).scalar_one_or_none()
+
+            # Already finished after the crash was recorded — nothing to redo.
+            if orig is not None and orig.status == TaskStatus.COMPLETED:
+                await delete_job(db, job.id)
+                logger.info(f"[Resume] Job {job.id} original task {job.ref_id} already completed — skipping")
+                return
+
+            # Retire a non-terminal original so it can't run alongside the replacement.
+            if orig is not None and not is_terminal_task_status(orig.status):
+                if orig.status == TaskStatus.QUEUED and orig.agent_id:
+                    await router._remove_from_queue(orig.agent_id, orig.id)
+                orig.status = TaskStatus.FAILED
+                orig.error = "Superseded by auto-resume after container restart"
+                orig.completed_at = datetime.now(timezone.utc)
+                orig.notified = True
+                await db.commit()
+
+            new_task = await router.create_and_route_task(
+                title=meta.get("title") or f"[Resumed] {job.ref_id or job.id}",
+                prompt=prompt,
+                priority=int(meta.get("priority") or 5),
+                agent_id=meta.get("agent_id"),
+                model=meta.get("model"),
+                metadata={"resumed_from_task": job.ref_id, "resumed_from_job": job.id},
+            )
+            await delete_job(db, job.id)
+            logger.info(
+                f"[Resume] Re-enqueued interrupted job {job.id} (task {job.ref_id}) as new task {new_task.id}"
+            )
+
     try:
         from app.db.session import async_session_factory as _sf_jobs
-        from app.services.job_state import recover_jobs_on_startup
+        from app.services.job_state import (
+            recover_jobs_on_startup,
+            register_resume_handler,
+            relaunch_resumable_jobs,
+        )
+
+        register_resume_handler("agent_task", _resume_agent_task)
 
         async with _sf_jobs() as db:
             resumable, crashed = await recover_jobs_on_startup(db)
             if resumable:
                 logger.info(f"[Startup] {len(resumable)} long job(s) resumable after restart")
+                outcomes = await relaunch_resumable_jobs(resumable, schedule=asyncio.create_task)
+                launched = sum(1 for _job, ok in outcomes if ok)
+                logger.info(f"[Startup] Re-launched {launched}/{len(resumable)} resumable job(s)")
             for job in crashed:
                 logger.warning(f"[Startup] Job {job.id} ({job.kind}) crashed across restart — no heartbeat")
                 try:

--- a/orchestrator/app/services/job_state.py
+++ b/orchestrator/app/services/job_state.py
@@ -13,11 +13,15 @@ heartbeat are resumable (the container restarted but the job's last checkpoint i
 recent), rows whose heartbeat is older than the stale threshold are marked crashed.
 """
 
+import logging
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import select
 
 from app.models.job_state import JobState
+
+logger = logging.getLogger(__name__)
 
 # A running job whose last heartbeat is within this window is considered
 # resumable after a restart. Beyond it we assume the job died mid-flight.
@@ -85,6 +89,60 @@ async def recover_jobs_on_startup(db, now: datetime | None = None) -> tuple[list
     return resumable, crashed
 
 
+# Resume-handler registry: each long-runner registers an async handler for its
+# `kind`. On startup the caller passes the resumable rows to `relaunch_resumable_jobs`
+# which dispatches each to its handler so the runner picks up from the persisted
+# `step`/`job_metadata`. Kept as a plain dict (no imports) so this module stays
+# dependency-light and unit-testable — services register at wiring time in main.py.
+ResumeHandler = Callable[[JobState], Awaitable[None]]
+_RESUME_HANDLERS: dict[str, ResumeHandler] = {}
+
+
+def register_resume_handler(kind: str, handler: ResumeHandler) -> None:
+    """Register the coroutine that re-launches a resumable job of the given kind."""
+    _RESUME_HANDLERS[kind] = handler
+
+
+def get_resume_handler(kind: str) -> ResumeHandler | None:
+    return _RESUME_HANDLERS.get(kind)
+
+
+def clear_resume_handlers() -> None:
+    """Test helper — reset the registry between cases."""
+    _RESUME_HANDLERS.clear()
+
+
+async def relaunch_resumable_jobs(
+    resumable: list[JobState],
+    *,
+    schedule: Callable[[Awaitable[None]], object] | None = None,
+) -> list[tuple[JobState, bool]]:
+    """Dispatch each resumable job to its registered handler.
+
+    `schedule` is normally `asyncio.create_task` so re-launched jobs run in the
+    background without blocking startup; when omitted the handler is awaited inline
+    (used by tests). Returns (job, launched?) — launched is False when no handler
+    is registered for the job's kind, so the caller can log the orphan.
+    """
+    outcomes: list[tuple[JobState, bool]] = []
+    for job in resumable:
+        handler = _RESUME_HANDLERS.get(job.kind)
+        if handler is None:
+            logger.warning(
+                "No resume handler registered for job kind '%s' (job %s) — cannot re-launch",
+                job.kind, job.id,
+            )
+            outcomes.append((job, False))
+            continue
+        coro = handler(job)
+        if schedule is not None:
+            schedule(coro)
+        else:
+            await coro
+        outcomes.append((job, True))
+    return outcomes
+
+
 async def checkpoint(
     db,
     job_id: str,
@@ -135,3 +193,19 @@ async def checkpoint(
 
     await db.commit()
     return job
+
+
+async def delete_job(db, job_id: str) -> bool:
+    """Delete a job row once its run has finished (kept-table stays bounded).
+
+    A completed agent task deletes its checkpoint so only in-flight jobs ever
+    leave a `running` row for the startup classifier to find. Returns True if a
+    row was removed.
+    """
+    result = await db.execute(select(JobState).where(JobState.id == job_id))
+    job = result.scalars().first()
+    if job is None:
+        return False
+    await db.delete(job)
+    await db.commit()
+    return True

--- a/orchestrator/tests/test_job_state.py
+++ b/orchestrator/tests/test_job_state.py
@@ -8,8 +8,13 @@ from app.models.job_state import JobState
 from app.services.job_state import (
     _RESUME_STALE_AFTER,
     classify_on_startup,
+    clear_resume_handlers,
+    delete_job,
+    get_resume_handler,
     is_resumable,
     recover_jobs_on_startup,
+    register_resume_handler,
+    relaunch_resumable_jobs,
 )
 
 
@@ -33,6 +38,17 @@ def _mock_db(rows):
     result = MagicMock()
     result.scalars.return_value.all.return_value = rows
     db.execute = AsyncMock(return_value=result)
+    db.commit = AsyncMock()
+    return db
+
+
+def _mock_db_first(row):
+    """Mock a db whose execute().scalars().first() returns `row`."""
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = row
+    db.execute = AsyncMock(return_value=result)
+    db.delete = AsyncMock()
     db.commit = AsyncMock()
     return db
 
@@ -120,6 +136,72 @@ class TestRecoverOnStartup(unittest.IsolatedAsyncioTestCase):
         self.assertEqual([j.id for j in crashed], ["stale"])
         self.assertEqual(fresh.resume_count, 1)
         self.assertEqual(stale.status, "crashed")
+
+
+class TestDeleteJob(unittest.IsolatedAsyncioTestCase):
+    async def test_delete_removes_existing_row(self):
+        job = _job(id="done-1", status="completed")
+        db = _mock_db_first(job)
+        removed = await delete_job(db, "done-1")
+        self.assertTrue(removed)
+        db.delete.assert_awaited_once_with(job)
+        db.commit.assert_awaited()
+
+    async def test_delete_missing_row_is_noop(self):
+        db = _mock_db_first(None)
+        removed = await delete_job(db, "ghost")
+        self.assertFalse(removed)
+        db.delete.assert_not_awaited()
+        db.commit.assert_not_awaited()
+
+
+class TestRelaunchResumable(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        clear_resume_handlers()
+
+    def tearDown(self):
+        clear_resume_handlers()
+
+    async def test_dispatches_to_registered_handler_inline(self):
+        seen = []
+
+        async def handler(job):
+            seen.append(job.id)
+
+        register_resume_handler("agent_task", handler)
+        job = _job(id="t-1", kind="agent_task")
+        outcomes = await relaunch_resumable_jobs([job])
+        self.assertEqual(seen, ["t-1"])
+        self.assertEqual(outcomes, [(job, True)])
+
+    async def test_unregistered_kind_reports_not_launched(self):
+        job = _job(id="orphan", kind="unknown_kind")
+        outcomes = await relaunch_resumable_jobs([job])
+        self.assertEqual(outcomes, [(job, False)])
+
+    async def test_schedule_callback_defers_execution(self):
+        scheduled = []
+
+        async def handler(job):
+            raise AssertionError("handler must not run inline when schedule is given")
+
+        def schedule(coro):
+            scheduled.append(coro)
+            coro.close()  # avoid 'coroutine was never awaited' warning
+
+        register_resume_handler("agent_task", handler)
+        job = _job(id="t-2", kind="agent_task")
+        outcomes = await relaunch_resumable_jobs([job], schedule=schedule)
+        self.assertEqual(len(scheduled), 1)
+        self.assertEqual(outcomes, [(job, True)])
+
+    def test_register_and_get_handler(self):
+        async def handler(job):
+            return None
+
+        register_resume_handler("agent_task", handler)
+        self.assertIs(get_resume_handler("agent_task"), handler)
+        self.assertIsNone(get_resume_handler("nope"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Closes the reliability gap from #211: the job-state checkpoint/recover/relaunch infrastructure (PRs #276/#278/#280) had **zero callers**, so startup recovery always found an empty table and an agent task that was mid-run when the container restarted died silently. This wires it end-to-end.

- **Checkpoint on task start** — `handle_task_start` persists a `running` `job_state` row (`kind=agent_task`, `ref_id=task_id`, with `prompt`/`agent_id`/`model`/`priority` metadata) so an interrupted task can be re-enqueued.
- **Cleanup on completion** — `handle_task_completion` deletes the row, so only genuinely in-flight jobs ever leave a `running` row (table stays bounded). New `delete_job` helper.
- **Actually re-launch** — startup registers an `agent_task` resume handler and calls `relaunch_resumable_jobs` (previously it only *logged* "N resumable"). Each fresh-heartbeat job is re-enqueued via `create_and_route_task`.
- **Idempotent / no double-run** — the original task is retired (marked `FAILED`, dropped from its Redis queue) so the replacement is the sole executor; the job row is deleted so a second restart never re-launches. An already-`COMPLETED` original is skipped.
- **Non-blocking** — both lifecycle hooks are wrapped in try/except so a checkpoint failure can never prevent a task from running.

## Architecture note
The orchestrator's real long-runner is the **agent task lifecycle** (`task_router.handle_task_start`/`handle_task_completion`), not the external HyperFrames/podcast render loops — those run in a separate MCP server with nothing to wire in-process. Coarse task-level recovery (`recover_stale_tasks`, #276) marks stale tasks failed; this layer adds the missing *resume* so the work is actually redone.

## Test plan
- [x] `python -m pytest tests/test_job_state.py -v` → **14 passed** (added `delete_job` + relaunch-dispatch cases)
- [x] `python -m py_compile` on all three changed modules → OK
- [ ] After merge + `docker restart`: confirm INFO `job_state table ensured` at startup, then verify a restart during a running task produces `[Resume] Re-enqueued ...` and a replacement task.

Fixes #282