### PR TITLE
chore(frontend): migrate React 18 -> 19 (#305 Phase 3)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,8 +25,8 @@
         "lucide-react": "^1.25.0",
         "mermaid": "^11.16.0",
         "next": "^16.2.10",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
         "react-force-graph-3d": "^1.29.1",
         "react-markdown": "^10.1.0",
         "react-pdf": "^10.4.1",
@@ -40,8 +40,8 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.3",
         "@types/node": "^26.1.1",
-        "@types/react": "^18.3.0",
-        "@types/react-dom": "^18.3.0",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
         "postcss": "^8.5.20",
         "tailwindcss": "^4.3.3",
         "typescript": "^5.9.3"
@@ -146,31 +146,31 @@
       "license": "MIT"
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
-      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
-      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.4",
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.7.tgz",
-      "integrity": "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.5"
+        "@floating-ui/dom": "^1.8.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
       "license": "MIT"
     },
     "node_modules/@iconify/types": {
@@ -2494,30 +2494,23 @@
         "undici-types": "~8.3.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -5968,28 +5961,24 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-force-graph-3d": {
@@ -6403,13 +6392,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,8 +25,8 @@
     "lucide-react": "^1.25.0",
     "mermaid": "^11.16.0",
     "next": "^16.2.10",
-    "react": "^18.3.0",
-    "react-dom": "^18.3.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "react-force-graph-3d": "^1.29.1",
     "react-markdown": "^10.1.0",
     "react-pdf": "^10.4.1",
@@ -40,8 +40,8 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.3",
     "@types/node": "^26.1.1",
-    "@types/react": "^18.3.0",
-    "@types/react-dom": "^18.3.0",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
     "postcss": "^8.5.20",
     "tailwindcss": "^4.3.3",
     "typescript": "^5.9.3"

--- a/frontend/src/app/second-brains/vault-graph-3d.tsx
+++ b/frontend/src/app/second-brains/vault-graph-3d.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { WheelEvent as ReactWheelEvent } from "react";
+import type { ReactElement, WheelEvent as ReactWheelEvent } from "react";
 import ForceGraph3D from "react-force-graph-3d";
 import SpriteText from "three-spritetext";
 import {
@@ -20,7 +20,7 @@ import type { VaultGraph, VaultGraphNode } from "@/lib/api";
 
 // react-force-graph's prop surface is broad and loosely typed — cast once so the
 // JSX below stays readable instead of fighting generics.
-const FG = ForceGraph3D as unknown as (props: Record<string, unknown>) => JSX.Element;
+const FG = ForceGraph3D as unknown as (props: Record<string, unknown>) => ReactElement;
 
 const PALETTE = [
   "#60a5fa", "#34d399", "#f472b6", "#fbbf24", "#a78bfa", "#22d3ee",

--- a/frontend/src/app/tasks/[id]/page.tsx
+++ b/frontend/src/app/tasks/[id]/page.tsx
@@ -69,7 +69,7 @@ export default function TaskDetailPage() {
   const wsRef = useRef<WebSocket | null>(null);
   const logContainerRef = useRef<HTMLDivElement>(null);
   const replayContainerRef = useRef<HTMLDivElement>(null);
-  const reconnectTimeout = useRef<ReturnType<typeof setTimeout>>();
+  const reconnectTimeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   // Auto-scroll the replay log to the newest revealed step while dragging the slider.
   useEffect(() => {

--- a/frontend/src/components/agents/chat.tsx
+++ b/frontend/src/components/agents/chat.tsx
@@ -256,7 +256,7 @@ export function AgentChat({ agentId, initialSessionId, embedded, busySessionIds 
     el.style.height = `${el.scrollHeight}px`;
   }, [input]);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const reconnectTimeout = useRef<ReturnType<typeof setTimeout>>();
+  const reconnectTimeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const reconnectAttempts = useRef(0);
   const intentionalClose = useRef(false);
   const currentWsSessionId = useRef<string | null>(null);

--- a/frontend/src/components/agents/todo-tab.tsx
+++ b/frontend/src/components/agents/todo-tab.tsx
@@ -60,7 +60,7 @@ export function TodoTab({ agentId }: TodoTabProps) {
   const [newDescription, setNewDescription] = useState("");
   const [newPriority, setNewPriority] = useState(3);
   const [newProject, setNewProject] = useState("");
-  const pollRef = useRef<ReturnType<typeof setInterval>>();
+  const pollRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
 
   const fetchTodos = useCallback(async () => {
     try {

--- a/frontend/src/components/layout/notification-bell.tsx
+++ b/frontend/src/components/layout/notification-bell.tsx
@@ -52,7 +52,7 @@ export function NotificationBell({
   const [unreadCount, setUnreadCount] = useState(0);
   const panelRef = useRef<HTMLDivElement>(null);
   const wsRef = useRef<WebSocket | null>(null);
-  const reconnectTimeout = useRef<ReturnType<typeof setTimeout>>();
+  const reconnectTimeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const intentionalClose = useRef(false);
 
   // Fetch unread count on mount and periodically

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -10,7 +10,7 @@ export function useWebSocket(path: string) {
   const [messages, setMessages] = useState<LogEvent[]>([]);
   const [isConnected, setIsConnected] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
-  const reconnectTimeout = useRef<ReturnType<typeof setTimeout>>();
+  const reconnectTimeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const mountedRef = useRef(false);
   const failCountRef = useRef(0);
   const wsToken = useAuthStore((s) => s.wsToken);


### PR DESCRIPTION
## Summary
Completes **#305 Phase 3**: bumps the frontend from React 18.3 to **React 19.2.7** (react, react-dom, @types/react, @types/react-dom). Now unblocked because Next 16 (merged in #334) peers React 19.

Supersedes the two split Dependabot PRs **#314** (react) and **#312** (react-dom) — they only bump versions and would break `next build` on the two @types/react 19 breaking changes below.

## Breaking changes handled
- **Removed global `JSX` namespace** → `vault-graph-3d.tsx` now uses `ReactElement` instead of `JSX.Element`.
- **`useRef` now requires an argument** → the 5 timeout/interval refs pass an explicit `undefined` initial value (`useRef<T | undefined>(undefined)`). Semantics are unchanged: a no-arg `useRef<T>()` already produced `T | undefined` under the old types.

Codebase audit found **no** other React 19 breaking patterns: no `defaultProps`/`propTypes` on function components, no `findDOMNode`, no `ReactDOM.render`, no `useFormState`, no legacy Context. All third-party libs (react-force-graph-3d, react-pdf, recharts, framer-motion, Radix, react-markdown, zustand) already peer React 19.

## Verification (frontend build is NOT in CI)
- `rm -rf .next && npx next build --webpack` → **exit 0, 34 routes**
- Runtime smoke `npx next start`: `/`, `/login`, `/dashboard` → **HTTP 200 text/html**
- CI frontend Trivy container scan additionally builds the frontend image (independent `next build` confirmation).

Closes #314
Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)