### PR TITLE
feat(brain): Hybrid semantic+keyword search for Second Brain vaults

### DIFF
--- a/orchestrator/alembic/versions/v7h1b2r3d4s5_vault_chunks_hybrid_search.py
+++ b/orchestrator/alembic/versions/v7h1b2r3d4s5_vault_chunks_hybrid_search.py
@@ -1,0 +1,54 @@
+"""vault_chunks: chunked + embedded Second Brain passages for hybrid search
+
+Adds passage-level retrieval to the Markdown Second Brain vaults, which were
+previously pure grep (no semantics). Each vault file is split into 1-3 paragraph
+chunks; every chunk gets a pgvector embedding (semantic signal) and a Postgres
+tsvector (BM25/keyword signal). Retrieval fuses both via RRF and, when the
+embedding service is disabled, falls back to the tsvector/grep path — so the
+vault stays searchable even with no embeddings (Pi-friendly).
+
+Also merges the three open heads into one.
+"""
+from alembic import op
+
+revision = "v7h1b2r3d4s5"
+down_revision = ("f1a2r3o4o5m6", "515d03f814a0", "c4d5e6f7a8b9")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS vault_chunks (
+            id           BIGSERIAL PRIMARY KEY,
+            brain_label  VARCHAR NOT NULL,
+            path         VARCHAR NOT NULL,
+            chunk_idx    INTEGER NOT NULL,
+            heading      TEXT,
+            content      TEXT NOT NULL,
+            file_hash    VARCHAR NOT NULL,
+            embedding    vector(1024),
+            ts           tsvector GENERATED ALWAYS AS (to_tsvector('simple', coalesce(content, ''))) STORED,
+            updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT uq_vault_chunk UNIQUE (brain_label, path, chunk_idx)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_vault_chunks_brain_path "
+        "ON vault_chunks (brain_label, path)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_vault_chunks_ts "
+        "ON vault_chunks USING gin (ts)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_vault_chunks_embedding "
+        "ON vault_chunks USING hnsw (embedding vector_cosine_ops)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS vault_chunks")

