### PR TITLE
Security: auth-gate interne Endpunkte (kiosk/memory/telegram) + fail-closed setup + Preload-Caller-Fix

### DIFF
--- a/agent/app/runner_hooks.py
+++ b/agent/app/runner_hooks.py
@@ -327,7 +327,11 @@ def get_memory_preload() -> str:
     """
     try:
         url = f"{settings.orchestrator_url}/api/v1/memory/preload/{settings.agent_id}"
-        with urllib.request.urlopen(url, timeout=5) as response:
+        req = urllib.request.Request(url, headers={
+            "Authorization": f"Bearer {settings.agent_token}",
+            "X-Agent-ID": settings.agent_id,
+        })
+        with urllib.request.urlopen(req, timeout=5) as response:
             data = _json.loads(response.read())
 
         critical = data.get("critical", [])
@@ -663,7 +667,11 @@ def get_user_feedback() -> str:
     """
     try:
         url = f"{settings.orchestrator_url}/api/v1/memory/preload/{settings.agent_id}"
-        with urllib.request.urlopen(url, timeout=5) as response:
+        req = urllib.request.Request(url, headers={
+            "Authorization": f"Bearer {settings.agent_token}",
+            "X-Agent-ID": settings.agent_id,
+        })
+        with urllib.request.urlopen(req, timeout=5) as response:
             data = _json.loads(response.read())
 
         # Extract correction-category memories from the critical bucket
@@ -697,7 +705,11 @@ def get_improvement_context() -> str:
     """
     try:
         url = f"{settings.orchestrator_url}/api/v1/memory/preload/{settings.agent_id}"
-        with urllib.request.urlopen(url, timeout=5) as response:
+        req = urllib.request.Request(url, headers={
+            "Authorization": f"Bearer {settings.agent_token}",
+            "X-Agent-ID": settings.agent_id,
+        })
+        with urllib.request.urlopen(req, timeout=5) as response:
             data = _json.loads(response.read())
         critical = data.get("critical", [])
         suggestions = [m for m in critical if m.get("category") == "improvement"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,6 +135,10 @@ services:
       # kiosk). Empty by default → endpoint 404s. Set to "true" ONLY on the single-
       # user Pi kiosk, NEVER on multi-tenant boxes.
       KIOSK_VOICE_ENABLED: ${KIOSK_VOICE_ENABLED:-}
+      # Kiosk router: mounts the UNAUTHENTICATED /api/v1/kiosk/* endpoints (local Pi
+      # browser). Empty/false by default → router not mounted, endpoints 404. Set to
+      # "true" ONLY on the single-user Pi kiosk, NEVER on multi-tenant/VPS boxes.
+      KIOSK_ENABLED: ${KIOSK_ENABLED:-}
       # How many different chat sessions ONE agent processes concurrently (1 =
       # serial default). >1 → independent sessions/tasks run in parallel in one
       # container. Passed through to each agent container.

--- a/orchestrator/app/api/agents.py
+++ b/orchestrator/app/api/agents.py
@@ -2355,12 +2355,17 @@ async def send_telegram_message(
     agent_id: str,
     body: TelegramSendMessage,
     manager: AgentManager = Depends(_get_agent_manager),
+    agent_auth: dict = Depends(verify_agent_token),
 ):
     """Send a direct Telegram message to all authorized users of this agent.
 
-    Called by the agent's MCP send_telegram tool (no user auth needed,
-    agent authenticates via AGENT_TOKEN header).
+    Called by the agent's MCP send_telegram tool. The caller must present a
+    valid agent token (Authorization: Bearer + X-Agent-ID) whose agent_id
+    matches the path — otherwise any unauthenticated caller could send Telegram
+    messages in an agent's name.
     """
+    if agent_auth["agent_id"] != agent_id:
+        raise HTTPException(status_code=403, detail="Agent token does not match target agent")
     sent_to = 0
     try:
         import app.main as main_mod

--- a/orchestrator/app/api/memory.py
+++ b/orchestrator/app/api/memory.py
@@ -537,6 +537,7 @@ async def search_memories(
 @router.get("/preload/{agent_id}")
 async def preload_critical_memories(
     agent_id: str,
+    user=Depends(require_auth_or_agent),
     db: AsyncSession = Depends(get_db),
 ):
     """Return the agent's most critical memories for prompt injection.
