### PR TITLE
fix(ci): repair orchestrator pytest gate (sqlalchemy stub leak)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         working-directory: orchestrator
         run: |
           pip install --no-cache-dir -e .
-          pip install --no-cache-dir pytest pytest-asyncio
+          pip install --no-cache-dir pytest pytest-asyncio aiosqlite
       - name: Run tests
         working-directory: orchestrator
         env:

--- a/orchestrator/pyproject.toml
+++ b/orchestrator/pyproject.toml
@@ -39,3 +39,9 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 include = ["app*"]
+
+[tool.pytest.ini_options]
+# Only collect the real test suite. app/ contains modules whose names match
+# test_*.py (e.g. app/models/test_run.py — a "TestRun" DB model) that are NOT
+# tests; scanning them just emits collection warnings.
+testpaths = ["tests"]

--- a/orchestrator/tests/test_api/test_telegram_actions.py
+++ b/orchestrator/tests/test_api/test_telegram_actions.py
@@ -16,6 +16,20 @@ def _make_stub(name: str, **attrs):
     sys.modules[name] = m
     return m
 
+
+# Snapshot originals so the stubs can be rolled back after import. pytest runs
+# every test module in ONE interpreter; a stubbed ``sqlalchemy`` left in
+# sys.modules poisons every later ``from sqlalchemy import ...`` (they'd raise
+# "cannot import name X from 'sqlalchemy' (unknown location)").
+_ORIGINAL_MODULES = {
+    name: sys.modules.get(name)
+    for name in (
+        "sqlalchemy", "sqlalchemy.ext", "sqlalchemy.ext.asyncio", "sqlalchemy.orm",
+        "redis", "redis.asyncio", "app.config", "app.db.session",
+        "app.dependencies", "app.models", "app.models.agent",
+    )
+}
+
 _sqlalchemy = _make_stub("sqlalchemy", select=MagicMock(), text=MagicMock())
 _make_stub("sqlalchemy.ext", asyncio=MagicMock())
 _make_stub("sqlalchemy.ext.asyncio", AsyncSession=MagicMock())
@@ -29,6 +43,14 @@ _make_stub("app.models")
 _make_stub("app.models.agent", Agent=MagicMock())
 
 from app.api.telegram_actions import _tg_request  # noqa: E402
+
+# telegram_actions has captured what it needs; put the real modules back so the
+# stubs don't leak into sibling test modules sharing this interpreter.
+for _name, _orig in _ORIGINAL_MODULES.items():
+    if _orig is None:
+        sys.modules.pop(_name, None)
+    else:
+        sys.modules[_name] = _orig
 
 
 # --- Helpers ---

--- a/orchestrator/tests/test_skill_improvement_review.py
+++ b/orchestrator/tests/test_skill_improvement_review.py
@@ -65,6 +65,7 @@ class TestImprovementEngineProposes:
             "min_skill_usages": 5, "skill_threshold": 3.0,
         })), patch.object(eng, "_generate_skill_improvement",
                            AsyncMock(return_value="much better rewritten content")), \
+             patch.object(eng, "_skill_helpfulness_history", AsyncMock(return_value=[])), \
              patch.object(eng, "_notify_feedback_contributors", AsyncMock()):
             await eng._improve_poorly_rated_skills(db)
 

--- a/orchestrator/tests/test_telegram_rich_message_json.py
+++ b/orchestrator/tests/test_telegram_rich_message_json.py
@@ -19,11 +19,14 @@ from app.api.telegram_actions import (
 )
 
 
+_BLOCKS = [{"type": "paragraph", "text": "Body paragraph"}]
+
+
 @pytest.mark.asyncio
 async def test_rich_message_is_forwarded_as_dict_not_string():
     body = SendRichMessageRequest(
         chat_id=480455764,
-        markdown="## Title\n\nBody paragraph",
+        blocks=_BLOCKS,
         reply_markup={"inline_keyboard": [[{"text": "ok", "callback_data": "ok"}]]},
     )
 
@@ -50,17 +53,17 @@ async def test_rich_message_is_forwarded_as_dict_not_string():
     assert captured["method"] == "sendRichMessage"
     rm = captured["data"]["rich_message"]
     assert isinstance(rm, dict), f"rich_message must be a dict, got {type(rm).__name__}"
-    assert "markdown" in rm
+    assert rm["blocks"] == _BLOCKS
     rk = captured["data"]["reply_markup"]
     assert isinstance(rk, dict), f"reply_markup must be a dict, got {type(rk).__name__}"
-    assert captured["data"]["chat_id"] == str(480455764)
+    assert captured["data"]["chat_id"] == 480455764
 
 
 @pytest.mark.asyncio
 async def test_draft_endpoint_also_forwards_as_dict():
     body = SendRichMessageRequest(
         chat_id=480455764,
-        html="<b>draft chunk</b>",
+        blocks=_BLOCKS,
     )
 
     captured: dict = {}
@@ -86,4 +89,4 @@ async def test_draft_endpoint_also_forwards_as_dict():
     assert captured["method"] == "sendRichMessageDraft"
     rm = captured["data"]["rich_message"]
     assert isinstance(rm, dict), f"rich_message must be a dict, got {type(rm).__name__}"
-    assert "html" in rm
+    assert rm["blocks"] == _BLOCKS


### PR DESCRIPTION
## Summary
The new **Orchestrator pytest** CI gate (added in v1.99.62) has failed on **every** PR since it landed — it has never passed. All 7 sqlalchemy-importing test modules died during collection with:

```
ImportError: cannot import name 'func' from 'sqlalchemy' (unknown location)
```

**Root cause:** `tests/test_api/test_telegram_actions.py` overwrites `sys.modules["sqlalchemy"]` with a bare stub (only `select`/`text`, no `__file__` → "unknown location") so it can import `telegram_actions` without heavy deps — but it never restores the real module. pytest runs the whole suite in **one interpreter**, and `test_api` sorts first, so the stub poisoned every later `from sqlalchemy import ...`. Each module passed alone but the suite always failed.

**Fix:** snapshot the original `sys.modules` entries and roll them back immediately after the import completes. `telegram_actions` has already bound what it needs, so restoring is safe and the stubs no longer leak.

Unblocking collection surfaced pre-existing failures the gate had never been able to report; fixed alongside:
- **`test_telegram_rich_message_json`** — updated to the block-based Bot API 10.1 `SendRichMessageRequest` (`markdown`/`html` → `blocks: list[dict]`) the endpoint now uses; intent (nested dict, not a json.dumps string) preserved.
- **`test_skill_improvement_review`** — patch `_skill_helpfulness_history` (added by the plateau-aware path) so the mocked DB isn't asked to `float()` a `Skill`.
- **`test_autonomy_enforcement`** — uses the async `sqlite+aiosqlite` driver; added `aiosqlite` to the CI test install.
- **`pyproject.toml`** — `testpaths = ["tests"]` so pytest stops scanning `app/` modules whose names match `test_*.py` (e.g. `app/models/test_run.py`, a DB model) but aren't tests.

Result: **285 passed, 0 errors** (was: 7 collection errors interrupting the run).

## Test plan
- [x] `pytest -q` in `orchestrator/` in a fresh venv reproducing CI (`pip install -e . && pip install pytest pytest-asyncio aiosqlite`) → 285 passed, 0 errors
- [x] `test_api/test_telegram_actions.py` still passes standalone (stub restore doesn't break its own import)
- [x] Import-smoke unaffected (no `app/` source changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)