### PR TITLE
Fix #336: host.docker.internal resolvable on Linux for TTS

### DIFF
--- a/docker-compose.aiemployee.yml
+++ b/docker-compose.aiemployee.yml
@@ -144,6 +144,11 @@ services:
       docker-socket-proxy:
         condition: service_started
     restart: unless-stopped
+    # Cross-platform host access: on Linux host.docker.internal is not resolvable
+    # by default; host-gateway adds the /etc/hosts entry so the orchestrator can
+    # reach host services (e.g. TTS on :8002). No-op on Docker Desktop.
+    extra_hosts:
+    - "host.docker.internal:host-gateway"
     networks:
     - internal
     - agent-network

--- a/docker-compose.community.yml
+++ b/docker-compose.community.yml
@@ -108,6 +108,11 @@ services:
       redis:
         condition: service_healthy
     restart: unless-stopped
+    # Cross-platform host access: on Linux host.docker.internal does not resolve
+    # by default; host-gateway adds the /etc/hosts entry so the orchestrator can
+    # reach host services (e.g. TTS on :8002). No-op on Docker Desktop.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/healthz', timeout=3)"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,6 +176,11 @@ services:
       docker-socket-proxy:
         condition: service_started
     restart: unless-stopped
+    # Cross-platform host access: Docker Desktop (Mac/Windows) provides
+    # host.docker.internal automatically, but on Linux hosts it does not resolve.
+    # host-gateway makes the orchestrator reach host services (e.g. TTS on :8002).
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       - internal
       - agent-network

--- a/orchestrator/app/config.py
+++ b/orchestrator/app/config.py
@@ -109,8 +109,10 @@ class Settings(BaseSettings):
     # OpenAI (for Whisper voice transcription)
     openai_api_key: str = ""
 
-    # Local TTS service (VibeVoice, runs natively on Mac host with Metal GPU)
-    # Docker containers reach Mac host via host.docker.internal
+    # Local TTS service (VibeVoice, runs natively on the host with GPU access).
+    # Containers reach the host via host.docker.internal. On Linux this hostname
+    # only resolves because the orchestrator service maps it to host-gateway in
+    # docker-compose (extra_hosts); on Docker Desktop it is provided automatically.
     tts_service_url: str = "http://host.docker.internal:8002"
 
     # Local STT service (faster-whisper) — transcribes Telegram voice messages.


### PR DESCRIPTION
Fixes #336

## Problem
Voice TTS (`tts_service_url = http://host.docker.internal:8002`) fails on Linux Docker hosts with `[Errno -2] Name or service not known`. `host.docker.internal` is only auto-provided by Docker Desktop (Mac/Windows); on bare-metal/VPS/Raspberry Pi Linux it does not resolve.

## Fix
Add `extra_hosts: - "host.docker.internal:host-gateway"` to the `orchestrator` service in all three compose files. `host-gateway` (Docker Engine 20.10+) resolves to the host's internal IP, making the setting cross-platform (no-op on Docker Desktop where the name already resolves).

- `docker-compose.yml`
- `docker-compose.aiemployee.yml`
- `docker-compose.community.yml`
- `orchestrator/app/config.py` — comment updated to reflect cross-platform behaviour (no logic change)

## Verification
All three compose files parse with PyYAML and expose `extra_hosts=['host.docker.internal:host-gateway']` on the orchestrator service. No code path changed — pure infra/deploy fix.