### PR TITLE
fix(voice): stop WARNING-level voice ws chunk log spam

### DIFF
--- a/orchestrator/app/api/ws.py
+++ b/orchestrator/app/api/ws.py
@@ -866,7 +866,7 @@ async def ws_agent_voice(
                     try:
                         chunk = base64.b64decode(b64)
                         session.push_audio_chunk(chunk)
-                        logger.warning(
+                        logger.debug(
                             "voice ws chunk agent=%s session=%s bytes=%d",
                             agent_id,
                             session.session_id,
@@ -877,7 +877,7 @@ async def ws_agent_voice(
             elif mtype == "commit":
                 lang = mdata.get("language")
                 # Process turn in background so we keep accepting interrupts
-                logger.warning(
+                logger.debug(
                     "voice ws commit agent=%s session=%s language=%s",
                     agent_id,
                     session.session_id,


### PR DESCRIPTION
## Problem
The voice websocket handler in \`orchestrator/app/api/ws.py\` logs **every inbound audio chunk** at \`logger.warning\` (line ~869) and every \`commit\` (line ~880). During an active voice session this fires 10+ times per second, flooding \`/shared/platform-errors.log\` with hundreds of \`voice ws chunk agent=... bytes=2730\` lines and burying genuine warnings/errors.

Observed in platform-errors.log 2026-07-03 07:12 — a single voice session produced a continuous wall of WARNING lines.

## Fix
Downgrade the two pure per-event trace logs (\`voice ws chunk\`, \`voice ws commit\`) from \`logger.warning\` → \`logger.debug\`. These are development instrumentation, not operational warnings.

Left untouched (genuine conditions): init-failed exception, invalid audio chunk, turn crashed, outbound pump stopped.

## Verification
- \`python -m py_compile orchestrator/app/api/ws.py\` → OK
- Audited all remaining \`logger.warning\` calls in the handler — all are real error/edge conditions.

Requires \`docker restart ai-employee-orchestrator\` to take effect on the running container.