### PR TITLE
Fix #340: disk_monitor KeyError 'disk_available_mb' — restore warn/stop

### DIFF
--- a/orchestrator/app/services/docker_service.py
+++ b/orchestrator/app/services/docker_service.py
@@ -248,6 +248,7 @@ class DockerService:
                 "disk_usage_mb": round(used_mb, 2),
                 "disk_limit_mb": round(limit_mb, 2),
                 "disk_percent": disk_percent,
+                "disk_available_mb": round(max(limit_mb - used_mb, 0), 2),
             }
         except Exception:
             return None

--- a/orchestrator/tests/test_disk_monitor.py
+++ b/orchestrator/tests/test_disk_monitor.py
@@ -1,0 +1,63 @@
+"""Regression tests for the disk-quota monitor (KeyError: 'disk_available_mb').
+
+`DiskMonitorService._write_warning` reads ``stats["disk_available_mb"]`` while
+``DockerService.get_workspace_disk_usage`` used to return only usage/limit/percent.
+The missing key raised a KeyError that (a) suppressed the 80% warning file and
+(b) crashed ``_stop_agent`` *before* the container was stopped, so over-quota
+agents were never actually stopped. These tests pin the producer/consumer
+contract so the four keys stay in sync.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from app.services.docker_service import DockerService
+from app.services.disk_monitor import DiskMonitorService
+
+
+def _docker_with_du(du_stdout: str) -> DockerService:
+    svc = DockerService.__new__(DockerService)  # bypass __init__ (no docker daemon)
+    container = MagicMock()
+    container.exec_run.return_value = (0, (du_stdout.encode("utf-8"), b""))
+    client = MagicMock()
+    client.containers.get.return_value = container
+    svc.client = client
+    return svc
+
+
+class TestWorkspaceDiskUsage(unittest.TestCase):
+    def test_returns_disk_available_mb(self):
+        # 2 GB used against a 10 GB quota -> 8 GB (8192 MB) available, 20%.
+        stats = _docker_with_du("2048\t/workspace\n").get_workspace_disk_usage("c1", 10.0)
+        self.assertIsNotNone(stats)
+        self.assertEqual(
+            set(stats),
+            {"disk_usage_mb", "disk_limit_mb", "disk_percent", "disk_available_mb"},
+        )
+        self.assertEqual(stats["disk_available_mb"], 8192.0)
+        self.assertEqual(stats["disk_percent"], 20.0)
+
+    def test_over_quota_available_clamped_to_zero(self):
+        # 11 GB used against a 10 GB quota -> available 0, percent capped at 100.
+        stats = _docker_with_du("11264\t/workspace\n").get_workspace_disk_usage("c1", 10.0)
+        self.assertEqual(stats["disk_available_mb"], 0.0)
+        self.assertEqual(stats["disk_percent"], 100.0)
+
+
+class TestWriteWarningContract(unittest.TestCase):
+    def test_write_warning_consumes_real_stats_without_keyerror(self):
+        docker = _docker_with_du("9728\t/workspace\n")  # 9.5 GB / 10 GB = 95%
+        stats = docker.get_workspace_disk_usage("c1", 10.0)
+
+        monitor = DiskMonitorService(session_factory=MagicMock(), docker_service=docker)
+        # This is the call site that used to raise KeyError('disk_available_mb').
+        monitor._write_warning("c1", stats)
+
+        # The .disk_warning file must actually be written into the container.
+        put_archive = docker.client.containers.get.return_value.put_archive
+        put_archive.assert_called_once()
+        self.assertEqual(put_archive.call_args.args[0], "/workspace")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `disk_available_mb` to `DockerService.get_workspace_disk_usage()` (clamped to 0 when over quota). It was missing, so `DiskMonitorService._write_warning()` raised `KeyError('disk_available_mb')`.
- That KeyError made the disk monitor fully non-functional: the 80% `.disk_warning` file was never written, and at 95% `_stop_agent` crashed **before** `stop_container`, so over-quota agents were never stopped (error re-fired every 5 min in `platform-errors.log`).
- Add `tests/test_disk_monitor.py` pinning the producer/consumer contract (all 4 keys, over-quota clamp, and `_write_warning` no longer raising).

Fixes #340.

## Test plan
- [x] `python -m pytest tests/test_disk_monitor.py -v` → 3 passed
- [x] Change is additive (one dict key); the other consumer (`agent_manager.py:1690`) reads via `.get()` and is unaffected.