--- a/orchestrator/app/api/brain_mcp.py
+++ b/orchestrator/app/api/brain_mcp.py
@@ -266,11 +266,11 @@ async def _call_tool(name: str, args: dict, brain: SecondBrain, db: AsyncSession
             return _tool_result(f"File already exists: {path} (set overwrite=true to replace).", is_error=True)
         except ValueError as e:
             return _tool_result(f"Error: {e}", is_error=True)
-        logger.info("brain_write brain=%s path=%s created=%s bytes=%s", brain.slug, path, res["created"], res["bytes"])
+        logger.info("brain_write brain=%s path=%s created=%s bytes=%s", brain.slug, vault.safe_log(path), res["created"], res["bytes"])
         try:
             await vault_indexer.index_file(db, brain.label, brain.host_path, path)
         except Exception as e:  # indexing must not fail the write
-            logger.warning("brain_write reindex failed brain=%s path=%s: %s", brain.slug, path, e)
+            logger.warning("brain_write reindex failed brain=%s path=%s: %s", brain.slug, vault.safe_log(path), e)
         verb = "Created" if res["created"] else "Updated"
         return _tool_result(f"{verb} {path} in {brain.name} ({res['bytes']} bytes).")
 
@@ -286,11 +286,11 @@ async def _call_tool(name: str, args: dict, brain: SecondBrain, db: AsyncSession
             return _tool_result(f"File not found: {path}", is_error=True)
         except ValueError as e:
             return _tool_result(f"Error: {e}", is_error=True)
-        logger.info("brain_delete brain=%s path=%s", brain.slug, path)
+        logger.info("brain_delete brain=%s path=%s", brain.slug, vault.safe_log(path))
         try:
             await vault_indexer.remove_file(db, brain.label, path)
         except Exception as e:
-            logger.warning("brain_delete deindex failed brain=%s path=%s: %s", brain.slug, path, e)
+            logger.warning("brain_delete deindex failed brain=%s path=%s: %s", brain.slug, vault.safe_log(path), e)
         return _tool_result(f"Deleted {path} from {brain.name}.")
 
     return _tool_result(f"Unknown tool: {name}", is_error=True)

--- a/orchestrator/app/api/brain_mcp.py
+++ b/orchestrator/app/api/brain_mcp.py
@@ -34,6 +34,7 @@ from app.core import vault
 from app.core.encryption import decrypt_token
 from app.db.session import get_db
 from app.models.second_brain import SecondBrain
+from app.services import vault_indexer, vault_search
 
 router = APIRouter(prefix="/mcp", tags=["mcp-brain"])
 logger = logging.getLogger(__name__)
@@ -167,18 +168,18 @@ async def mcp_brain_endpoint(
     if isinstance(body, list):
         responses = []
         for req in body:
-            resp = _handle_rpc(req, brain)
+            resp = await _handle_rpc(req, brain, db)
             if resp is not None:
                 responses.append(resp)
         return JSONResponse(responses)
 
-    resp = _handle_rpc(body, brain)
+    resp = await _handle_rpc(body, brain, db)
     if resp is None:
         return JSONResponse(None, status_code=202)  # notification — no body
     return JSONResponse(resp)
 
 
-def _handle_rpc(req: dict, brain: SecondBrain):
+async def _handle_rpc(req: dict, brain: SecondBrain, db: AsyncSession):
     """Dispatch a single JSON-RPC request (or None for notifications)."""
     rpc_id = req.get("id")
     method = req.get("method", "")
@@ -201,12 +202,13 @@ def _handle_rpc(req: dict, brain: SecondBrain):
         return _mcp_result(rpc_id, {"tools": BRAIN_TOOLS})
 
     if method == "tools/call":
-        return _mcp_result(rpc_id, _call_tool(params.get("name", ""), params.get("arguments", {}), brain))
+        result = await _call_tool(params.get("name", ""), params.get("arguments", {}), brain, db)
+        return _mcp_result(rpc_id, result)
 
     return _mcp_error(rpc_id, -32601, f"Method not found: {method}")
 
 
-def _call_tool(name: str, args: dict, brain: SecondBrain) -> dict:
+async def _call_tool(name: str, args: dict, brain: SecondBrain, db: AsyncSession) -> dict:
     """Execute a vault tool and return an MCP tool result."""
     if name == "brain_search":
         query = (args.get("query") or "").strip()
@@ -216,7 +218,7 @@ def _call_tool(name: str, args: dict, brain: SecondBrain) -> dict:
             limit = min(int(float(str(args.get("limit", 10)))), 50)
         except (ValueError, TypeError):
             limit = 10
-        hits = vault.search(brain.host_path, query, limit)
+        hits = await vault_search.hybrid_search(db, brain.label, brain.host_path, query, limit)
         if not hits:
             return _tool_result(f"No matches for '{query}' in {brain.name}.")
         lines = [f"{len(hits)} match(es) in {brain.name}:"]
@@ -265,6 +267,10 @@ def _call_tool(name: str, args: dict, brain: SecondBrain) -> dict:
         except ValueError as e:
             return _tool_result(f"Error: {e}", is_error=True)
         logger.info("brain_write brain=%s path=%s created=%s bytes=%s", brain.slug, path, res["created"], res["bytes"])
+        try:
+            await vault_indexer.index_file(db, brain.label, brain.host_path, path)
+        except Exception as e:  # indexing must not fail the write
+            logger.warning("brain_write reindex failed brain=%s path=%s: %s", brain.slug, path, e)
         verb = "Created" if res["created"] else "Updated"
         return _tool_result(f"{verb} {path} in {brain.name} ({res['bytes']} bytes).")
 
@@ -281,6 +287,10 @@ def _call_tool(name: str, args: dict, brain: SecondBrain) -> dict:
         except ValueError as e:
             return _tool_result(f"Error: {e}", is_error=True)
         logger.info("brain_delete brain=%s path=%s", brain.slug, path)
+        try:
+            await vault_indexer.remove_file(db, brain.label, path)
+        except Exception as e:
+            logger.warning("brain_delete deindex failed brain=%s path=%s: %s", brain.slug, path, e)
         return _tool_result(f"Deleted {path} from {brain.name}.")
 
     return _tool_result(f"Unknown tool: {name}", is_error=True)

--- a/orchestrator/app/api/brains.py
+++ b/orchestrator/app/api/brains.py
@@ -432,7 +432,7 @@ async def brain_write_file(brain_id: int, body: BrainFileWrite, user=Depends(req
     try:
         await vault_indexer.index_file(db, brain.label, brain.host_path, body.path)
     except Exception as e:
-        log.warning("reindex after write failed brain=%s path=%s: %s", brain.slug, body.path, e)
+        log.warning("reindex after write failed brain=%s path=%s: %s", brain.slug, vault.safe_log(body.path), e)
     return {"ok": True, "path": body.path}
 
 
@@ -454,7 +454,7 @@ async def brain_delete_file(brain_id: int, path: str, user=Depends(require_auth)
     try:
         await vault_indexer.remove_file(db, brain.label, path)
     except Exception as e:
-        log.warning("deindex after delete failed brain=%s path=%s: %s", brain.slug, path, e)
+        log.warning("deindex after delete failed brain=%s path=%s: %s", brain.slug, vault.safe_log(path), e)
     return {"ok": True, "path": path}
 
 

--- a/orchestrator/app/api/brains.py
+++ b/orchestrator/app/api/brains.py
@@ -30,6 +30,7 @@ from app.dependencies import require_auth
 from app.models.audit_log import AuditEventType, AuditLog
 from app.models.second_brain import SecondBrain
 from app.models.user import UserRole
+from app.services import vault_indexer
 
 log = logging.getLogger(__name__)
 router = APIRouter(prefix="/brains", tags=["brains"])
@@ -428,6 +429,10 @@ async def brain_write_file(brain_id: int, body: BrainFileWrite, user=Depends(req
         os.chmod(target, 0o666)
     except OSError:
         pass
+    try:
+        await vault_indexer.index_file(db, brain.label, brain.host_path, body.path)
+    except Exception as e:
+        log.warning("reindex after write failed brain=%s path=%s: %s", brain.slug, body.path, e)
     return {"ok": True, "path": body.path}
 
 
@@ -446,4 +451,24 @@ async def brain_delete_file(brain_id: int, path: str, user=Depends(require_auth)
         os.rmdir(target)
     else:
         raise HTTPException(status_code=404, detail="File not found")
+    try:
+        await vault_indexer.remove_file(db, brain.label, path)
+    except Exception as e:
+        log.warning("deindex after delete failed brain=%s path=%s: %s", brain.slug, path, e)
     return {"ok": True, "path": path}
+
+
+@router.post("/{brain_id}/reindex")
+async def brain_reindex(brain_id: int, user=Depends(require_auth), db: AsyncSession = Depends(get_db)):
+    """Re-chunk + re-embed a whole vault into ``vault_chunks`` for hybrid search.
+
+    Idempotent and incremental: unchanged files are skipped (file-hash check),
+    files that vanished are pruned. Run after bulk-editing the vault on disk or
+    to backfill an existing vault the first time.
+    """
+    _require_admin(user)
+    brain = await db.get(SecondBrain, brain_id)
+    if not brain:
+        raise HTTPException(status_code=404, detail="Brain not found")
+    stats = await vault_indexer.reindex_vault(db, brain.label, brain.host_path)
+    return {"ok": True, "brain": brain.slug, **stats}

--- a/orchestrator/app/core/chunking.py
+++ b/orchestrator/app/core/chunking.py
@@ -154,8 +154,15 @@ def chunk_markdown(text: str) -> list[Chunk]:
             cur_heading = _heading_path(heading_stack)
             continue
 
-        # code or para
         blen = len(btext)
+        # Oversized code blocks must never be hard-split (would produce unbalanced fences).
+        if kind == "code" and blen > MAX_CHARS:
+            emit()
+            if any(ch.isalnum() for ch in btext):
+                chunks.append(Chunk(index=len(chunks), heading=cur_heading, content=btext))
+            continue
+
+        # code (small) or para
         if cur_len and cur_len + blen > TARGET_CHARS:
             emit()
         cur_parts.append(btext)

--- a/orchestrator/app/core/chunking.py
+++ b/orchestrator/app/core/chunking.py
@@ -1,0 +1,170 @@
+"""Markdown-aware chunking for Second Brain vault indexing.
+
+Pure, dependency-free, unit-testable. Splits a Markdown document into
+passage-sized chunks (1-3 paragraphs) so retrieval can return the relevant
+*passage* instead of the whole file — the missing "chunking" layer from the
+RAG maturity model (Naive -> Advanced -> Agentic).
+
+Design goals:
+  * Never split in the middle of a fenced code block (``` ... ```).
+  * Prefer splitting on Markdown headings, then on blank-line paragraph breaks.
+  * Keep the nearest preceding heading as lightweight context on every chunk so
+    a passage stays interpretable on its own.
+  * Deterministic: same input -> same chunks (important for incremental
+    re-indexing keyed on a content hash).
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+_FENCE_RE = re.compile(r"^(```|~~~)")
+
+# Target sizes in characters. A "chunk" is 1-3 paragraphs; we merge small
+# paragraphs up to TARGET and hard-split anything above MAX.
+TARGET_CHARS = 900
+MAX_CHARS = 1400
+
+
+@dataclass
+class Chunk:
+    """One retrievable passage of a vault file."""
+
+    index: int
+    heading: str  # nearest preceding heading path, e.g. "Drucker > Fehlercodes"
+    content: str  # the passage text (without the injected heading)
+
+    @property
+    def embed_text(self) -> str:
+        """Text handed to the embedding model — heading gives context."""
+        if self.heading:
+            return f"{self.heading}\n\n{self.content}"
+        return self.content
+
+
+def _split_blocks(text: str) -> list[tuple[str, str]]:
+    """Split raw markdown into (kind, text) blocks.
+
+    kind is one of: 'heading', 'code', 'para'. Fenced code blocks are kept
+    intact as a single block so they never get cut mid-fence.
+    """
+    lines = text.splitlines()
+    blocks: list[tuple[str, str]] = []
+    buf: list[str] = []
+    in_fence = False
+    fence_marker = ""
+
+    def flush_para() -> None:
+        if buf:
+            chunk = "\n".join(buf).strip()
+            if chunk:
+                blocks.append(("para", chunk))
+            buf.clear()
+
+    for line in lines:
+        fence = _FENCE_RE.match(line.strip())
+        if in_fence:
+            buf.append(line)
+            if line.strip().startswith(fence_marker):
+                blocks.append(("code", "\n".join(buf)))
+                buf.clear()
+                in_fence = False
+            continue
+        if fence:
+            flush_para()
+            fence_marker = fence.group(1)
+            buf.append(line)
+            in_fence = True
+            continue
+        if _HEADING_RE.match(line):
+            flush_para()
+            blocks.append(("heading", line))
+            continue
+        if line.strip() == "":
+            flush_para()
+            continue
+        buf.append(line)
+
+    if in_fence:  # unterminated fence — keep what we have
+        blocks.append(("code", "\n".join(buf)))
+    else:
+        flush_para()
+    return blocks
+
+
+def _heading_path(stack: list[tuple[int, str]]) -> str:
+    return " > ".join(title for _, title in stack)
+
+
+def _hard_split(content: str, max_chars: int) -> list[str]:
+    """Split an oversized block on paragraph/sentence/line boundaries."""
+    if len(content) <= max_chars:
+        return [content]
+    parts: list[str] = []
+    remaining = content
+    while len(remaining) > max_chars:
+        window = remaining[:max_chars]
+        cut = max(window.rfind("\n\n"), window.rfind(". "), window.rfind("\n"))
+        if cut < max_chars // 2:
+            cut = max_chars  # no good boundary — hard cut
+        parts.append(remaining[:cut].strip())
+        remaining = remaining[cut:].strip()
+    if remaining:
+        parts.append(remaining)
+    return [p for p in parts if p]
+
+
+def chunk_markdown(text: str) -> list[Chunk]:
+    """Chunk a Markdown document into passage-sized :class:`Chunk` objects."""
+    if not text or not text.strip():
+        return []
+
+    blocks = _split_blocks(text)
+    heading_stack: list[tuple[int, str]] = []
+    chunks: list[Chunk] = []
+    cur_parts: list[str] = []
+    cur_len = 0
+    cur_heading = ""
+
+    def emit() -> None:
+        nonlocal cur_parts, cur_len
+        if not cur_parts:
+            return
+        body = "\n\n".join(cur_parts).strip()
+        cur_parts = []
+        cur_len = 0
+        # Drop pure noise (horizontal rules, stray punctuation) but keep short
+        # real passages — a two-line note is still worth retrieving.
+        if not any(ch.isalnum() for ch in body):
+            return
+        for piece in _hard_split(body, MAX_CHARS):
+            if any(ch.isalnum() for ch in piece):
+                chunks.append(Chunk(index=len(chunks), heading=cur_heading, content=piece))
+
+    for kind, btext in blocks:
+        if kind == "heading":
+            emit()
+            m = _HEADING_RE.match(btext)
+            level = len(m.group(1))
+            title = m.group(2).strip()
+            while heading_stack and heading_stack[-1][0] >= level:
+                heading_stack.pop()
+            heading_stack.append((level, title))
+            cur_heading = _heading_path(heading_stack)
+            continue
+
+        # code or para
+        blen = len(btext)
+        if cur_len and cur_len + blen > TARGET_CHARS:
+            emit()
+        cur_parts.append(btext)
+        cur_len += blen
+        if cur_len >= TARGET_CHARS:
+            emit()
+
+    emit()
+    # renumber to be safe (hard_split may have added extras)
+    for i, c in enumerate(chunks):
+        c.index = i
+    return chunks

--- a/orchestrator/app/core/rrf.py
+++ b/orchestrator/app/core/rrf.py
@@ -1,0 +1,54 @@
+"""Reciprocal Rank Fusion (RRF) for hybrid retrieval.
+
+Pure, dependency-free, unit-testable. Fuses several ranked result lists
+(e.g. semantic/vector search + keyword/BM25 search) into one ranking without
+needing the individual scores to be on a comparable scale — the standard
+"Advanced RAG" fusion step.
+
+RRF score for an item = sum over each list of 1 / (k + rank), where rank is the
+0-based position of the item in that list. k (default 60) damps the influence
+of very high ranks; it is the value from the original Cormack et al. paper.
+"""
+from __future__ import annotations
+
+from collections.abc import Hashable, Sequence
+
+DEFAULT_K = 60
+
+
+def reciprocal_rank_fusion(
+    ranked_lists: Sequence[Sequence[Hashable]],
+    *,
+    k: int = DEFAULT_K,
+    weights: Sequence[float] | None = None,
+) -> list[tuple[Hashable, float]]:
+    """Fuse ranked lists of item keys into one ``(key, score)`` ranking.
+
+    Args:
+        ranked_lists: each inner sequence is a list of item keys ordered best
+            -> worst. Keys must be hashable and comparable across lists (use the
+            same id for the same item in every list).
+        k: RRF damping constant (default 60).
+        weights: optional per-list weight (e.g. trust semantic more than
+            keyword). Defaults to 1.0 for every list.
+
+    Returns:
+        ``(key, fused_score)`` tuples sorted by descending score. Ties are
+        broken deterministically by the key's first-seen order.
+    """
+    if weights is None:
+        weights = [1.0] * len(ranked_lists)
+    if len(weights) != len(ranked_lists):
+        raise ValueError("weights length must match number of ranked_lists")
+
+    scores: dict[Hashable, float] = {}
+    first_seen: dict[Hashable, int] = {}
+    order = 0
+    for lst, weight in zip(ranked_lists, weights):
+        for rank, key in enumerate(lst):
+            scores[key] = scores.get(key, 0.0) + weight * (1.0 / (k + rank))
+            if key not in first_seen:
+                first_seen[key] = order
+                order += 1
+
+    return sorted(scores.items(), key=lambda kv: (-kv[1], first_seen[kv[0]]))

--- a/orchestrator/app/core/vault.py
+++ b/orchestrator/app/core/vault.py
@@ -33,6 +33,12 @@ _HEADING_RE = re.compile(r"^\s{0,3}#\s+(.+?)\s*$", re.MULTILINE)
 MAX_GRAPH_NODES = 2000
 
 
+def safe_log(value: object) -> str:
+    """Strip CR/LF (and other control chars) from a user-controlled value before
+    it is written to a log line, preventing log-forging / log-injection."""
+    return re.sub(r"[\x00-\x1f\x7f]", " ", str(value))
+
+
 def resolve_path(host_path: str, rel_path: str) -> str:
     """Resolve a vault-relative path to an absolute host path, jailed to the
     vault root and never touching ``.git``. Raises ``ValueError`` on escape."""

--- a/orchestrator/app/models/__init__.py
+++ b/orchestrator/app/models/__init__.py
@@ -38,6 +38,7 @@ from app.models.user_mount_access import UserMountAccess
 from app.models.custom_role import CustomRole
 from app.models.ai_account import AIAccount
 from app.models.second_brain import SecondBrain
+from app.models.vault_chunk import VaultChunk
 from app.models.job_state import JobState
 from app.models.reflection_run import ReflectionRun
 
@@ -65,6 +66,7 @@ __all__ = [
     "UserProfile", "UserProfileEvent",
     "AgentSecret", "AgentSecretAssignment", "SecretType",
     "UserMountAccess", "CustomRole", "AIAccount", "SecondBrain",
+    "VaultChunk",
     "JobState",
     "ReflectionRun",
 ]

--- a/orchestrator/app/models/vault_chunk.py
+++ b/orchestrator/app/models/vault_chunk.py
@@ -1,0 +1,43 @@
+"""VaultChunk — a chunked, embedded passage of a Second Brain Markdown file.
+
+Bridges the two previously disconnected knowledge layers: the plain-Markdown
+Second Brain vaults (grep-only) and the pgvector semantic layer. Each vault file
+is split into passage-sized chunks (see ``app.core.chunking``); every chunk
+carries a pgvector embedding for semantic search and a Postgres ``tsvector`` for
+keyword/BM25 search. Retrieval fuses both signals via Reciprocal Rank Fusion.
+
+The ``embedding`` (vector(1024)) and ``ts`` (generated tsvector) columns are
+managed in raw SQL by the migration — matching how ``knowledge_entries`` /
+``agent_memories`` handle their pgvector columns — so they are intentionally not
+declared as ORM attributes here.
+"""
+from datetime import datetime, timezone
+
+from sqlalchemy import Integer, String, Text, UniqueConstraint, DateTime
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class VaultChunk(Base):
+    __tablename__ = "vault_chunks"
+    __table_args__ = (
+        UniqueConstraint("brain_label", "path", "chunk_idx", name="uq_vault_chunk"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    # Which vault (SecondBrain.label) and which file inside it.
+    brain_label: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    path: Mapped[str] = mapped_column(String, nullable=False)  # vault-relative file path
+    chunk_idx: Mapped[int] = mapped_column(Integer, nullable=False)
+    heading: Mapped[str | None] = mapped_column(Text, nullable=True)  # nearest heading path
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    # Hash of the whole source file — lets the indexer skip unchanged files and
+    # replace all chunks of a file atomically when it changes.
+    file_hash: Mapped[str] = mapped_column(String, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )

--- a/orchestrator/app/services/vault_indexer.py
+++ b/orchestrator/app/services/vault_indexer.py
@@ -1,0 +1,168 @@
+"""Vault indexer — chunk + embed Second Brain Markdown files into ``vault_chunks``.
+
+Walks a vault, splits each Markdown/text file into passages
+(:func:`app.core.chunking.chunk_markdown`), embeds them in a batch, and upserts
+the rows keyed on a per-file content hash so unchanged files are skipped on
+re-index. This is the "indexing" phase of the RAG pipeline; retrieval lives in
+:mod:`app.services.vault_search`.
+
+Embedding is best-effort: if the embedding service is disabled (e.g. on the Pi),
+chunks are still written *without* a vector, so keyword/tsvector search keeps
+working. Semantic search lights up automatically once embeddings are available
+and a re-index runs.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+
+from sqlalchemy import text as sa_text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core import vault
+from app.core.chunking import chunk_markdown
+
+logger = logging.getLogger(__name__)
+
+_SEARCHABLE_SUFFIXES = (".md", ".markdown", ".txt")
+
+
+def _file_hash(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8", errors="replace")).hexdigest()
+
+
+def _iter_files(base: str):
+    for root, dirs, files in os.walk(base):
+        dirs[:] = [d for d in dirs if d != ".git"]
+        for f in files:
+            if f.lower().endswith(_SEARCHABLE_SUFFIXES):
+                full = os.path.join(root, f)
+                yield full, os.path.relpath(full, base)
+
+
+async def _embed_chunks(texts: list[str]) -> list[list[float] | None]:
+    """Embed chunk texts, tolerating a disabled/failed embedding service."""
+    if not texts:
+        return []
+    try:
+        from app.services.embedding_service import get_embedding_service
+
+        svc = get_embedding_service()
+        return await svc.embed_batch(texts)
+    except Exception as e:  # never let embedding break indexing
+        logger.warning("[VaultIndexer] embedding unavailable, indexing without vectors: %s", e)
+        return [None] * len(texts)
+
+
+async def index_file(
+    db: AsyncSession, brain_label: str, host_path: str, rel_path: str
+) -> int:
+    """(Re)index a single vault file. Returns the number of chunks written."""
+    try:
+        content = vault.read_file(host_path, rel_path)
+    except (FileNotFoundError, ValueError):
+        await remove_file(db, brain_label, rel_path)
+        return 0
+
+    fhash = _file_hash(content)
+    existing = (
+        await db.execute(
+            sa_text(
+                "SELECT file_hash FROM vault_chunks "
+                "WHERE brain_label = :b AND path = :p LIMIT 1"
+            ),
+            {"b": brain_label, "p": rel_path},
+        )
+    ).first()
+    if existing and existing[0] == fhash:
+        return 0  # unchanged
+
+    chunks = chunk_markdown(content)
+    # Replace all chunks of this file atomically.
+    await db.execute(
+        sa_text("DELETE FROM vault_chunks WHERE brain_label = :b AND path = :p"),
+        {"b": brain_label, "p": rel_path},
+    )
+    if not chunks:
+        await db.commit()
+        return 0
+
+    vectors = await _embed_chunks([c.embed_text for c in chunks])
+    for c, vec in zip(chunks, vectors):
+        params = {
+            "b": brain_label,
+            "p": rel_path,
+            "i": c.index,
+            "h": c.heading or None,
+            "c": c.content,
+            "fh": fhash,
+        }
+        if vec is not None:
+            params["emb"] = str(vec)
+            await db.execute(
+                sa_text(
+                    "INSERT INTO vault_chunks "
+                    "(brain_label, path, chunk_idx, heading, content, file_hash, embedding) "
+                    "VALUES (:b, :p, :i, :h, :c, :fh, CAST(:emb AS vector))"
+                ),
+                params,
+            )
+        else:
+            await db.execute(
+                sa_text(
+                    "INSERT INTO vault_chunks "
+                    "(brain_label, path, chunk_idx, heading, content, file_hash) "
+                    "VALUES (:b, :p, :i, :h, :c, :fh)"
+                ),
+                params,
+            )
+    await db.commit()
+    return len(chunks)
+
+
+async def remove_file(db: AsyncSession, brain_label: str, rel_path: str) -> None:
+    """Drop all chunks for a deleted vault file."""
+    await db.execute(
+        sa_text("DELETE FROM vault_chunks WHERE brain_label = :b AND path = :p"),
+        {"b": brain_label, "p": rel_path},
+    )
+    await db.commit()
+
+
+async def reindex_vault(
+    db: AsyncSession, brain_label: str, host_path: str
+) -> dict[str, int]:
+    """Full (incremental) re-index of a vault. Returns simple stats.
+
+    Prunes chunks whose source file no longer exists, then indexes every file
+    (unchanged files are skipped via the file-hash check).
+    """
+    base = os.path.realpath(host_path)
+    if not os.path.isdir(base):
+        return {"files": 0, "chunks": 0, "pruned": 0}
+
+    present = {rel for _, rel in _iter_files(base)}
+
+    known = (
+        await db.execute(
+            sa_text("SELECT DISTINCT path FROM vault_chunks WHERE brain_label = :b"),
+            {"b": brain_label},
+        )
+    ).scalars().all()
+    pruned = 0
+    for stale in set(known) - present:
+        await remove_file(db, brain_label, stale)
+        pruned += 1
+
+    files = chunks = 0
+    for rel in present:
+        n = await index_file(db, brain_label, host_path, rel)
+        if n:
+            files += 1
+            chunks += n
+    logger.info(
+        "[VaultIndexer] reindexed brain=%s files=%s chunks=%s pruned=%s",
+        brain_label, files, chunks, pruned,
+    )
+    return {"files": files, "chunks": chunks, "pruned": pruned}

--- a/orchestrator/app/services/vault_indexer.py
+++ b/orchestrator/app/services/vault_indexer.py
@@ -76,7 +76,20 @@ async def index_file(
         )
     ).first()
     if existing and existing[0] == fhash:
-        return 0  # unchanged
+        # File unchanged; but back-fill embeddings that were skipped when the
+        # embedding service was unavailable during a prior index run.
+        has_null = (
+            await db.execute(
+                sa_text(
+                    "SELECT 1 FROM vault_chunks "
+                    "WHERE brain_label = :b AND path = :p AND embedding IS NULL LIMIT 1"
+                ),
+                {"b": brain_label, "p": rel_path},
+            )
+        ).first()
+        if not has_null:
+            return 0  # unchanged and fully embedded
+        # Fall through: re-index to fill missing embeddings.
 
     chunks = chunk_markdown(content)
     # Replace all chunks of this file atomically.
@@ -155,14 +168,18 @@ async def reindex_vault(
         await remove_file(db, brain_label, stale)
         pruned += 1
 
-    files = chunks = 0
+    files = chunks = errors = 0
     for rel in present:
-        n = await index_file(db, brain_label, host_path, rel)
-        if n:
-            files += 1
-            chunks += n
+        try:
+            n = await index_file(db, brain_label, host_path, rel)
+            if n:
+                files += 1
+                chunks += n
+        except Exception:
+            logger.warning("[VaultIndexer] skipping %s due to error", rel, exc_info=True)
+            errors += 1
     logger.info(
-        "[VaultIndexer] reindexed brain=%s files=%s chunks=%s pruned=%s",
-        brain_label, files, chunks, pruned,
+        "[VaultIndexer] reindexed brain=%s files=%s chunks=%s pruned=%s errors=%s",
+        brain_label, files, chunks, pruned, errors,
     )
-    return {"files": files, "chunks": chunks, "pruned": pruned}
+    return {"files": files, "chunks": chunks, "pruned": pruned, "errors": errors}

--- a/orchestrator/app/services/vault_search.py
+++ b/orchestrator/app/services/vault_search.py
@@ -1,0 +1,158 @@
+"""Hybrid retrieval over the Second Brain vault chunks.
+
+Fuses two signals with Reciprocal Rank Fusion:
+  * semantic  — pgvector cosine distance over chunk embeddings, and
+  * keyword    — Postgres full-text (tsvector/``websearch_to_tsquery`` + ``ts_rank_cd``),
+which upgrades the old substring grep to real BM25-style ranking.
+
+Graceful degradation (Pi-friendly):
+  * embeddings disabled/unavailable  -> keyword (FTS) only,
+  * vault not indexed yet (no chunks) -> pure grep via :func:`app.core.vault.search`.
+
+Returns the same shape as ``vault.search`` — ``[{path, score, snippets}]`` — so
+the MCP ``brain_search`` handler formats results unchanged.
+"""
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import text as sa_text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core import vault
+from app.core.rrf import reciprocal_rank_fusion
+
+logger = logging.getLogger(__name__)
+
+# How many candidates to pull from each signal before fusion.
+_CANDIDATES = 30
+# Trust semantic a bit more than keyword when both fire (Advanced-RAG default).
+_WEIGHTS = (1.3, 1.0)
+
+
+async def _has_chunks(db: AsyncSession, brain_label: str) -> bool:
+    row = (
+        await db.execute(
+            sa_text("SELECT 1 FROM vault_chunks WHERE brain_label = :b LIMIT 1"),
+            {"b": brain_label},
+        )
+    ).first()
+    return row is not None
+
+
+async def _semantic_ids(
+    db: AsyncSession, brain_label: str, query: str
+) -> list[int]:
+    try:
+        from app.services.embedding_service import get_embedding_service
+
+        qvec = await get_embedding_service().embed(query)
+    except Exception as e:
+        logger.warning("[VaultSearch] embed failed, semantic skipped: %s", e)
+        qvec = None
+    if not qvec:
+        return []
+    rows = (
+        await db.execute(
+            sa_text(
+                "SELECT id FROM vault_chunks "
+                "WHERE brain_label = :b AND embedding IS NOT NULL "
+                "ORDER BY embedding <=> CAST(:qv AS vector) ASC "
+                "LIMIT :lim"
+            ),
+            {"b": brain_label, "qv": str(qvec), "lim": _CANDIDATES},
+        )
+    ).scalars().all()
+    return list(rows)
+
+
+async def _keyword_ids(
+    db: AsyncSession, brain_label: str, query: str
+) -> list[int]:
+    rows = (
+        await db.execute(
+            sa_text(
+                "SELECT id FROM vault_chunks "
+                "WHERE brain_label = :b "
+                "AND ts @@ websearch_to_tsquery('simple', :q) "
+                "ORDER BY ts_rank_cd(ts, websearch_to_tsquery('simple', :q)) DESC "
+                "LIMIT :lim"
+            ),
+            {"b": brain_label, "q": query, "lim": _CANDIDATES},
+        )
+    ).scalars().all()
+    return list(rows)
+
+
+def _snippets(content: str, query: str, max_lines: int = 3) -> list[str]:
+    terms = [t for t in query.lower().split() if t]
+    out: list[str] = []
+    for line in content.splitlines():
+        low = line.lower()
+        if any(t in low for t in terms):
+            s = line.strip()
+            if s:
+                out.append(s[:240])
+            if len(out) >= max_lines:
+                break
+    if not out:  # semantic-only hit — show the passage head
+        head = content.strip().splitlines()
+        out = [ln.strip()[:240] for ln in head[:2] if ln.strip()]
+    return out
+
+
+async def hybrid_search(
+    db: AsyncSession, brain_label: str, host_path: str, query: str, limit: int = 10
+) -> list[dict]:
+    """Hybrid semantic+keyword search over a vault, grep as last-resort fallback."""
+    query = (query or "").strip()
+    if not query:
+        return []
+
+    if not await _has_chunks(db, brain_label):
+        # Not indexed yet — keep the vault searchable with plain grep.
+        return vault.search(host_path, query, limit)
+
+    semantic = await _semantic_ids(db, brain_label, query)
+    keyword = await _keyword_ids(db, brain_label, query)
+
+    if not semantic and not keyword:
+        return vault.search(host_path, query, limit)
+
+    fused = reciprocal_rank_fusion([semantic, keyword], weights=list(_WEIGHTS))
+    fused_ids = [cid for cid, _ in fused]
+    if not fused_ids:
+        return vault.search(host_path, query, limit)
+
+    rows = (
+        await db.execute(
+            sa_text(
+                "SELECT id, path, heading, content FROM vault_chunks WHERE id = ANY(:ids)"
+            ),
+            {"ids": fused_ids},
+        )
+    ).all()
+    by_id = {r.id: r for r in rows}
+
+    # Fuse chunk ranking up to file level: a file's score is its best chunk's
+    # fused score; keep the best passage as the snippet source.
+    file_rank: dict[str, float] = {}
+    file_best: dict[str, object] = {}
+    for cid, score in fused:
+        r = by_id.get(cid)
+        if r is None:
+            continue
+        if r.path not in file_rank or score > file_rank[r.path]:
+            file_rank[r.path] = score
+            file_best[r.path] = r
+
+    ordered = sorted(file_rank.items(), key=lambda kv: kv[1], reverse=True)[:limit]
+    results: list[dict] = []
+    for path, score in ordered:
+        r = file_best[path]
+        heading = f"{r.heading}: " if r.heading else ""
+        snips = _snippets(r.content, query)
+        if heading and snips:
+            snips[0] = heading + snips[0]
+        results.append({"path": path, "score": round(score, 6), "snippets": snips})
+    return results

--- a/orchestrator/tests/test_vault_chunking_rrf.py
+++ b/orchestrator/tests/test_vault_chunking_rrf.py
@@ -1,0 +1,96 @@
+"""Tests for the pure chunking and RRF helpers (hybrid vault search)."""
+from app.core.chunking import chunk_markdown, TARGET_CHARS, MAX_CHARS
+from app.core.rrf import reciprocal_rank_fusion
+
+
+class TestChunkMarkdown:
+    def test_empty(self):
+        assert chunk_markdown("") == []
+        assert chunk_markdown("   \n  \n") == []
+
+    def test_single_paragraph(self):
+        chunks = chunk_markdown("Ein einfacher Absatz über Drucker.")
+        assert len(chunks) == 1
+        assert "Drucker" in chunks[0].content
+        assert chunks[0].index == 0
+
+    def test_heading_becomes_context(self):
+        md = "# Drucker\n\n## Fehlercodes\n\nDer Code x17137 bedeutet Papierstau."
+        chunks = chunk_markdown(md)
+        assert len(chunks) == 1
+        assert chunks[0].heading == "Drucker > Fehlercodes"
+        assert "x17137" in chunks[0].content
+        assert "Drucker > Fehlercodes" in chunks[0].embed_text
+
+    def test_heading_stack_pops_siblings(self):
+        md = (
+            "# A\n\n## B\n\n" + "Inhalt B. " * 60 + "\n\n## C\n\n" + "Inhalt C. " * 60
+        )
+        chunks = chunk_markdown(md)
+        headings = {c.heading for c in chunks}
+        assert "A > B" in headings
+        assert "A > C" in headings
+
+    def test_code_block_not_split(self):
+        code = "```python\n" + "\n".join(f"line_{i} = {i}" for i in range(80)) + "\n```"
+        md = f"# Code\n\n{code}"
+        chunks = chunk_markdown(md)
+        joined = "\n".join(c.content for c in chunks)
+        assert "```python" in joined
+        # the fence must stay attached to its opening in one chunk
+        for c in chunks:
+            assert c.content.count("```") % 2 == 0 or "```" not in c.content or True
+
+    def test_large_document_splits(self):
+        md = "# Big\n\n" + ("Ein Absatz mit Text. " * 20 + "\n\n") * 20
+        chunks = chunk_markdown(md)
+        assert len(chunks) > 1
+        for c in chunks:
+            assert len(c.content) <= MAX_CHARS
+
+    def test_deterministic(self):
+        md = "# T\n\n" + ("Absatz. " * 30 + "\n\n") * 10
+        a = chunk_markdown(md)
+        b = chunk_markdown(md)
+        assert [c.content for c in a] == [c.content for c in b]
+
+    def test_indices_sequential(self):
+        md = "# T\n\n" + ("Absatz Text hier. " * 30 + "\n\n") * 8
+        chunks = chunk_markdown(md)
+        assert [c.index for c in chunks] == list(range(len(chunks)))
+
+
+class TestRRF:
+    def test_empty(self):
+        assert reciprocal_rank_fusion([]) == []
+        assert reciprocal_rank_fusion([[], []]) == []
+
+    def test_single_list_preserves_order(self):
+        res = reciprocal_rank_fusion([["a", "b", "c"]])
+        assert [k for k, _ in res] == ["a", "b", "c"]
+
+    def test_agreement_boosts_item(self):
+        # "b" appears high in both lists -> should win
+        res = reciprocal_rank_fusion([["a", "b", "c"], ["b", "d", "e"]])
+        assert res[0][0] == "b"
+
+    def test_scores_descending(self):
+        res = reciprocal_rank_fusion([["a", "b"], ["b", "a"]])
+        scores = [s for _, s in res]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_weights_shift_ranking(self):
+        lists = [["x", "y"], ["y", "x"]]
+        weighted = reciprocal_rank_fusion(lists, weights=[5.0, 1.0])
+        assert weighted[0][0] == "x"
+
+    def test_k_constant(self):
+        res = reciprocal_rank_fusion([["a"]], k=60)
+        assert abs(res[0][1] - (1.0 / 60)) < 1e-9
+
+    def test_weights_length_mismatch_raises(self):
+        try:
+            reciprocal_rank_fusion([["a"]], weights=[1.0, 2.0])
+            assert False, "expected ValueError"
+        except ValueError:
+            pass

--- a/orchestrator/tests/test_vault_chunking_rrf.py
+++ b/orchestrator/tests/test_vault_chunking_rrf.py
@@ -37,9 +37,20 @@ class TestChunkMarkdown:
         chunks = chunk_markdown(md)
         joined = "\n".join(c.content for c in chunks)
         assert "```python" in joined
-        # the fence must stay attached to its opening in one chunk
+        # every chunk must have balanced fence markers
         for c in chunks:
-            assert c.content.count("```") % 2 == 0 or "```" not in c.content or True
+            assert c.content.count("```") % 2 == 0 or "```" not in c.content
+
+    def test_large_code_fence_not_split(self):
+        # A code fence longer than MAX_CHARS must be emitted as one chunk — never hard-split.
+        long_code = "```python\n" + "\n".join(f"result_{i} = i * {i}" for i in range(120)) + "\n```"
+        assert len(long_code) > MAX_CHARS
+        md = f"# Big Fence\n\n{long_code}"
+        chunks = chunk_markdown(md)
+        fence_chunks = [c for c in chunks if "```" in c.content]
+        # The entire fence must appear in exactly one chunk with balanced markers.
+        assert len(fence_chunks) == 1
+        assert fence_chunks[0].content.count("```") % 2 == 0
 
     def test_large_document_splits(self):
         md = "# Big\n\n" + ("Ein Absatz mit Text. " * 20 + "\n\n") * 20


### PR DESCRIPTION
## Warum

Die **Second Brain Vaults** (die geteilten Markdown-Wissensdatenbanken unter `/mnt/brains/<slug>`) waren bisher **reines Grep**: `os.walk` + Substring-Match (`vault.search`), komplett getrennt von der pgvector-Semantik-Schicht der DB. Genau der „Grep-Ansatz", den moderne RAG-Systeme hinter sich lassen — keine Bedeutungssuche, kein Ranking, kein Passagen-Retrieval.

Dieser PR verbindet die beiden Wissensschichten und hebt die Vault-Suche auf **Advanced-RAG-Niveau** (Hybrid = Semantik + Stichwort, fusioniert per RRF), **ohne** die robuste Grep-Basis zu verlieren.

## Was

**Reine, getestete Logik**
- `core/chunking.py` — Markdown-bewusster Chunker (1–3 Absätze; Code-Fences bleiben intakt; nächste Überschrift wird als Kontext mitgeführt). Deterministisch.
- `core/rrf.py` — Reciprocal Rank Fusion zum Verschmelzen von Semantik- + Stichwort-Ranking.

**Speicher & Index**
- `models/vault_chunk.py` + Migration — Tabelle `vault_chunks` mit `embedding vector(1024)` + generierter `tsvector`, HNSW- + GIN-Index. Die Migration **merged außerdem die drei offenen Alembic-Heads**.
- `services/vault_indexer.py` — chunk → Batch-Embed → inkrementeller Upsert (per File-Hash; unveränderte Dateien werden übersprungen, verschwundene geprunt). Embedding ist *best-effort*: fehlt der Embedding-Service, werden Chunks **ohne** Vektor geschrieben.

**Retrieval**
- `services/vault_search.py` — `hybrid_search` = pgvector-Cosine **+** Postgres-FTS (`websearch_to_tsquery`/`ts_rank_cd`), per RRF fusioniert und auf Datei-Ebene gruppiert.
  - **Graceful degradation:** nur FTS wenn Embeddings aus sind → reines Grep wenn ein Vault noch nicht indexiert ist. Der MCP-Endpoint funktioniert also immer.

**Verdrahtung**
- `brain_mcp.py` — async-Refactor (DB-Session durchgereicht); `brain_search` nutzt jetzt `hybrid_search`; `brain_write`/`brain_delete` halten den Index synchron.
- `brains.py` — Index-Sync bei Admin-Write/Delete + neuer `POST /brains/{id}/reindex` zum Backfill bestehender Vaults.

## Reifegrad-Sprung

| | vorher | nachher |
|---|---|---|
| Suche | Substring-Grep | Semantik + BM25/FTS, RRF-fusioniert |
| Einheit | ganze Datei | Passage (Chunk) |
| Fallback | – | FTS → Grep (immer nutzbar) |

## Test

- [x] `tests/test_vault_chunking_rrf.py` — 15 Tests für Chunking + RRF (lokal grün).
- [ ] DB-abhängige Pfade (pgvector/FTS) sind geschrieben, aber in dieser Umgebung **nicht live getestet** (kein Postgres+pgvector zur Hand). Nach dem Merge: Migration fahren, dann `POST /brains/{id}/reindex` je Vault, dann `brain_search` prüfen.

## Hinweis / Follow-up

Der Pi-schonende **Embedding-Backend-Switch (Model2Vec)** ist bewusst **nicht** Teil dieses PRs — er ist eine separate Änderung am `embedding-service` und war ausdrücklich als Hardware-Thema abgegrenzt. Diese Lösung funktioniert schon heute über den vorhandenen OpenAI-Fallback bzw. rein per FTS, wenn der Embedding-Service aus ist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)