### PR TITLE
Fix #346/#347: guard only Redis I/O in rate-limit ASGI middleware + expand tests

### DIFF
--- a/orchestrator/app/main.py
+++ b/orchestrator/app/main.py
@@ -117,25 +117,35 @@ class APIRateLimitMiddleware:
         redis_client = getattr(redis_svc, "client", None) if redis_svc else None
 
         if redis_client:
+            # Only Redis I/O is guarded here. The downstream app call and the 429
+            # response are issued *outside* the try so a downstream 500 propagates
+            # instead of being swallowed and re-dispatched (double app-call).
+            redis_ok = False
+            retry_after: int | None = None  # None => allowed, int => blocked
             try:
                 current = await redis_client.incr(redis_key)
                 if current == 1:
                     await redis_client.expire(redis_key, self.window)
                 if current > self.max_requests:
                     ttl = await redis_client.ttl(redis_key)
+                    retry_after = max(ttl, 1)
                     logger.warning(f"Rate limit exceeded for {key} ({current}/{self.max_requests})")
+                redis_ok = True
+            except Exception:
+                pass  # Redis unavailable — fall through to in-memory
+
+            if redis_ok:
+                if retry_after is not None:
                     response = Response(
                         content='{"detail":"Rate limit exceeded. Try again later."}',
                         status_code=429,
                         media_type="application/json",
-                        headers={"Retry-After": str(max(ttl, 1))},
+                        headers={"Retry-After": str(retry_after)},
                     )
                     await response(scope, receive, send)
-                    return
-                await self.app(scope, receive, send)
+                else:
+                    await self.app(scope, receive, send)
                 return
-            except Exception:
-                pass  # Redis unavailable — fall through to in-memory
 
         # In-memory fallback
         now = time.time()

