### PR TITLE
fix(agent): pipe claude CLI prompt via stdin (fixes 'Argument list too long')

### DIFF
--- a/agent/app/agent_runner.py
+++ b/agent/app/agent_runner.py
@@ -10,6 +10,7 @@ from app.log_publisher import LogPublisher
 from app.runner_hooks import (
     SELF_IMPROVEMENT_SUFFIX,
     compose_prompt_bundle,
+    feed_prompt_via_stdin,
 )
 
 logger = logging.getLogger(__name__)
@@ -53,9 +54,12 @@ class AgentRunner:
             + SELF_IMPROVEMENT_SUFFIX
         )
 
+        # Prompt goes via stdin, NOT argv: a large task prompt (e.g. a PR review
+        # with a big diff) overflows the kernel's per-arg limit and exec fails with
+        # "[Errno 7] Argument list too long: 'claude'".
         cmd = [
             "claude",
-            "-p", enhanced_prompt,
+            "-p",
             "--output-format", "stream-json",
             "--verbose",
             "--dangerously-skip-permissions",
@@ -98,13 +102,17 @@ class AgentRunner:
         try:
             self._process = await asyncio.create_subprocess_exec(
                 *cmd,
+                stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=settings.workspace_dir,
                 env=env,
             )
 
-            # Read stderr in background
+            # Feed the prompt via stdin and read stderr, both in the background.
+            stdin_task = asyncio.create_task(
+                feed_prompt_via_stdin(self._process, enhanced_prompt)
+            )
             stderr_task = asyncio.create_task(_collect_stderr(self._process))
 
             async for event in self._stream_output(self._process):
@@ -142,6 +150,7 @@ class AgentRunner:
 
             returncode = await self._process.wait()
             await stderr_task
+            await stdin_task
 
             # A successful run emits a "result" event before exiting. If we already
             # captured that result, a non-zero exit code (CLI cleanup/stdin quirks)

--- a/agent/app/chat_handler.py
+++ b/agent/app/chat_handler.py
@@ -9,6 +9,7 @@ from typing import AsyncIterator
 
 from app.config import get_oauth_token, settings
 from app.log_publisher import LogPublisher
+from app.runner_hooks import feed_prompt_via_stdin
 
 logger = logging.getLogger(__name__)
 
@@ -90,8 +91,9 @@ class ChatHandler:
         if self.session_id:
             cmd.extend(["--resume", self.session_id])
 
+        # Prompt via stdin, not argv — avoids "Argument list too long" on large input.
         cmd.extend([
-            "-p", text,
+            "-p",
             "--output-format", "stream-json",
             "--verbose",
             "--dangerously-skip-permissions",
@@ -157,13 +159,18 @@ class ChatHandler:
         try:
             self._process = await asyncio.create_subprocess_exec(
                 *cmd,
+                stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=settings.workspace_dir,
                 env=env,
             )
 
-            # Read stderr in background so we capture it even if CLI crashes
+            # Feed the prompt via stdin; read stderr in background so we capture it
+            # even if the CLI crashes.
+            stdin_task = asyncio.create_task(
+                feed_prompt_via_stdin(self._process, text)
+            )
             stderr_task = asyncio.create_task(_collect_stderr(self._process))
 
             full_text = ""
@@ -289,8 +296,9 @@ class ChatHandler:
                             )
 
             returncode = await self._process.wait()
-            # Ensure stderr collection is complete
+            # Ensure stderr collection and stdin feed are complete
             await stderr_task
+            await stdin_task
 
             if returncode != 0 and not stream_had_error:
                 # Code -2 (SIGINT) = graceful interrupt for queued messages — not an error

--- a/agent/app/message_consumer.py
+++ b/agent/app/message_consumer.py
@@ -133,6 +133,9 @@ class MessageConsumer:
         if settings.agent_mode == "custom_llm":
             return await self._execute_custom_llm(prompt, model)
 
+        # For the claude CLI the prompt is piped via stdin (not argv) to avoid
+        # "[Errno 7] Argument list too long" on large prompts.
+        stdin_input: bytes | None = None
         if settings.agent_mode == "codex_cli":
             cmd = [
                 "codex", "exec",
@@ -145,9 +148,10 @@ class MessageConsumer:
                 cmd.extend(["-m", model])
             cmd.append(prompt)
         else:
-            cmd = ["claude", "-p", prompt, "--output-format", "json", "--dangerously-skip-permissions"]
+            cmd = ["claude", "-p", "--output-format", "json", "--dangerously-skip-permissions"]
             if model and model != "default":
                 cmd.extend(["--model", model])
+            stdin_input = prompt.encode("utf-8")
 
         env = os.environ.copy()
         if settings.agent_mode == "codex_cli":
@@ -162,14 +166,15 @@ class MessageConsumer:
         try:
             self._process = await asyncio.create_subprocess_exec(
                 *cmd,
-                stdin=asyncio.subprocess.DEVNULL,
+                stdin=(asyncio.subprocess.PIPE if stdin_input is not None
+                       else asyncio.subprocess.DEVNULL),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=settings.workspace_dir,
                 env=env,
             )
             stdout, stderr = await asyncio.wait_for(
-                self._process.communicate(), timeout=300
+                self._process.communicate(input=stdin_input), timeout=300
             )
             self._process = None
 

--- a/agent/app/runner_hooks.py
+++ b/agent/app/runner_hooks.py
@@ -4,6 +4,7 @@ Provides startup context (knowledge/memory/approval rules) and end-of-task
 reflection prompts so both runners behave consistently.
 """
 
+import asyncio
 import json as _json
 import logging
 import os
@@ -12,6 +13,29 @@ import urllib.request
 from app.config import settings
 
 logger = logging.getLogger(__name__)
+
+
+async def feed_prompt_via_stdin(proc: "asyncio.subprocess.Process", prompt: str) -> None:
+    """Write the prompt to the CLI's stdin, then close it.
+
+    The prompt MUST NOT be passed on argv: a large PR diff overflows the kernel's
+    per-argument limit (MAX_ARG_STRLEN, 128 KB) and exec fails with
+    "[Errno 7] Argument list too long: 'claude'". Piping via stdin has no such cap.
+    Runs as a background task so a prompt larger than the pipe buffer can't deadlock
+    against the CLI, which streams stdout while still reading stdin.
+    """
+    if proc.stdin is None:
+        return
+    try:
+        proc.stdin.write(prompt.encode("utf-8"))
+        await proc.stdin.drain()
+    except (BrokenPipeError, ConnectionResetError):
+        pass
+    finally:
+        try:
+            proc.stdin.close()
+        except Exception:
+            pass
 
 
 TASK_STARTUP_PREFIX = """


### PR DESCRIPTION
## Problem

Every PR-review delegation to a `claude_code` agent failed with:

> `[Errno 7] Argument list too long: 'claude'`

This is an OS-level `E2BIG` from `execvp`. The task/chat/message runners passed the prompt as a `-p <prompt>` **argv argument**. A large prompt — a PR review carries the full diff — exceeds the kernel's per-argument limit (`MAX_ARG_STRLEN` = 128 KB / 32 pages), so the process can't even be spawned.

## Fix

Feed the prompt through the CLI's **stdin** instead (no such cap):

- `-p` stays as the print-mode flag with **no** positional prompt.
- stdin is opened as a pipe and the prompt written to it.
- Streaming runners (`agent_runner.py` task path — the failing review path — and `chat_handler.py`) use a shared background writer `feed_prompt_via_stdin` in `runner_hooks.py`, so a prompt larger than the 64 KB pipe buffer can't deadlock against stdout streaming.
- The `communicate()`-based `message_consumer.py` (inter-agent messages) passes it via `communicate(input=...)`.

`--input-format` stays at its `text` default, so piped stdin is treated as a plain-text prompt; `--output-format stream-json/json` is unaffected.

## Scope / follow-up

The Codex paths (`codex_runner.py`, the codex branch of `message_consumer.py`) still pass the prompt positionally — the same latent limit with a different binary and error. Left as a follow-up since the reported failure is specifically the `claude` CLI; `codex exec` stdin semantics should be verified before changing.

## Test plan
- [ ] Delegate a PR review with a large diff to a claude_code agent → task runs instead of failing at spawn.
- [ ] Normal short chat message still returns a response (stdin path works for small prompts too).
- [ ] Inter-agent message via claude CLI still replies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)