### PR TITLE
Fix #337: remove JWT-in-URL WebSocket auth fallback

### DIFF
--- a/frontend/src/app/tasks/[id]/page.tsx
+++ b/frontend/src/app/tasks/[id]/page.tsx
@@ -14,7 +14,6 @@ import { Header } from "@/components/layout/header";
 import { cn } from "@/lib/utils";
 import { formatDuration, formatCost, timeAgo, formatBytes } from "@/lib/utils";
 import * as api from "@/lib/api";
-import { useAuthStore } from "@/lib/auth";
 import type { Task, LogEvent } from "@/lib/types";
 import { useSimpleMode } from "@/hooks/use-simple-mode";
 import { MarkdownContent } from "@/components/ui/markdown-content";
@@ -156,24 +155,30 @@ export default function TaskDetailPage() {
 
   // Connect WebSocket for live logs
   const connectWs = useCallback(async (agentId: string) => {
-    // Fetch one-time ticket for WebSocket auth
-    let authParam = "";
+    // Fetch one-time ticket for WebSocket auth (short-lived, single-use).
+    // SECURITY (#337): never fall back to a long-lived JWT in the URL — that
+    // leaks the token into proxy/access logs, browser history and Referer
+    // headers. If no ticket can be obtained, retry with backoff instead.
+    let ticket: string | null = null;
     try {
       const resp = await fetch(`${getApiUrl()}/api/v1/ws/ticket`, {
         method: "POST",
         credentials: "include",
       });
       if (resp.ok) {
-        const { ticket } = await resp.json();
-        authParam = `?ticket=${ticket}`;
+        ticket = (await resp.json())?.ticket ?? null;
       }
     } catch {
-      // Fallback to legacy token auth
-      const token = useAuthStore.getState().wsToken;
-      authParam = token ? `?token=${token}` : "";
+      ticket = null;
     }
 
-    const ws = new WebSocket(`${getWsUrl()}/api/v1/ws/agents/${agentId}/logs${authParam}`);
+    if (!ticket) {
+      setIsConnected(false);
+      reconnectTimeout.current = setTimeout(() => connectWs(agentId), 3000);
+      return;
+    }
+
+    const ws = new WebSocket(`${getWsUrl()}/api/v1/ws/agents/${agentId}/logs?ticket=${ticket}`);
     wsRef.current = ws;
 
     ws.onopen = () => setIsConnected(true);

--- a/frontend/src/components/agents/chat.tsx
+++ b/frontend/src/components/agents/chat.tsx
@@ -437,24 +437,55 @@ export function AgentChat({ agentId, initialSessionId, embedded, busySessionIds 
       return;
     }
 
-    // Fetch one-time ticket for WebSocket auth
-    let authParam = "";
+    // Fetch one-time ticket for WebSocket auth (short-lived, single-use).
+    // SECURITY (#337): never fall back to a long-lived JWT in the URL — that
+    // leaks the token into proxy/access logs, browser history and Referer
+    // headers. If no ticket can be obtained, treat it as a temporary connection
+    // failure and retry with backoff instead of degrading auth.
+    let ticket: string | null = null;
     try {
       const resp = await fetch(`${getApiUrl()}/api/v1/ws/ticket`, {
         method: "POST",
         credentials: "include",
       });
       if (resp.ok) {
-        const { ticket } = await resp.json();
-        authParam = `?ticket=${ticket}`;
+        ticket = (await resp.json())?.ticket ?? null;
       }
     } catch {
-      // Fallback to legacy token auth
-      const token = useAuthStore.getState().wsToken;
-      authParam = token ? `?token=${token}` : "";
+      ticket = null;
     }
 
-    const ws = new WebSocket(`${getWsUrl()}/api/v1/ws/agents/${agentId}/chat${authParam}`);
+    if (!ticket) {
+      setIsConnected(false);
+      reconnectAttempts.current++;
+      if (reconnectAttempts.current < MAX_RECONNECT_ATTEMPTS) {
+        const delay = Math.min(1000 * Math.pow(2, reconnectAttempts.current - 1), 10000);
+        setMessages((prev) => [
+          ...prev.filter((m) => m.id !== "reconnecting"),
+          {
+            id: "reconnecting",
+            role: "system",
+            content: `Reconnecting... (${reconnectAttempts.current}/${MAX_RECONNECT_ATTEMPTS})`,
+            timestamp: new Date().toISOString(),
+          },
+        ]);
+        reconnectTimeout.current = setTimeout(connect, delay);
+      } else {
+        setConnectionFailed(true);
+        setMessages((prev) => [
+          ...prev.filter((m) => m.id !== "reconnecting"),
+          {
+            id: "connection-failed",
+            role: "error",
+            content: "Could not authenticate the connection. Please refresh the page and sign in again.",
+            timestamp: new Date().toISOString(),
+          },
+        ]);
+      }
+      return;
+    }
+
+    const ws = new WebSocket(`${getWsUrl()}/api/v1/ws/agents/${agentId}/chat?ticket=${ticket}`);
     wsRef.current = ws;
 
     ws.onopen = () => {

--- a/frontend/src/components/layout/notification-bell.tsx
+++ b/frontend/src/components/layout/notification-bell.tsx
@@ -74,6 +74,8 @@ export function NotificationBell({
     }
   }, []);
 
+  // Subscribed only as an auth-change signal to rebuild the socket on
+  // login/logout. Deliberately NOT placed in the WebSocket URL (see #337).
   const wsToken = useAuthStore((s) => s.wsToken);
 
   // WebSocket for live notifications
@@ -84,25 +86,34 @@ export function NotificationBell({
     const connect = async () => {
       if (failCount >= 5) return; // Stop retrying after repeated auth failures
 
-      // Fetch one-time ticket for WebSocket auth
-      let authParam = "";
+      // Fetch one-time ticket for WebSocket auth (short-lived, single-use).
+      // SECURITY (#337): never fall back to a long-lived JWT in the URL — that
+      // leaks the token into proxy/access logs, browser history and Referer
+      // headers. If no ticket can be obtained, retry with backoff instead.
+      let ticket: string | null = null;
       try {
         const resp = await fetch(`${getApiUrl()}/api/v1/ws/ticket`, {
           method: "POST",
           credentials: "include",
         });
         if (resp.ok) {
-          const { ticket } = await resp.json();
-          authParam = `?ticket=${ticket}`;
+          ticket = (await resp.json())?.ticket ?? null;
         }
       } catch {
-        // Fallback to legacy token auth
-        authParam = wsToken ? `?token=${wsToken}` : "";
+        ticket = null;
       }
 
       if (intentionalClose.current) return; // Bail if unmounted while awaiting ticket
 
-      const ws = new WebSocket(`${getWsUrl()}/api/v1/ws/notifications${authParam}`);
+      if (!ticket) {
+        failCount++;
+        if (failCount >= 5) return;
+        const delay = 5000 * Math.pow(2, Math.min(failCount, 3));
+        reconnectTimeout.current = setTimeout(connect, delay);
+        return;
+      }
+
+      const ws = new WebSocket(`${getWsUrl()}/api/v1/ws/notifications?ticket=${ticket}`);
       wsRef.current = ws;
       let wasOpen = false;
 

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -13,6 +13,8 @@ export function useWebSocket(path: string) {
   const reconnectTimeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const mountedRef = useRef(false);
   const failCountRef = useRef(0);
+  // Subscribed only as an auth-change signal to rebuild the socket on
+  // login/logout. Deliberately NOT placed in the WebSocket URL (see #337).
   const wsToken = useAuthStore((s) => s.wsToken);
 
   const connect = useCallback(async () => {
@@ -28,25 +30,37 @@ export function useWebSocket(path: string) {
       wsRef.current.close();
     }
 
-    // Fetch one-time ticket for WebSocket auth
-    let authParam = "";
+    // Fetch one-time ticket for WebSocket auth (short-lived, single-use).
+    // SECURITY (#337): never fall back to a long-lived JWT in the URL — that
+    // leaks the token into proxy/access logs, browser history and Referer
+    // headers. If no ticket can be obtained (network error or non-OK response),
+    // treat it as a connection failure and retry with backoff.
+    let ticket: string | null = null;
     try {
       const resp = await fetch(`${getApiUrl()}/api/v1/ws/ticket`, {
         method: "POST",
         credentials: "include",
       });
       if (resp.ok) {
-        const { ticket } = await resp.json();
-        authParam = `${path.includes("?") ? "&" : "?"}ticket=${ticket}`;
+        ticket = (await resp.json())?.ticket ?? null;
       }
     } catch {
-      // Fallback to legacy token auth
-      authParam = wsToken ? `${path.includes("?") ? "&" : "?"}token=${wsToken}` : "";
+      ticket = null;
     }
 
     // Bail out if unmounted while awaiting ticket
     if (!mountedRef.current) return;
 
+    if (!ticket) {
+      setIsConnected(false);
+      failCountRef.current++;
+      if (failCountRef.current >= 5) return;
+      const delay = 3000 * Math.pow(2, Math.min(failCountRef.current, 3));
+      reconnectTimeout.current = setTimeout(connect, delay);
+      return;
+    }
+
+    const authParam = `${path.includes("?") ? "&" : "?"}ticket=${ticket}`;
     const ws = new WebSocket(`${getWsUrl()}/api/v1${path}${authParam}`);
     wsRef.current = ws;
     let wasOpen = false;


### PR DESCRIPTION
Fixes #337

## Problem
When the one-time-ticket fetch (`POST /api/v1/ws/ticket`) threw an exception (network error, CORS, timeout) — or returned a non-OK status — the WebSocket clients fell back to appending the long-lived JWT access token as a `?token=` URL query parameter. That leaks the token into:
- server/Caddy/nginx access logs
- browser history
- `Referer` headers to third-party resources
- the DevTools Network tab

The degradation was silent (no user-visible error).

## Fix
Remove the `wsToken` URL fallback in **all** affected WS clients. If no ticket can be obtained, treat it as a retriable connection failure (backoff reconnect) and surface an explicit error state where the component supports it, instead of degrading auth.

Files changed:
- `frontend/src/hooks/use-websocket.ts` (log stream)
- `frontend/src/components/agents/chat.tsx` (agent chat — uses existing reconnect + `connection-failed` message)
- `frontend/src/components/layout/notification-bell.tsx` (notifications)
- `frontend/src/app/tasks/[id]/page.tsx` (task log stream — **not listed in the issue** but had the identical fallback)

Non-OK ticket responses (401/500) are now handled the same as network errors — previously they left `authParam` empty and produced a silently rejected socket.

The `wsToken` field in the auth store is kept (larger refactor to remove) but is no longer placed in any WebSocket URL. Where still subscribed, it now serves only as an auth-change signal to rebuild the socket, with a comment noting it must not go in the URL.

## Verification
- `grep` confirms **zero** `?token=${...}` fallbacks remain in `frontend/src`.
- `rm -rf .next && npx next build --webpack` → exit 0, 32/32 static pages (frontend build is not in CI).