### PR TITLE
chore(orchestrator): single-worker production + document poller constraint (Fixes #319)

### DIFF
--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -27,4 +27,12 @@ CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload
 # Production target
 FROM base AS production
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]
+# IMPORTANT: exactly ONE worker. The app lifespan (app/main.py) starts many
+# process-wide singletons — the global Telegram getUpdates poller, the schedule
+# runner, the daily self-test, the skill crawler, OAuth/token refreshers, the
+# disk monitor. Running >1 uvicorn worker (or >1 replica) duplicates all of
+# them: schedules fire twice and Telegram raises "terminated by other
+# getUpdates request" with every message delivered twice (issue #319).
+# Scaling horizontally requires a cluster-wide lock per singleton first
+# (see app/telegram/bot_manager.py).
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1"]

--- a/orchestrator/app/telegram/bot_manager.py
+++ b/orchestrator/app/telegram/bot_manager.py
@@ -2,6 +2,16 @@
 
 Starts/stops individual bot instances when agents configure their Telegram token.
 Loads all configured bots on startup.
+
+SINGLE-PROCESS ASSUMPTION (issue #319): the token dedup here (``claimed_tokens``
+and the ``start_bot`` guards) only deduplicates pollers *within one process*. A
+Telegram token may be polled by exactly one ``getUpdates`` loop cluster-wide, so
+the orchestrator must run as a single uvicorn worker / single replica (enforced
+by ``--workers 1`` in the Dockerfile ``production`` stage). Before scaling to
+multiple workers or replicas, add a distributed lock per token (e.g. a Redis
+lease or ``SELECT ... FOR UPDATE SKIP LOCKED``) so only one instance polls each
+token; otherwise Telegram raises "terminated by other getUpdates request" and
+every message is delivered twice.
 """
 
 import uuid


### PR DESCRIPTION
## Verification result (W2 follow-up to #317)

**Compose deployments are already single-instance and safe:** both `docker-compose.yml` and `docker-compose.aiemployee.yml` build `target: base`, whose CMD is `uvicorn ... --reload` (a single worker). The Telegram poller starts in the app lifespan (once per process), so one process = one poller.

**The `production` Dockerfile stage was NOT safe:** it ran `uvicorn --workers 2`. The lifespan starts many process-wide singletons — global Telegram `getUpdates` poller, schedule runner, daily self-test, skill crawler, OAuth/token refreshers, disk monitor. With 2 workers each runs twice: schedules fire twice and Telegram raises `terminated by other getUpdates request` (the 362× errors in `platform-errors.log`), delivering every message twice.

## Changes

- `orchestrator/Dockerfile` — production stage `--workers 2` → `--workers 1`, with a comment explaining why.
- `orchestrator/app/telegram/bot_manager.py` — module docstring documents the single-process assumption and that horizontal scaling first requires a distributed lock per token (Redis lease / `SELECT ... FOR UPDATE SKIP LOCKED`).

## Acceptance criteria

- [x] Single-instance confirmed (compose builds `base` = 1 worker) **and** documented
- [x] Production image hardened to 1 worker so the in-process singletons aren't duplicated

Distributed-lock implementation is intentionally deferred — the deployment is single-instance today; the docs flag the prerequisite for future scaling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)