### PR TITLE
chore(frontend): migrate lucide-react 0.460 -> 1.25 (#305 Phase 5)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,7 @@
         "exceljs": "^4.4.0",
         "framer-motion": "^12.42.2",
         "geist": "^1.7.2",
-        "lucide-react": "^0.460.0",
+        "lucide-react": "^1.25.0",
         "mermaid": "^11.16.0",
         "next": "^14.2.0",
         "react": "^18.3.0",
@@ -4175,12 +4175,12 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.460.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.460.0.tgz",
-      "integrity": "sha512-BVtq/DykVeIvRTJvRAgCsOwaGL8Un3Bxh8MbDxMhEWlZay3T4IpEKDEpwt5KZ0KJMHzgm6jrltxlT5eXOWXDHg==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.25.0.tgz",
+      "integrity": "sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw==",
       "license": "ISC",
       "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "exceljs": "^4.4.0",
     "framer-motion": "^12.42.2",
     "geist": "^1.7.2",
-    "lucide-react": "^0.460.0",
+    "lucide-react": "^1.25.0",
     "mermaid": "^11.16.0",
     "next": "^14.2.0",
     "react": "^18.3.0",

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -21,7 +21,6 @@ import {
   EyeOff,
   MessageSquare,
   ExternalLink,
-  Github,
   Bug,
   Lightbulb,
   TrendingUp,
@@ -37,6 +36,7 @@ import {
   ScrollText,
   Brain,
 } from "lucide-react";
+import { Github } from "@/components/icons/github";
 
 import { SettingsView } from "@/app/settings/view";
 import { AIAccountsView } from "@/app/ai-accounts/view";

--- a/frontend/src/app/integrations/page.tsx
+++ b/frontend/src/app/integrations/page.tsx
@@ -5,8 +5,9 @@ import {
   Plug, Mail, Cloud, Smartphone, CheckCircle2,
   AlertCircle, Loader2, Unplug, ExternalLink, RefreshCw,
   Plus, Trash2, ChevronRight, Wrench, Globe, Power,
-  Github, Eye, EyeOff, Save, Users, Copy, Info,
+  Eye, EyeOff, Save, Users, Copy, Info,
 } from "lucide-react";
+import { Github } from "@/components/icons/github";
 import { Header } from "@/components/layout/header";
 import { cn } from "@/lib/utils";
 import * as api from "@/lib/api";

--- a/frontend/src/components/agents/skills-tab.tsx
+++ b/frontend/src/components/agents/skills-tab.tsx
@@ -13,13 +13,13 @@ import {
   Save,
   X,
   Download,
-  Github,
   Loader2,
   ExternalLink,
   Search,
   Store,
   Check,
 } from "lucide-react";
+import { Github } from "@/components/icons/github";
 import { cn } from "@/lib/utils";
 
 const API = process.env.NEXT_PUBLIC_API_URL || "";

--- a/frontend/src/components/icons/github.tsx
+++ b/frontend/src/components/icons/github.tsx
@@ -1,0 +1,21 @@
+import { forwardRef, type SVGProps } from "react";
+
+// lucide-react 1.x removed brand icons (including Github). This is a drop-in
+// replacement exposing the same forwardRef component shape as lucide icons, so
+// it stays assignable where a lucide icon type is expected.
+export const Github = forwardRef<SVGSVGElement, SVGProps<SVGSVGElement>>(
+  ({ className, ...props }, ref) => (
+    <svg
+      ref={ref}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M12 .5C5.73.5.5 5.74.5 12.02c0 5.1 3.29 9.42 7.86 10.95.58.11.79-.25.79-.56v-2.02c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.29-1.7-1.29-1.7-1.05-.72.08-.71.08-.71 1.16.08 1.77 1.2 1.77 1.2 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.56-.29-5.25-1.28-5.25-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 2.9-.39c.98 0 1.97.13 2.9.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.7 5.41-5.27 5.69.41.36.78 1.06.78 2.14v3.17c0 .31.21.68.8.56A11.53 11.53 0 0 0 23.5 12.02C23.5 5.74 18.27.5 12 .5Z" />
+    </svg>
+  ),
+);
+Github.displayName = "Github";


### PR DESCRIPTION
## Summary
- Bumps `lucide-react` `^0.460.0` -> `^1.25.0` (Phase 5 of the #305 framework-upgrade plan).
- lucide-react 1.x **removed brand icons** — `Github` is no longer exported. Added a small local `forwardRef` `Github` icon (`frontend/src/components/icons/github.tsx`) as a drop-in replacement and repointed the three importing files (`admin/page.tsx`, `integrations/page.tsx`, `agents/skills-tab.tsx`).
- All other 184+ used icons still exist in 1.25 (verified programmatically) — no other changes needed.

## Why not just merge Dependabot #329?
The version-only bump in #329 breaks the build because it doesn't handle the removed `Github` brand icon. This PR supersedes #329.

## Verification
- Checked all lucide icon imports across `frontend/src` against the installed 1.25.0 package: only `Github` was missing.
- `cd frontend && rm -rf .next && npx next build` -> **exit 0, 33/33 static pages** (frontend build is not in CI, so verified locally).

Part of #305.