### PR TITLE
fix(models): codex_cli can't use gpt-5-codex on ChatGPT-account auth

### DIFF
--- a/frontend/src/app/settings/view.tsx
+++ b/frontend/src/app/settings/view.tsx
@@ -55,7 +55,6 @@ const MODEL_OPTIONS: Record<ModelProvider, { value: string; label: string; tier:
   codex: [
     { value: "gpt-5.5", label: "GPT-5.5", tier: "Codex" },
     { value: "gpt-5.4", label: "GPT-5.4", tier: "Codex" },
-    { value: "gpt-5-codex", label: "GPT-5 Codex", tier: "Codex" },
   ],
 };
 

--- a/orchestrator/app/core/model_catalog.py
+++ b/orchestrator/app/core/model_catalog.py
@@ -65,7 +65,6 @@ _CODEX_MODELS: dict[str, list[dict]] = {
     "codex": [
         {"value": "gpt-5.5", "label": "GPT-5.5 (Latest)", "tier": "Most Powerful"},
         {"value": "gpt-5.4", "label": "GPT-5.4", "tier": "Balanced"},
-        {"value": "gpt-5-codex", "label": "GPT-5 Codex", "tier": "Code-optimised"},
     ],
 }
 
@@ -82,13 +81,23 @@ MODEL_CATALOG: dict[str, dict] = {
         "label": "Codex CLI",
         "providers": _CODEX_MODELS,
         "default_provider": "codex",
-        "default_model": "gpt-5-codex",
+        "default_model": "gpt-5.5",
     },
 }
 
 # Modes whose model is validated here. custom_llm is intentionally excluded —
 # its model is whatever the linked AI account / inline llm_config provides.
 _GUARDED_MODES = frozenset(MODEL_CATALOG.keys())
+
+# Models that classify into a guarded harness by family but cannot actually run
+# there. ``gpt-5-codex`` is an API-key-only model; our codex_cli harness always
+# authenticates via a ChatGPT/Codex account (see agent/app/codex_runner.py),
+# which rejects it at runtime ("The 'gpt-5-codex' model is not supported when
+# using Codex with a ChatGPT account"). Treating it as not-allowed makes the
+# guard reject it and coercion route it to the harness default instead.
+_UNSUPPORTED_FOR_MODE: dict[str, frozenset[str]] = {
+    "codex_cli": frozenset({"gpt-5-codex"}),
+}
 
 
 def model_family(model: str | None) -> str | None:
@@ -119,6 +128,8 @@ def is_model_allowed_for_mode(mode: str, model: str | None) -> bool:
         return True
     fam = model_family(model)
     if fam is None:
+        return False
+    if (model or "").strip().lower() in _UNSUPPORTED_FOR_MODE.get(mode, frozenset()):
         return False
     return fam == mode
 

--- a/orchestrator/tests/test_agent_harness_mapping.py
+++ b/orchestrator/tests/test_agent_harness_mapping.py
@@ -93,9 +93,12 @@ class ModelCatalogGuardTests(unittest.TestCase):
         self.assertFalse(is_model_allowed_for_mode("claude_code", "gemini-2.5-pro"))
 
     def test_codex_cli_accepts_only_gpt(self):
-        self.assertTrue(is_model_allowed_for_mode("codex_cli", "gpt-5-codex"))
+        self.assertTrue(is_model_allowed_for_mode("codex_cli", "gpt-5.5"))
         self.assertTrue(is_model_allowed_for_mode("codex_cli", "o3-mini"))
         self.assertFalse(is_model_allowed_for_mode("codex_cli", "claude-sonnet-4-6"))
+        # gpt-5-codex classifies as codex family but is API-key-only; the codex
+        # harness authenticates via a ChatGPT account and rejects it at runtime.
+        self.assertFalse(is_model_allowed_for_mode("codex_cli", "gpt-5-codex"))
 
     def test_custom_llm_accepts_anything(self):
         for model in ["gpt-5.5", "claude-opus-4-8", "gemini-2.5-pro", "llama3.2", ""]:
@@ -104,7 +107,10 @@ class ModelCatalogGuardTests(unittest.TestCase):
     def test_coerce_keeps_valid_and_replaces_invalid(self):
         # Valid stays untouched.
         self.assertEqual(coerce_model_for_mode("claude_code", "claude-opus-4-8"), "claude-opus-4-8")
-        self.assertEqual(coerce_model_for_mode("codex_cli", "gpt-5-codex"), "gpt-5-codex")
+        self.assertEqual(coerce_model_for_mode("codex_cli", "gpt-5.5"), "gpt-5.5")
+        # gpt-5-codex is unsupported on a ChatGPT-account codex harness -> default.
+        self.assertEqual(coerce_model_for_mode("codex_cli", "gpt-5-codex"),
+                         default_model_for_mode("codex_cli"))
         # Invalid / missing -> harness default (this is the "codex agent handed
         # the platform default claude-sonnet-4-6" regression that broke runs).
         self.assertEqual(coerce_model_for_mode("codex_cli", "claude-sonnet-4-6"),

--- a/orchestrator/tests/test_task_router_model_coercion.py
+++ b/orchestrator/tests/test_task_router_model_coercion.py
@@ -40,8 +40,8 @@ class TaskModelCoercionTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_compatible_model_passes_through(self):
         router = _router_with_agent(_agent(mode="codex_cli"))
-        out = await router._coerce_task_model_for_agent("a1", "gpt-5-codex")
-        self.assertEqual(out, "gpt-5-codex")
+        out = await router._coerce_task_model_for_agent("a1", "gpt-5.5")
+        self.assertEqual(out, "gpt-5.5")
 
     async def test_claude_model_to_claude_agent_passes_through(self):
         router = _router_with_agent(_agent(mode="claude_code"))


### PR DESCRIPTION
## Problem
A delegated codex task failed at runtime:

```
The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.
```

**Root cause:** the `codex_cli` harness always authenticates via a ChatGPT/Codex `auth.json` (`agent/app/codex_runner.py`), so it can only run models that account exposes (gpt-5.5 / gpt-5.4). `gpt-5-codex` is API-key-only. But `gpt-5-codex` was the `codex_cli` **default_model**, so the task-dispatch coercion (PR #286 — rewrites an inherited/incompatible model to the harness default) emitted `gpt-5-codex` for delegated codex tasks → HTTP 400.

## Fix
- `codex_cli` `default_model`: `gpt-5-codex` → **`gpt-5.5`** (account-supported latest)
- Mark `gpt-5-codex` as **unsupported for `codex_cli`** (`_UNSUPPORTED_FOR_MODE`) so `is_model_allowed_for_mode` rejects it and `coerce_model_for_mode` routes any lingering value to the harness default
- Remove `gpt-5-codex` from the selectable model lists (backend catalog + settings UI) — it can't run on this harness
- Update harness/coercion tests to the corrected behaviour

`model_family("gpt-5-codex")` still classifies as `codex_cli` (unchanged) — this only changes runnability, not classification.

## Verification
- `py_compile` on all changed Python files ✅
- Standalone `model_catalog` logic checks (default, guard, coercion, catalog list) ✅
- Full pytest runs in CI (import-smoke/pytest gate); local env lacks fastapi/sqlalchemy

## Test plan
- [ ] CI: `test_agent_harness_mapping` + `test_task_router_model_coercion` green
- [ ] After deploy: delegate a codex task → no "not supported ... ChatGPT account" 400; model resolves to gpt-5.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)