### PR TITLE
fix(task_router): coerce task model to agent harness at dispatch (#282)

### DIFF
--- a/orchestrator/app/core/task_router.py
+++ b/orchestrator/app/core/task_router.py
@@ -297,6 +297,12 @@ class TaskRouter:
         # the agent once its (or its owner's) monthly budget is exhausted.
         model = await self._apply_budget_policy(agent_id, model)
 
+        # Harness compatibility: a delegated/inherited model (e.g. a Claude model
+        # from a claude_code delegator) must be coerced to one the target agent's
+        # harness actually supports, or the task fails at runtime (e.g. a codex_cli
+        # agent rejecting claude-* with "not supported using Codex").
+        model = await self._coerce_task_model_for_agent(agent_id, model)
+
         # Create task in DB
         task_metadata = dict(metadata or {})
         if created_by_agent:
@@ -1001,6 +1007,45 @@ class TaskRouter:
             f"[Budget] {reason} → agent {agent_id} downgraded to {BUDGET_FALLBACK_MODEL}"
         )
         return BUDGET_FALLBACK_MODEL
+
+    async def _coerce_task_model_for_agent(
+        self, agent_id: str, model: str | None
+    ) -> str | None:
+        """Coerce the task model to the target agent's harness mode.
+
+        Mirrors the container-launch coercion (agent_manager) so a model that a
+        delegator inherited/picked is validated against where it will actually run.
+        A claude_code agent whose provider is codex is treated as codex_cli. When
+        no model is requested we leave it None so the agent falls back to its own
+        default. Never raises — on any lookup failure the model passes through.
+        """
+        if not model:
+            return model
+        try:
+            from app.config import settings
+            from app.core.model_catalog import coerce_model_for_mode
+            from app.models.agent import Agent
+
+            result = await self.db.execute(select(Agent).where(Agent.id == agent_id))
+            agent = result.scalar_one_or_none()
+            if not agent:
+                return model
+
+            mode = agent.mode or "claude_code"
+            provider = (agent.config or {}).get("model_provider") or settings.model_provider
+            if mode == "claude_code" and provider == "codex":
+                mode = "codex_cli"
+
+            coerced = coerce_model_for_mode(mode, model)
+            if coerced != model:
+                logger.info(
+                    "[ModelCoerce] task model %s incompatible with agent %s (mode=%s) → %s",
+                    model, agent_id, mode, coerced,
+                )
+            return coerced
+        except Exception as e:
+            logger.warning(f"Model coercion skipped for agent {agent_id}: {e}")
+            return model
 
     async def _check_budget_thresholds(self, agent_id: str) -> None:
         """After task completion, check if monthly budget thresholds are reached."""

--- a/orchestrator/tests/test_task_router_model_coercion.py
+++ b/orchestrator/tests/test_task_router_model_coercion.py
@@ -1,0 +1,63 @@
+"""Tests for task-dispatch model coercion (issue #282 follow-up).
+
+A delegated/inherited model must be coerced to the target agent's harness mode at
+task-dispatch time, or a codex_cli agent handed a claude-* model fails at runtime
+("not supported when using Codex with a ChatGPT account").
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from app.core.model_catalog import default_model_for_mode
+from app.core.task_router import TaskRouter
+
+
+def _router_with_agent(agent):
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = agent
+    db.execute = AsyncMock(return_value=result)
+    return TaskRouter(db=db, redis=MagicMock(), load_balancer=MagicMock(), docker_service=None)
+
+
+def _agent(mode="claude_code", config=None):
+    return SimpleNamespace(mode=mode, config=config or {})
+
+
+class TaskModelCoercionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_claude_model_to_codex_agent_is_coerced(self):
+        router = _router_with_agent(_agent(mode="codex_cli"))
+        out = await router._coerce_task_model_for_agent("a1", "claude-opus-4-8")
+        self.assertEqual(out, default_model_for_mode("codex_cli"))
+
+    async def test_claude_code_agent_with_codex_provider_is_coerced(self):
+        router = _router_with_agent(
+            _agent(mode="claude_code", config={"model_provider": "codex"})
+        )
+        out = await router._coerce_task_model_for_agent("a1", "claude-opus-4-8")
+        self.assertEqual(out, default_model_for_mode("codex_cli"))
+
+    async def test_compatible_model_passes_through(self):
+        router = _router_with_agent(_agent(mode="codex_cli"))
+        out = await router._coerce_task_model_for_agent("a1", "gpt-5-codex")
+        self.assertEqual(out, "gpt-5-codex")
+
+    async def test_claude_model_to_claude_agent_passes_through(self):
+        router = _router_with_agent(_agent(mode="claude_code"))
+        out = await router._coerce_task_model_for_agent("a1", "claude-opus-4-8")
+        self.assertEqual(out, "claude-opus-4-8")
+
+    async def test_none_model_stays_none(self):
+        router = _router_with_agent(_agent(mode="codex_cli"))
+        out = await router._coerce_task_model_for_agent("a1", None)
+        self.assertIsNone(out)
+
+    async def test_missing_agent_passes_model_through(self):
+        router = _router_with_agent(None)
+        out = await router._coerce_task_model_for_agent("ghost", "claude-opus-4-8")
+        self.assertEqual(out, "claude-opus-4-8")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Every DevAgent delegation (proactive + review runs) has been failing at runtime with:

> `claude-opus-4-8` … not supported when using Codex with a ChatGPT account (`400 invalid_request_error`)

Root cause: when a task is routed to an agent, the requested/inherited `model` is written straight onto the `Task` row and the Redis dispatch payload **without checking it against the target agent's harness mode**. A `claude_code` delegator (Opus) hands `claude-opus-4-8` to a `codex_cli` agent, and nothing corrects it before dispatch.

The model catalog already has the guard (`coerce_model_for_mode`) and it *is* applied at **container launch** (`agent_manager.py:1110`) — but **not at task dispatch**, so the incompatible model still lands in the agent's queue and fails.

## Fix

Apply the same coercion in `TaskRouter.create_and_route_task`, right after the budget policy:

- Load the target agent, resolve its effective mode (a `claude_code` agent whose provider is `codex` is treated as `codex_cli`).
- `coerce_model_for_mode(mode, model)` keeps a compatible model, replaces an incompatible one with the harness default (`gpt-5-codex` for codex_cli).
- Never raises: any lookup failure passes the model through. `None` stays `None`.

Both the stored `Task.model` and the dispatched Redis payload now use the coerced model.

## Tests

New `tests/test_task_router_model_coercion.py` (unittest) covers: claude→codex coercion, codex-provider claude_code coercion, compatible pass-through, claude→claude pass-through, `None`, and missing agent.

## Note

Fixes future dispatches. The live DevAgent's stored default `model` may still need updating via the admin path, but the run will no longer break regardless.

Refs #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)