### PR TITLE
fix(self_test): GITHUB_PAT fallback for issue creation (Fixes #316)

### DIFF
--- a/orchestrator/app/services/self_test_service.py
+++ b/orchestrator/app/services/self_test_service.py
@@ -7,6 +7,7 @@ creates GitHub issues for failures, and sends a Telegram digest.
 import asyncio
 import json
 import logging
+import os
 import time
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -574,11 +575,18 @@ class SelfTestService:
             )
             oauth = result.scalar_one_or_none()
             if not oauth or not oauth.access_token:
-                logger.warning("[SelfTest] No GitHub OAuth token — skipping issue creation")
-                return 0
-
-            from app.security.encryption import decrypt_value
-            token = decrypt_value(oauth.access_token)
+                # Fallback for agent-only environments without a user OAuth
+                # connection: the orchestrator may carry a GITHUB_PAT env var.
+                env_token = os.environ.get("GITHUB_PAT")
+                if not env_token:
+                    logger.warning(
+                        "[SelfTest] No GitHub OAuth token or GITHUB_PAT — skipping issue creation"
+                    )
+                    return 0
+                token = env_token
+            else:
+                from app.security.encryption import decrypt_value
+                token = decrypt_value(oauth.access_token)
         except Exception as e:
             logger.warning(f"[SelfTest] Could not get GitHub token: {e}")
             return 0

--- a/orchestrator/tests/test_self_test_github_pat_fallback.py
+++ b/orchestrator/tests/test_self_test_github_pat_fallback.py
@@ -1,0 +1,82 @@
+"""Tests for the GITHUB_PAT fallback in SelfTestService._create_github_issues (issue #316).
+
+When no user has connected a GitHub OAuth account, the service must fall back to
+the GITHUB_PAT environment variable instead of silently skipping issue creation.
+The warning is only logged when BOTH the OAuth integration and GITHUB_PAT are absent.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.self_test_service import SelfTestService, TestResult
+
+
+def _failed_result() -> TestResult:
+    r = TestResult(name="db_connectivity", category="integration")
+    r.status = "failed"
+    r.error = "connection refused"
+    return r
+
+
+def _db_with_oauth(oauth):
+    """AsyncSession stub whose execute(...).scalar_one_or_none() returns *oauth*."""
+    db = AsyncMock()
+    exec_result = MagicMock()
+    exec_result.scalar_one_or_none.return_value = oauth
+    db.execute = AsyncMock(return_value=exec_result)
+    return db
+
+
+def _http_client_ctx(search_status=200, search_total=0, create_status=201):
+    """Mock httpx.AsyncClient context manager for the happy path (no existing issue)."""
+    client = AsyncMock()
+
+    search_resp = MagicMock()
+    search_resp.status_code = search_status
+    search_resp.json.return_value = {"total_count": search_total, "items": []}
+    client.get = AsyncMock(return_value=search_resp)
+
+    create_resp = MagicMock()
+    create_resp.status_code = create_status
+    create_resp.json.return_value = {"html_url": "https://github.com/greeves89/AI-Employee/issues/999"}
+    client.post = AsyncMock(return_value=create_resp)
+
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=client)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx, client
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_github_pat_when_no_oauth(monkeypatch):
+    """OAuth integration absent + GITHUB_PAT set → issue creation proceeds with the env token."""
+    monkeypatch.setenv("GITHUB_PAT", "ghp_envtoken123")
+    db = _db_with_oauth(None)
+    ctx, client = _http_client_ctx()
+
+    with patch("app.services.self_test_service.httpx.AsyncClient", return_value=ctx):
+        created = await SelfTestService()._create_github_issues(
+            db, [_failed_result()], test_run_id=42
+        )
+
+    assert created == 1
+    # The env PAT must be the bearer token on the create call.
+    _, kwargs = client.post.call_args
+    assert kwargs["headers"]["Authorization"] == "Bearer ghp_envtoken123"
+
+
+@pytest.mark.asyncio
+async def test_warns_and_returns_zero_when_both_absent(monkeypatch, caplog):
+    """No OAuth integration AND no GITHUB_PAT → warning logged, nothing created."""
+    monkeypatch.delenv("GITHUB_PAT", raising=False)
+    db = _db_with_oauth(None)
+
+    with patch("app.services.self_test_service.httpx.AsyncClient") as client_cls:
+        with caplog.at_level("WARNING"):
+            created = await SelfTestService()._create_github_issues(
+                db, [_failed_result()], test_run_id=42
+            )
+
+    assert created == 0
+    client_cls.assert_not_called()  # never reached the HTTP client
+    assert any("GITHUB_PAT" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Problem

`self_test_service.py:_create_github_issues()` fetched the GitHub token **only** from the `OAuthIntegration` table. In agent-only environments with no user-connected GitHub OAuth account, it logged `[SelfTest] No GitHub OAuth token — skipping issue creation` and silently dropped all auto-issue creation — the core purpose of the service. A `GITHUB_PAT` env var was available but never used as a fallback.

## Fix

Add an `os.environ.get("GITHUB_PAT")` fallback after the OAuth fetch. The warning now only fires when **both** the OAuth integration and `GITHUB_PAT` are absent. Added `import os`.

## Tests

`tests/test_self_test_github_pat_fallback.py`:
- OAuth absent + `GITHUB_PAT` set → issue creation proceeds, env PAT used as bearer token
- both absent → warning logged, returns 0, HTTP client never constructed

## Acceptance criteria

- [x] Falls back to `GITHUB_PAT` when no `github` OAuthIntegration row exists
- [x] Warning only logged when both OAuth AND `GITHUB_PAT` absent
- [x] Unit test: OAuth None + `GITHUB_PAT` → proceeds
- [x] Unit test: both absent → warning, returns 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)