### PR TITLE
Fix #344: pure-ASGI middleware to stop DB connection pool leak

### DIFF
--- a/orchestrator/app/main.py
+++ b/orchestrator/app/main.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
-from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.datastructures import MutableHeaders
 
 from app.api.router import api_router
 from app.api.ws import init_stream_manager
@@ -21,51 +21,83 @@ logger = logging.getLogger(__name__)
 # --- Security Headers Middleware ---
 
 
-class SecurityHeadersMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request: Request, call_next):
-        response: Response = await call_next(request)
-        response.headers["X-Content-Type-Options"] = "nosniff"
-        response.headers["X-Frame-Options"] = "DENY"
-        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
-        response.headers["X-XSS-Protection"] = "1; mode=block"
-        response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()"
-        # CSP - allow self + inline styles (Tailwind) + wss for websockets
-        response.headers["Content-Security-Policy"] = (
-            "default-src 'self'; "
-            "script-src 'self' 'unsafe-inline'; "
-            "style-src 'self' 'unsafe-inline'; "
-            "img-src 'self' data: blob:; "
-            "connect-src 'self' ws: wss:; "
-            "font-src 'self' data:; "
-            "frame-ancestors 'none'"
-        )
-        return response
+class SecurityHeadersMiddleware:
+    """Pure-ASGI middleware that stamps security headers on every response.
+
+    Implemented as pure ASGI (not BaseHTTPMiddleware) on purpose: BaseHTTPMiddleware
+    runs the downstream app inside its own anyio task/cancel-scope. When a client
+    disconnects mid-request, that inner task is cancelled while an endpoint still
+    holds a checked-out SQLAlchemy connection, orphaning it (the pool then logs
+    "non-checked-in connection ... will be terminated"). Pure ASGI keeps the request
+    on the original task, so cancellation unwinds the session cleanly.
+    """
+
+    _CSP = (
+        "default-src 'self'; "
+        "script-src 'self' 'unsafe-inline'; "
+        "style-src 'self' 'unsafe-inline'; "
+        "img-src 'self' data: blob:; "
+        "connect-src 'self' ws: wss:; "
+        "font-src 'self' data:; "
+        "frame-ancestors 'none'"
+    )
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def send_with_headers(message):
+            if message["type"] == "http.response.start":
+                headers = MutableHeaders(scope=message)
+                headers["X-Content-Type-Options"] = "nosniff"
+                headers["X-Frame-Options"] = "DENY"
+                headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+                headers["X-XSS-Protection"] = "1; mode=block"
+                headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()"
+                headers["Content-Security-Policy"] = self._CSP
+            await send(message)
+
+        await self.app(scope, receive, send_with_headers)
 
 
 # --- API Rate Limiting Middleware ---
 
 
-class APIRateLimitMiddleware(BaseHTTPMiddleware):
+class APIRateLimitMiddleware:
     """Per-user / per-IP rate limiting backed by Redis.
 
     Uses Redis INCR + EXPIRE for distributed, restart-safe counters.
     Falls back to in-memory tracking if Redis is unavailable.
+
+    Implemented as pure ASGI (not BaseHTTPMiddleware) so client disconnects don't
+    orphan checked-out DB connections — see SecurityHeadersMiddleware for the why.
     """
 
     def __init__(self, app, max_requests: int = 120, window_seconds: int = 60):
-        super().__init__(app)
+        self.app = app
         self.max_requests = max_requests
         self.window = window_seconds
         # In-memory fallback (only used if Redis is unreachable)
         self._fallback: dict[str, list[float]] = {}
 
-    async def dispatch(self, request: Request, call_next):
+    async def __call__(self, scope, receive, send):
         import time
+
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request = Request(scope, receive)
 
         # Skip rate limiting for health checks and WebSocket upgrades
         path = request.url.path
         if path in ("/health", "/healthz") or request.headers.get("upgrade", "").lower() == "websocket":
-            return await call_next(request)
+            await self.app(scope, receive, send)
+            return
 
         # Identify caller: user_id from JWT cookie, fallback to IP
         key = request.client.host if request.client else "unknown"
@@ -92,13 +124,16 @@ class APIRateLimitMiddleware(BaseHTTPMiddleware):
                 if current > self.max_requests:
                     ttl = await redis_client.ttl(redis_key)
                     logger.warning(f"Rate limit exceeded for {key} ({current}/{self.max_requests})")