--- a/orchestrator/tests/test_asgi_middleware.py
+++ b/orchestrator/tests/test_asgi_middleware.py
@@ -10,10 +10,11 @@ the DB session cleanly. These tests pin the observable behaviour (headers +
 rate-limit responses) so the pure-ASGI implementation stays correct.
 """
 
+import app.core.auth as auth_module
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.responses import PlainTextResponse
-from starlette.routing import Route
+from starlette.routing import Route, WebSocketRoute
 from starlette.testclient import TestClient
 
 from app.main import APIRateLimitMiddleware, SecurityHeadersMiddleware
@@ -23,9 +24,49 @@ def _ok(request):
     return PlainTextResponse("ok")
 
 
+async def _ws(websocket):
+    await websocket.accept()
+    await websocket.send_text("ok")
+    await websocket.close()
+
+
 def _build(middleware):
-    routes = [Route("/x", _ok), Route("/health", _ok)]
+    routes = [
+        Route("/x", _ok),
+        Route("/health", _ok),
+        WebSocketRoute("/ws", _ws),
+    ]
     return TestClient(Starlette(routes=routes, middleware=middleware))
+
+
+class _FakeRedisClient:
+    """Minimal async Redis stub for the distributed rate-limit branch."""
+
+    def __init__(self, ttl: int = 42):
+        self._counts: dict[str, int] = {}
+        self._ttl = ttl
+
+    async def incr(self, key):
+        self._counts[key] = self._counts.get(key, 0) + 1
+        return self._counts[key]
+
+    async def expire(self, key, seconds):
+        return True
+
+    async def ttl(self, key):
+        return self._ttl
+
+
+class _FakeRedisSvc:
+    def __init__(self, client):
+        self.client = client
+
+
+def _build_with_redis(middleware, redis_client, routes=None):
+    routes = routes or [Route("/x", _ok)]
+    app = Starlette(routes=routes, middleware=middleware)
+    app.state.redis = _FakeRedisSvc(redis_client)
+    return TestClient(app, raise_server_exceptions=True)
 
 
 class TestSecurityHeaders:
@@ -61,3 +102,98 @@ class TestRateLimit:
         # Far more than the limit — health must always pass through.
         for _ in range(5):
             assert client.get("/health").status_code == 200
+
+    def test_websocket_upgrade_skips_rate_limit(self):
+        # An Upgrade: websocket handshake must never be counted or blocked, even
+        # when the per-key budget is already exhausted by prior HTTP traffic.
+        client = _build(
+            [Middleware(APIRateLimitMiddleware, max_requests=1, window_seconds=60)]
+        )
+        assert client.get("/x").status_code == 200
+        assert client.get("/x").status_code == 429  # budget now exhausted
+        with client.websocket_connect("/ws") as ws:
+            assert ws.receive_text() == "ok"
+
+    def test_jwt_cookie_keys_per_user_with_ip_fallback(self, monkeypatch):
+        # Callers are bucketed by user:<sub> from the JWT cookie; a valid token
+        # for a *different* user gets its own budget, and an undecodable token
+        # falls back to the shared IP bucket.
+        def fake_decode(token):
+            if token == "bad":
+                raise ValueError("invalid token")
+            return {"sub": token}  # token string doubles as the subject
+
+        monkeypatch.setattr(auth_module, "decode_token", fake_decode)
+
+        client = _build(
+            [Middleware(APIRateLimitMiddleware, max_requests=1, window_seconds=60)]
+        )
+
+        def _get(token=None):
+            client.cookies.clear()
+            if token is not None:
+                client.cookies.set("access_token", token)
+            return client.get("/x")
+
+        # alice: first ok, second blocked (own bucket).
+        assert _get("alice").status_code == 200
+        assert _get("alice").status_code == 429
+        # bob: independent bucket, still allowed.
+        assert _get("bob").status_code == 200
+        # invalid token -> IP bucket (untouched so far) -> allowed, then blocked.
+        assert _get("bad").status_code == 200
+        assert _get("bad").status_code == 429
+
+    def test_redis_path_retry_after_from_ttl(self):
+        # When Redis backs the limiter, Retry-After echoes the key's remaining TTL.
+        redis = _FakeRedisClient(ttl=42)
+        client = _build_with_redis(
+            [Middleware(APIRateLimitMiddleware, max_requests=1, window_seconds=60)],
+            redis,
+        )
+        assert client.get("/x").status_code == 200
+        blocked = client.get("/x")
+        assert blocked.status_code == 429
+        assert blocked.headers.get("Retry-After") == "42"
+
+    def test_redis_branch_does_not_double_call_app_on_downstream_error(self):
+        # Regression for #346: a downstream 500 in the Redis branch must propagate,
+        # not be swallowed and re-dispatched (which double-checks-out a DB conn).
+        calls = {"n": 0}
+
+        def _boom(request):
+            calls["n"] += 1
+            raise RuntimeError("downstream failure")
+
+        redis = _FakeRedisClient()
+        client = _build_with_redis(
+            [Middleware(APIRateLimitMiddleware, max_requests=10, window_seconds=60)],
+            redis,
+            routes=[Route("/x", _boom)],
+        )
+        try:
+            client.get("/x")
+        except RuntimeError:
+            pass  # propagation is the expected behaviour
+        assert calls["n"] == 1  # app invoked exactly once, no re-dispatch
+
+
+class TestCombinedStack:
+    def test_429_carries_no_security_headers(self):
+        # Production order: RateLimit wraps SecurityHeaders (which wraps the app).
+        # A 429 returned by RateLimit short-circuits before SecurityHeaders runs,
+        # so the rejection response must not carry any security headers.
+        client = _build(
+            [
+                Middleware(APIRateLimitMiddleware, max_requests=1, window_seconds=60),
+                Middleware(SecurityHeadersMiddleware),
+            ]
+        )
+        ok = client.get("/x")
+        assert ok.status_code == 200
+        assert ok.headers["X-Frame-Options"] == "DENY"  # inner mw ran on success
+
+        blocked = client.get("/x")
+        assert blocked.status_code == 429
+        assert "X-Frame-Options" not in blocked.headers
+        assert "Content-Security-Policy" not in blocked.headers


### PR DESCRIPTION
## Summary
- **#346 (bug):** In `APIRateLimitMiddleware.__call__`, `await self.app()` sat inside the `try/except` that guards Redis I/O. A downstream 500 was swallowed by `except Exception: pass`, and the request fell through to the in-memory fallback which dispatched the app a **second time** (double DB checkout, original error masked). Fix: only Redis I/O (`incr`/`expire`/`ttl`) stays inside the try; the app call and the 429 response are issued outside it, so downstream errors propagate cleanly.
- **#347 (tests):** Expanded `tests/test_asgi_middleware.py` with the coverage gaps flagged in the PR #345 review.

## Test coverage added
- WebSocket-upgrade `Upgrade` header skips rate limiting (even when the budget is exhausted)
- JWT-cookie keying → `user:<sub>` via `decode_token`, with IP fallback on an undecodable token (per-user buckets are independent)
- Redis-backed path: `Retry-After` echoes the key's remaining TTL
- **#346 regression:** downstream error in the Redis branch invokes the app exactly once (no re-dispatch)
- Combined stack: a 429 from RateLimit short-circuits before SecurityHeaders and carries no security headers

## Test plan
- [x] `pytest tests/test_asgi_middleware.py -v` → 8 passed
- [x] `pytest tests/test_asgi_middleware.py tests/test_job_state.py` → 22 passed
- [ ] CI green

Fixes #346
Fixes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)