### PR TITLE
fix(ws): rate-limit legacy token= WARNING to 1×/token/600s

### DIFF
--- a/orchestrator/app/api/ws.py
+++ b/orchestrator/app/api/ws.py
@@ -4,6 +4,7 @@ import logging
 import mimetypes
 import os
 import re
+import time
 import uuid
 from datetime import datetime, timezone
 
@@ -33,6 +34,10 @@ _CHAT_ATTACHMENT_EXTENSIONS = {
     ".mp3", ".m4a", ".wav", ".ogg", ".opus", ".aac", ".flac",
 }
 _active_chat_websockets: dict[str, WebSocket] = {}
+
+# Rate-limit the legacy token= warning: at most once per token prefix per 600s
+_legacy_token_warned: dict[str, float] = {}
+_LEGACY_WARN_COOLDOWN = 600
 
 
 def init_stream_manager(redis: RedisService, docker: DockerService | None = None) -> StreamManager:
@@ -79,7 +84,11 @@ async def _authenticate_ws(websocket: WebSocket, token: str | None = None, ticke
 
     # Legacy: JWT token in URL (deprecated)
     if token:
-        logger.warning("WebSocket using legacy token= param — migrate to ticket-based auth")
+        key = token[:16]
+        now = time.monotonic()
+        if now - _legacy_token_warned.get(key, 0) >= _LEGACY_WARN_COOLDOWN:
+            _legacy_token_warned[key] = now
+            logger.warning("WebSocket using legacy token= param — migrate to ticket-based auth")
 
     try:
         async with async_session_factory() as db:


### PR DESCRIPTION
## Summary

- Adds a module-level TTL dict `_legacy_token_warned` in `ws.py`
- The `WARNING "WebSocket using legacy token= param"` now fires at most **once per token prefix per 600 seconds**
- Stops hundreds of identical WARNING lines per minute from auto-reconnecting legacy clients masking real errors in `platform-errors.log`

## Root cause

`_authenticate_ws()` logged `logger.warning(...)` unconditionally on every connection attempt with `token=`. Legacy clients that auto-reconnect triggered this loop continuously.

## Test plan

- [ ] Connect a legacy-token WS client multiple times rapidly — only 1 WARNING per 600s per token prefix
- [ ] Ticket-based auth clients: no change in behaviour
- [ ] platform-errors.log no longer flooded after deploy + container restart

Fixes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)