### PR TITLE
Fix: force JSON-only reflection rating (stop prose fallback)

### DIFF
--- a/orchestrator/app/core/task_router.py
+++ b/orchestrator/app/core/task_router.py
@@ -108,6 +108,32 @@ def _parse_reflection_stdout(stdout: bytes, stderr: bytes, returncode: "int | No
     return rating, reflection
 
 
+def _build_reflection_prompt(
+    title: str, status: str, duration_s: float, num_turns: int, cost_usd: float, error: str
+) -> str:
+    """Build the claude-CLI reflection prompt. Pure/import-free so it is unit-testable.
+
+    The metrics below are the ONLY context the rater gets, so the prompt must forbid the
+    model from asking for more (it otherwise replies with prose like "I don't have enough
+    context to rate this task fairly", which has no JSON object and forces a formula
+    fallback — the LLM rating then never runs). We give an explicit scoring rubric and
+    demand a bare JSON object so a best-guess rating is always produced from the metrics.
+    """
+    return (
+        "You are an automated task-quality rater. Rate the AI agent task below 1-5 stars "
+        "using ONLY the metrics provided — they are the complete context. Do NOT ask for "
+        "more information and do NOT write any prose outside the JSON.\n\n"
+        f"Task: {title or 'Untitled'}\n"
+        f"Status: {status}\n"
+        f"Duration: {duration_s}s | Turns: {num_turns or 0} | Cost: ${cost_usd or 0:.4f}\n"
+        f"Error: {error or 'none'}\n\n"
+        "Scoring guide: completed with no error and reasonable cost/turns = 4-5; "
+        "completed but slow, costly, or many turns = 3; failed or errored = 1-2.\n"
+        'Output ONLY this JSON object and nothing else: '
+        '{"rating": <1-5>, "reflection": "<one sentence>"}'
+    )
+
+
 async def _llm_reflect_on_task(task: "Task") -> tuple[int, str]:  # noqa: F821
     """Ask Claude CLI to self-reflect on a completed task and return (rating, reflection).
 
@@ -121,13 +147,13 @@ async def _llm_reflect_on_task(task: "Task") -> tuple[int, str]:  # noqa: F821
         return _compute_formula_rating(task), "auto-rated (claude CLI not found)"
 
     duration_s = round((task.duration_ms or 0) / 1000, 1)
-    prompt = (
-        "Rate this AI agent task 1-5 stars and give a one-sentence reflection.\n\n"
-        f"Task: {task.title or 'Untitled'}\n"
-        f"Status: {task.status.value}\n"
-        f"Duration: {duration_s}s | Turns: {task.num_turns or 0} | Cost: ${task.cost_usd or 0:.4f}\n"
-        f"Error: {task.error or 'none'}\n\n"
-        'Respond with JSON only: {"rating": <1-5>, "reflection": "<one sentence>"}'
+    prompt = _build_reflection_prompt(
+        title=task.title or "",
+        status=task.status.value,
+        duration_s=duration_s,
+        num_turns=task.num_turns or 0,
+        cost_usd=task.cost_usd or 0,
+        error=task.error or "",
     )
 
     try:

--- a/orchestrator/tests/test_reflection_parse.py
+++ b/orchestrator/tests/test_reflection_parse.py
@@ -7,7 +7,7 @@ and masked the real auth/quota failure in the platform log.
 import json
 import unittest
 
-from app.core.task_router import _parse_reflection_stdout
+from app.core.task_router import _build_reflection_prompt, _parse_reflection_stdout
 
 
 def _envelope(result, is_error=False, subtype="success"):
@@ -69,6 +69,38 @@ class ParseReflectionStdoutTests(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             _parse_reflection_stdout(out, b"", 0)
         self.assertIn("no JSON object", str(cm.exception))
+
+
+class BuildReflectionPromptTests(unittest.TestCase):
+    def _prompt(self, **kw):
+        base = dict(
+            title="Fix bug", status="completed", duration_s=12.3,
+            num_turns=4, cost_usd=0.02, error="",
+        )
+        base.update(kw)
+        return _build_reflection_prompt(**base)
+
+    def test_forbids_asking_for_context(self):
+        # The 00:20 prod failure: model replied "I don't have enough context..." with no
+        # JSON. The prompt must explicitly forbid that so a rating is always produced.
+        p = self._prompt().lower()
+        self.assertIn("do not ask for more information", p)
+        self.assertIn("only the metrics provided", p)
+
+    def test_demands_bare_json_object(self):
+        p = self._prompt()
+        self.assertIn('{"rating": <1-5>, "reflection": "<one sentence>"}', p)
+        self.assertIn("Output ONLY this JSON object", p)
+
+    def test_includes_metrics_and_rubric(self):
+        p = self._prompt(title="Deploy", status="failed", error="boom")
+        self.assertIn("Deploy", p)
+        self.assertIn("failed", p)
+        self.assertIn("boom", p)
+        self.assertIn("Scoring guide", p)
+
+    def test_empty_title_falls_back_to_untitled(self):
+        self.assertIn("Task: Untitled", self._prompt(title=""))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem
After PR #281 went live, the LLM self-reflection **still** fails — now for a new reason. Observed live in `/shared/platform-errors.log`:

```
2026-07-03 00:20:30 WARNING app.core.task_router: LLM self-reflection failed for task ta9ycsk3f,
falling back to formula: no JSON object in claude reflection result:
I don't have enough context to rate this task fairly. I can see it completed in 258 seconds...
```

The model replies **conversationally asking for context** instead of emitting JSON. `_parse_reflection_stdout` correctly raises `no JSON object...`, but that means **every** reflection silently falls back to the formula rating — the LLM rating never actually runs. #281 fixed the *parser* (surface real cause); this fixes the *prompt* (stop causing prose in the first place).

## Fix
- Extract prompt-building into a pure, import-free `_build_reflection_prompt()` helper (mirrors the testable `_parse_reflection_stdout` pattern).
- Strengthen the prompt: state the metrics are the complete context, **forbid asking for more information / prose outside the JSON**, add an explicit scoring rubric, and demand a bare JSON object.

## Tests
`orchestrator/tests/test_reflection_parse.py` — 4 new cases (13 total, all green):
- forbids asking for context
- demands bare JSON object
- includes metrics + rubric
- empty title → `Untitled`

Run: `cd orchestrator && python -m pytest tests/test_reflection_parse.py -q`

## Risk
Low blast radius — prompt string + pure helper on a graceful-fallback path. No auth/startup/schema changes.