@@ -546,8 +547,20 @@ async def preload_critical_memories(
     - categories: credentials, preference, procedure
     - recent learnings (last 10)
 
-    Open endpoint (no auth) — agents fetch their own preload on every task start.
+    Requires user or agent auth. This response includes credential-category
+    memories in clear text, so it must never be unauthenticated: an agent
+    principal may only preload its own memories; a user must own the agent.
     """
+    if hasattr(user, "role"):
+        from app.models.user import UserRole
+        from app.models.agent import Agent
+        if is_agent_principal(user):
+            if user.id != agent_id:
+                raise HTTPException(status_code=403, detail="Agent can only preload its own memories")
+        elif user.role != UserRole.ADMIN:
+            agent_obj = await db.get(Agent, agent_id)
+            if agent_obj and agent_obj.user_id and agent_obj.user_id != user.id:
+                raise HTTPException(status_code=403, detail="Access denied")
     # Critical memories (importance = 5) — ALWAYS preloaded, no limit compromise
     critical_result = await db.execute(
         select(AgentMemory)

--- a/orchestrator/app/api/router.py
+++ b/orchestrator/app/api/router.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 
+from app.config import settings
 from app.api import admin, agents, ai_accounts, analytics, approval_rules, approvals, audit, auth, brain, brain_mcp, brains, command_policies, computer_use, docker_apps, downloads, event_triggers, features, feedback, health, integrations, kiosk, knowledge, knowledge_feeds, license as license_api, meeting_rooms, memory, mcp_agent, mcp_exchange, mcp_msgraph, mcp_msgraph_external, mcp_servers, notifications, oauth_as, ratings, roles, schedules, secrets, skill_marketplace, skills_catalog, tasks, teams, telegram_actions, templates, todos, url_allowlist, user_profiles, version, vertical_packs, webhooks, ws, settings
 
 api_router = APIRouter()
@@ -20,7 +21,10 @@ api_router.include_router(features.router)
 api_router.include_router(feedback.router)
 api_router.include_router(health.router)
 api_router.include_router(integrations.router)
-api_router.include_router(kiosk.router)
+# Kiosk endpoints are unauthenticated by design (local Pi browser) — only mount
+# them on an actual kiosk device. See config.kiosk_enabled.
+if settings.kiosk_enabled:
+    api_router.include_router(kiosk.router)
 api_router.include_router(brain.router)
 api_router.include_router(knowledge.router)
 api_router.include_router(knowledge_feeds.router)

--- a/orchestrator/app/config.py
+++ b/orchestrator/app/config.py
@@ -74,6 +74,10 @@ class Settings(BaseSettings):
     secondbrain_base: str = "/srv/secondbrain"
 
     # Kiosk (local-only on-device status display on the Raspberry Pi)
+    # The kiosk router is UNAUTHENTICATED by design (local Pi browser). It must
+    # only be mounted on an actual kiosk device. Default off so non-kiosk
+    # deployments (e.g. a shared VPS) never expose the unauthenticated router.
+    kiosk_enabled: bool = False
     # Live electricity price for the power-cost estimate (env: ELECTRICITY_PRICE_EUR_KWH).
     electricity_price_eur_kwh: float = 0.35
     # Host metrics JSON written by the host power collector (bind-mounted read-only).

--- a/orchestrator/app/dependencies.py
+++ b/orchestrator/app/dependencies.py
@@ -43,14 +43,21 @@ def get_docker_service(request: Request) -> DockerService:
 
 
 async def _check_users_exist(db: AsyncSession) -> bool:
-    """Check if any users have been registered yet."""
+    """Check if any users have been registered yet.
+
+    Fail-closed: only a genuinely missing users table (fresh install, no
+    migration yet) counts as "no users -> setup mode". Any other DB error
+    (connection lost, timeout, permission) propagates so the caller denies
+    the request instead of granting an anonymous ADMIN with RLS bypass.
+    """
     from sqlalchemy import func
+    from sqlalchemy.exc import ProgrammingError
+    from app.models.user import User
     try:
-        from app.models.user import User
         count = await db.scalar(select(func.count()).select_from(User))
-        return count > 0
-    except Exception:
-        # Table doesn't exist yet (no migration) - no users
+        return (count or 0) > 0
+    except ProgrammingError:
+        # users table does not exist yet (no migration) - genuine setup mode
         return False
 
 

--- a/orchestrator/tests/test_api/test_security_hardening.py
+++ b/orchestrator/tests/test_api/test_security_hardening.py
@@ -1,0 +1,81 @@
+"""Security-hardening regression tests (Security-Audit 2026-07-01).
+
+Cover the four fixes on branch ``harden/kiosk-memory-auth``:
+  1. ``POST /agents/{id}/telegram/send`` requires an agent token
+  2. ``GET /memory/preload/{id}`` requires user/agent auth
+  3. the kiosk router is only mounted when ``settings.kiosk_enabled``
+  4. setup mode is fail-closed on real DB errors (no anonymous ADMIN)
+
+These import the app package, so they run in the orchestrator container / CI
+(where fastapi + sqlalchemy are installed), not on a bare host. They are
+DB-free by design: they assert the wiring (route dependencies, settings,
+error handling), not full HTTP round-trips.
+"""
+import asyncio
+
+
+def _route_dependency_names(router, path_suffix: str, method: str) -> list[str]:
+    """Names of the callables the matching route depends on (Depends(...))."""
+    names: list[str] = []
+    for route in router.routes:
+        path = getattr(route, "path", "")
+        methods = getattr(route, "methods", set()) or set()
+        if path.endswith(path_suffix) and method in methods:
+            for dep in route.dependant.dependencies:
+                call = getattr(dep, "call", None)
+                if call is not None:
+                    names.append(call.__name__)
+    return names
+
+
+def test_kiosk_enabled_defaults_false():
+    from app.config import settings
+    assert settings.kiosk_enabled is False
+
+
+def test_kiosk_router_not_mounted_when_disabled():
+    import importlib
+    from app.config import settings
+    settings.kiosk_enabled = False
+    from app.api import router as router_mod
+    importlib.reload(router_mod)
+    paths = [getattr(r, "path", "") for r in router_mod.api_router.routes]
+    assert not any("/kiosk" in p for p in paths)
+
+
+def test_telegram_send_requires_agent_token():
+    from app.api import agents
+    names = _route_dependency_names(agents.router, "/telegram/send", "POST")
+    assert "verify_agent_token" in names
+
+
+def test_memory_preload_requires_auth():
+    from app.api import memory
+    names = _route_dependency_names(memory.router, "/preload/{agent_id}", "GET")
+    assert "require_auth_or_agent" in names
+
+
+def test_check_users_exist_is_fail_closed_on_db_error():
+    from sqlalchemy.exc import OperationalError, ProgrammingError
+    from app import dependencies
+
+    class _FakeSession:
+        def __init__(self, exc):
+            self._exc = exc
+
+        async def scalar(self, *args, **kwargs):
+            raise self._exc
+
+    # A genuinely missing users table -> real setup mode -> False.
+    prog = ProgrammingError("SELECT", {}, Exception("relation \"users\" does not exist"))
+    assert asyncio.run(dependencies._check_users_exist(_FakeSession(prog))) is False
+
+    # Any other DB error (connection down/timeout) must PROPAGATE, so the caller
+    # denies the request instead of granting an anonymous ADMIN with RLS bypass.
+    op = OperationalError("SELECT", {}, Exception("connection refused"))
+    raised = False
+    try:
+        asyncio.run(dependencies._check_users_exist(_FakeSession(op)))
+    except OperationalError:
+        raised = True
+    assert raised


### PR DESCRIPTION
## Was & warum

Ein Security-Audit hat gezeigt: mehrere Orchestrator-Endpunkte sind **unauthentifiziert** und aus dem Docker-`ai-employee-network` erreichbar. Live verifiziert — aus einem Nachbar-Container liefert `GET /api/v1/kiosk/overview` HTTP 200 mit Agenten-Daten. Extern deckt Cloudflare Access das ab, **intern** (jeder Agent-Container, MCP-Container) aber nicht. Angriffskette: prompt-injizierter/kompromittierter Agent → `kiosk/overview` (IDs sammeln) → `memory/preload` (Credential-Memories im Klartext) oder `kiosk/chat` (fremden Agenten kapern).

Dieser PR schließt die Lücken **und** zieht die Aufrufer-Seite mit, damit nichts still bricht. Der Branch ist frisch auf `main` (v1.99.43) rebased.

## Änderungen (4 Fixes + 2 Companion-Änderungen)

**1. `POST /agents/{id}/telegram/send` → `verify_agent_token` + agent_id-Match** (`agents.py`)
Der Endpoint war unauth, obwohl der Docstring „agent authenticates via AGENT_TOKEN header" behauptete — es wurde nichts geprüft. Jeder konnte im Namen eines Agenten Telegram-Nachrichten an dessen autorisierte Nutzer senden.
- **Funktionale Auswirkung: keine.** Der einzige HTTP-Aufrufer (`agent/mcp/notification-server.mjs`, `send_telegram`-Tool) schickt über seinen `apiCall`-Wrapper bereits `Authorization: Bearer <AGENT_TOKEN>` + `X-Agent-ID`. Der Redis-basierte `custom_llm`-Pfad ist ohnehin nicht betroffen. Transparent.

**2. `GET /memory/preload/{id}` → `require_auth_or_agent` + Ownership** (`memory.py`)
War „Open endpoint (no auth)" und liefert Memories der Kategorien `credentials/api_key/secret/auth` **im Klartext**. Agent-Prinzipale dürfen jetzt nur ihren eigenen Preload ziehen; User über RLS/Ownership.
- **Funktionale Auswirkung: wäre BREAKING ohne Companion-Fix (5).** Die drei Runner-Hooks `get_memory_preload` / `get_user_feedback` / `get_improvement_context` riefen den Endpoint mit nacktem `urlopen(url)` **ohne** Auth-Header auf. Nach dem Endpoint-Fix hätten sie 401 bekommen — und weil jeder Hook `except Exception: return ''` macht, **still**: Agenten verlieren unbemerkt Memory-Preload (inkl. Credential-Injektion), User-Korrekturen und Performance-Feedback. → Deshalb Fix (5).

**3. Kiosk-Router hinter `settings.kiosk_enabled` (Default false)** (`router.py`, `config.py`)
Der Kiosk-Router ist bewusst unauth (lokaler Pi-Browser), bisher aber **immer** gemountet — auf jedem VPS/Multi-Tenant-Deployment eine offene, unauth Angriffsfläche. Jetzt nur bei `KIOSK_ENABLED=true`.
- **Funktionale Auswirkung: auf VPS/Server keine** (genau gewollt — die unauth Endpunkte sind zu). Aufrufer ist ausschließlich `frontend/src/app/kiosk/page.tsx`; kein Nav-Link/Redirect aus der normalen Web-App. **Bruch nur auf einem echten Pi-Kiosk**, wenn `KIOSK_ENABLED` nicht gesetzt ist → siehe Deployment-Hinweis.

**4. `_check_users_exist` fail-closed** (`dependencies.py`)
Vorher `except Exception: return False` → bei **jedem** DB-Fehler wurde „keine User → Setup-Mode" angenommen und ein `_AnonymousUser` mit **ADMIN + RLS-Bypass** zurückgegeben (Fail-open während DB-Hickup). Jetzt fängt nur `ProgrammingError` (fehlende `users`-Tabelle = echtes Setup); andere DB-Fehler propagieren.
- **Funktionale Auswirkung: niedrig, verifiziert korrekt.** Der Erstinstallations-Fall ist abgedeckt: fehlende Tabelle → asyncpg `UndefinedTableError` → SQLAlchemy `ProgrammingError` → `return False` → Setup-Mode funktioniert. Verhaltensänderung nur bei **echtem** DB-Ausfall (OperationalError): unauth Requests sehen jetzt 500 statt fälschlich Admin-Zugang. Kein legitimer Flow beruht auf dem alten Verhalten; Agent-Auth (HMAC, ohne DB) ist unberührt.

**5. Companion: Agent-Runtime authentifiziert die Preload-Hooks** (`agent/app/runner_hooks.py`)
Die drei `preload`-Aufrufe senden jetzt `Authorization: Bearer <agent_token>` + `X-Agent-ID` — exakt wie die bereits authentifizierten Hooks `get_skill_preload` / `get_approval_rules_prefix`. **Muss zwingend zusammen mit Fix (2) deployt werden** (siehe unten).

**6. Companion: `KIOSK_ENABLED` durch Compose durchreichen** (`docker-compose.yml`)
Der Orchestrator nutzt einen expliziten `environment:`-Block ohne `env_file` — ein reines `.env` erreicht den Container nicht. Neue Zeile `KIOSK_ENABLED: ${KIOSK_ENABLED:-}` neben `KIOSK_VOICE_ENABLED`, damit ein Pi-Operator den Kiosk per Env aktivieren kann. Default leer = false = sicher auf VPS.

## Deployment-Hinweise (wichtig)

- **Agent-Image neu bauen.** Fix (5) liegt in `agent/` — `docker compose up --build` baut das Agent-Image nicht mit. Nach dem Merge zusätzlich `docker build -t ai-employee-agent:latest ./agent`. **Orchestrator und Agent-Image müssen zusammen deployt werden**, sonst trifft man das stille Preload-401-Fenster.
- **Pi-Kiosk:** `KIOSK_ENABLED=true` in die `.env` des Pi (die Compose-Zeile reicht den Wert jetzt durch). Auf VPS/Multi-Tenant nichts tun.
- **Kein Env-Zwang sonst:** Alle Änderungen sind rückwärtskompatibel bei Standard-Agent-Start (Container bekommt `AGENT_TOKEN=make_agent_token(agent_id)` + `AGENT_ID` wie gehabt).

## Tests

- Neue DB-freie Wiring-/Regression-Tests: `orchestrator/tests/test_api/test_security_hardening.py` (Kiosk-Gating default-off, `verify_agent_token` an telegram/send, `require_auth_or_agent` an preload, `_check_users_exist` fail-closed via ProgrammingError vs. propagierendem OperationalError).
- Lokal nur `py_compile` gelaufen (kein Orchestrator-Env/DB auf der Dev-Maschine) — die Tests sind für CI/Container gedacht.

## Kontext

- **PR #247 (`harden/telegram-loopback-auth`) ist CLOSED, nicht gemergt.** Die dortige Telegram-Loopback-Härtung + `127.0.0.1`-Bindings sind also nicht über #247 in `main` gelandet — bitte klären, ob anderweitig eingeflossen oder offen.
- **Bewusst NICHT in diesem PR:** RLS „bypass by default" in `get_db` invertieren (betrifft alle Hintergrund-Jobs, braucht eigene Testabdeckung); `docker-socket-proxy` `EXEC:0`; `:latest`-Pinning. Als Folge-Tickets.

## Verifikation nach Deploy (aus dem agent-network)

```bash
# jetzt 404 statt 200:
docker exec yannik-mcp python -c "import urllib.request as u;print(u.urlopen('http://ai-employee-orchestrator:8000/api/v1/kiosk/overview').status)"
# jetzt 401 statt 200:
docker exec yannik-mcp python -c "import urllib.request as u;print(u.urlopen('http://ai-employee-orchestrator:8000/api/v1/memory/preload/x').status)"
# Agent-Preload muss weiter funktionieren (Weikert-Task starten, Memory-Preload im Prompt prüfen)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
