### PR TITLE
chore(models): backfill agents.model gpt-5-codex → gpt-5.5 (#293)

### DIFF
--- a/orchestrator/alembic/versions/515d03f814a0_backfill_codex_model_gpt5codex_to_gpt55.py
+++ b/orchestrator/alembic/versions/515d03f814a0_backfill_codex_model_gpt5codex_to_gpt55.py
@@ -1,0 +1,33 @@
+"""Backfill agents.model 'gpt-5-codex' -> 'gpt-5.5' (issue #293)
+
+Revision ID: 515d03f814a0
+Revises: c3d4e5f6a7b8
+Create Date: 2026-07-06
+
+PR #292 removed gpt-5-codex from the codex_cli catalog and made the runtime
+coerce guard route it to gpt-5.5 (the ChatGPT-account codex harness rejects
+gpt-5-codex at runtime: "not supported when using Codex with a ChatGPT
+account"). The dispatch-time guard already handles existing agents, but the
+stored agents.model values stay stale. This one-off data migration rewrites
+them so the DB matches the catalog. It is a no-op on deployments that never
+stored gpt-5-codex.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "515d03f814a0"
+down_revision = "c3d4e5f6a7b8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text("UPDATE agents SET model = 'gpt-5.5' WHERE model = 'gpt-5-codex'")
+    )
+
+
+def downgrade() -> None:
+    # Intentionally irreversible: gpt-5-codex is unsupported on the codex
+    # harness, so restoring it would only re-introduce the broken state.
+    pass


### PR DESCRIPTION
## Summary
One-off Alembic **data migration** that backfills stale stored model names:

```sql
UPDATE agents SET model='gpt-5.5' WHERE model='gpt-5-codex';
```

Follow-up to #292. That PR removed `gpt-5-codex` from the `codex_cli` catalog and added the runtime coerce guard (`is_model_allowed_for_mode` → `False`, `coerce_model_for_mode` → `gpt-5.5`), which fixes agents **at dispatch time**. But the `agents.model` values persisted in the DB stay stale until rewritten — this migration does that so the DB matches the catalog.

- Revision `515d03f814a0`, down_revision `c3d4e5f6a7b8` (current sole head).
- No-op on deployments that never stored `gpt-5-codex`.
- Applies on the next `alembic upgrade` — **no restart required** (runtime guard already live via #292).
- `downgrade()` is intentionally a no-op (restoring `gpt-5-codex` would only re-introduce the broken state).

Fixes #293.

## Test plan
- [x] Migration compiles (`py_compile`) and is the single alembic head (verified locally).
- [ ] On deploy: `alembic upgrade head` runs the UPDATE; confirm `SELECT count(*) FROM agents WHERE model='gpt-5-codex'` returns 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)