-                    return Response(
+                    response = Response(
                         content='{"detail":"Rate limit exceeded. Try again later."}',
                         status_code=429,
                         media_type="application/json",
                         headers={"Retry-After": str(max(ttl, 1))},
                     )
-                return await call_next(request)
+                    await response(scope, receive, send)
+                    return
+                await self.app(scope, receive, send)
+                return
             except Exception:
                 pass  # Redis unavailable — fall through to in-memory
 
@@ -110,15 +145,17 @@ class APIRateLimitMiddleware(BaseHTTPMiddleware):
 
         if len(self._fallback[key]) >= self.max_requests:
             logger.warning(f"Rate limit exceeded for {key} (in-memory fallback)")
-            return Response(
+            response = Response(
                 content='{"detail":"Rate limit exceeded. Try again later."}',
                 status_code=429,
                 media_type="application/json",
                 headers={"Retry-After": str(self.window)},
             )
+            await response(scope, receive, send)
+            return
 
         self._fallback[key].append(now)
-        return await call_next(request)
+        await self.app(scope, receive, send)
 
 
 # --- Config Validation ---

--- a/orchestrator/tests/test_asgi_middleware.py
+++ b/orchestrator/tests/test_asgi_middleware.py
@@ -1,0 +1,63 @@
+"""Regression tests for the pure-ASGI security & rate-limit middleware.
+
+Both middlewares used to subclass Starlette's ``BaseHTTPMiddleware``, which runs
+the downstream app inside its own anyio task/cancel-scope. When a client
+disconnected mid-request, that inner task was cancelled while an endpoint still
+held a checked-out SQLAlchemy connection, orphaning it — the pool then logged
+``non-checked-in connection ... will be terminated`` (seen 2026-07-23). Rewriting
+them as pure ASGI keeps the request on the original task so cancellation unwinds
+the DB session cleanly. These tests pin the observable behaviour (headers +
+rate-limit responses) so the pure-ASGI implementation stays correct.
+"""
+
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from app.main import APIRateLimitMiddleware, SecurityHeadersMiddleware
+
+
+def _ok(request):
+    return PlainTextResponse("ok")
+
+
+def _build(middleware):
+    routes = [Route("/x", _ok), Route("/health", _ok)]
+    return TestClient(Starlette(routes=routes, middleware=middleware))
+
+
+class TestSecurityHeaders:
+    def test_headers_are_stamped(self):
+        client = _build([Middleware(SecurityHeadersMiddleware)])
+        r = client.get("/x")
+        assert r.status_code == 200
+        assert r.headers["X-Content-Type-Options"] == "nosniff"
+        assert r.headers["X-Frame-Options"] == "DENY"
+        assert r.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+        assert r.headers["X-XSS-Protection"] == "1; mode=block"
+        assert "camera=()" in r.headers["Permissions-Policy"]
+        assert "default-src 'self'" in r.headers["Content-Security-Policy"]
+        assert "frame-ancestors 'none'" in r.headers["Content-Security-Policy"]
+
+
+class TestRateLimit:
+    def test_allows_up_to_limit_then_429(self):
+        client = _build(
+            [Middleware(APIRateLimitMiddleware, max_requests=2, window_seconds=60)]
+        )
+        assert client.get("/x").status_code == 200
+        assert client.get("/x").status_code == 200
+        blocked = client.get("/x")
+        assert blocked.status_code == 429
+        assert blocked.headers.get("Retry-After") == "60"
+        assert "Rate limit exceeded" in blocked.text
+
+    def test_health_is_never_rate_limited(self):
+        client = _build(
+            [Middleware(APIRateLimitMiddleware, max_requests=1, window_seconds=60)]
+        )
+        # Far more than the limit — health must always pass through.
+        for _ in range(5):
+            assert client.get("/health").status_code == 200


### PR DESCRIPTION
## Summary
- Converts `SecurityHeadersMiddleware` and `APIRateLimitMiddleware` from Starlette `BaseHTTPMiddleware` to **pure ASGI** middleware.
- Fixes the recurring `AsyncAdaptedQueuePool: non-checked-in connection ... will be terminated` errors caused by `BaseHTTPMiddleware`'s cancel-scope orphaning checked-out DB connections when a client disconnects mid-request (see #344 for the full trace + evidence).
- Behaviour preserved exactly: security headers, 429 rate-limit responses, `/health` skip, WebSocket-upgrade skip, JWT-cookie keying, Redis + in-memory fallback, middleware order.

## Changes
- `orchestrator/app/main.py`: both middlewares now implement `async def __call__(self, scope, receive, send)`; header injection via `MutableHeaders(scope=message)`, short-circuit 429 via `await response(scope, receive, send)`. Removed the now-unused `BaseHTTPMiddleware` import.
- `orchestrator/tests/test_asgi_middleware.py`: new regression tests (headers stamped, rate-limit 200→200→429 with `Retry-After`, `/health` never limited).

## Test plan
- [ ] CI `orchestrator-import` job imports `app.main` cleanly
- [ ] CI `orchestrator pytest` runs `tests/test_asgi_middleware.py` green
- [x] ASGI mechanics (MutableHeaders header injection, Response short-circuit, cookie/app.state reads, /health passthrough) verified in isolation locally with starlette+httpx
- [ ] Reviewer: confirm middleware ordering (CORS → rate-limit → security-headers) and that a rate-limit 429 intentionally does **not** carry security headers (unchanged from before — rate-limit is the outer of the two)

Note: touches the request hot path + auth-cookie decode → please review, do not fast-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)