### PR TITLE
Fix #285: preserve Responses API tool arguments

### DIFF
--- a/agent/app/providers/openai_provider.py
+++ b/agent/app/providers/openai_provider.py
@@ -83,6 +83,20 @@ class OpenAIProvider(BaseLLMProvider):
             return False
         return True
 
+    @staticmethod
+    def _parse_function_arguments(arguments_json: str, final_arguments: str | None = None) -> dict:
+        """Parse streamed function-call arguments.
+
+        Some Responses-compatible providers emit no argument deltas and only
+        include the complete JSON string on the final `.done` event. Prefer the
+        accumulated stream, but fall back to that final payload when needed.
+        """
+        raw = arguments_json or final_arguments or ""
+        try:
+            return json.loads(raw) if raw else {}
+        except json.JSONDecodeError:
+            return {"raw": raw}
+
     def _azure_version(self, fmt: str = "chat") -> str:
         """api-version for Azure requests (account value, else a sane default).
 
@@ -216,7 +230,7 @@ class OpenAIProvider(BaseLLMProvider):
                             pending_calls[item_id] = {
                                 "name": item.get("name", ""),
                                 "call_id": item.get("call_id", item_id),
-                                "arguments_json": "",
+                                "arguments_json": item.get("arguments") or "",
                             }
 
                     # Function call: arguments streaming
@@ -231,10 +245,10 @@ class OpenAIProvider(BaseLLMProvider):
                         item_id = data.get("item_id", "")
                         if item_id in pending_calls:
                             tc = pending_calls.pop(item_id)
-                            try:
-                                tool_input = json.loads(tc["arguments_json"])
-                            except json.JSONDecodeError:
-                                tool_input = {"raw": tc["arguments_json"]}
+                            tool_input = self._parse_function_arguments(
+                                tc["arguments_json"],
+                                data.get("arguments"),
+                            )
                             yield LLMEvent(
                                 type="tool_call",
                                 tool_id=tc["call_id"],
@@ -251,10 +265,7 @@ class OpenAIProvider(BaseLLMProvider):
 
                         # Emit any remaining pending calls
                         for item_id, tc in pending_calls.items():
-                            try:
-                                tool_input = json.loads(tc["arguments_json"])
-                            except json.JSONDecodeError:
-                                tool_input = {"raw": tc["arguments_json"]}
+                            tool_input = self._parse_function_arguments(tc["arguments_json"])
                             yield LLMEvent(
                                 type="tool_call",
                                 tool_id=tc["call_id"],

--- a/agent/tests/test_openai_responses_tool_args.py
+++ b/agent/tests/test_openai_responses_tool_args.py
@@ -1,0 +1,31 @@
+"""Regression tests for Responses API function-call argument parsing."""
+
+from app.providers.openai_provider import OpenAIProvider
+
+
+def test_function_arguments_fall_back_to_done_payload():
+    parsed = OpenAIProvider._parse_function_arguments(
+        "",
+        '{"category":"learning","key":"lesson_learned","content":"kept"}',
+    )
+
+    assert parsed == {
+        "category": "learning",
+        "key": "lesson_learned",
+        "content": "kept",
+    }
+
+
+def test_streamed_function_arguments_win_over_done_payload():
+    parsed = OpenAIProvider._parse_function_arguments(
+        '{"rating":5,"reflection":"streamed"}',
+        '{"rating":3,"reflection":"final"}',
+    )
+
+    assert parsed == {"rating": 5, "reflection": "streamed"}
+
+
+def test_invalid_function_arguments_are_preserved_as_raw():
+    parsed = OpenAIProvider._parse_function_arguments("", '{"category":')
+
+    assert parsed == {"raw": '{"category":'}


### PR DESCRIPTION
Fixes #285\n\n## Summary\n- parse final Responses API function-call arguments when no delta chunks were emitted\n- seed pending function calls with arguments from the added item when present\n- add regression tests for final-only, streamed, and invalid argument payloads\n\n## Verification\n- python -m py_compile agent/app/providers/openai_provider.py\n- PYTHONPATH=agent python direct parser regression assertions\n- git diff --check -- agent/app/providers/openai_provider.py agent/tests/test_openai_responses_tool_args.py\n\nNote: full pytest target could not run in this container because pytest is not installed.