### PR TITLE
Fix #354: hoist import time to module level in main.py

### DIFF
--- a/orchestrator/app/main.py
+++ b/orchestrator/app/main.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import os
+import time
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 
@@ -85,8 +86,6 @@ class APIRateLimitMiddleware:
         self._fallback: dict[str, list[float]] = {}
 
     async def __call__(self, scope, receive, send):
-        import time
-
         if scope["type"] != "http":
             await self.app(scope, receive, send)
             return


### PR DESCRIPTION
## Summary
Moves `import time` from inside `APIRateLimitMiddleware.__call__` to the module-level import block in `orchestrator/app/main.py`.

Carry-over style fix flagged during the PR #345 review (W1, deferred) and re-confirmed in the PR #348 review.

## Details
- `time` was only used at one call site (`now = time.time()`) inside `__call__`; the local import obscured the dependency and violated PEP8/isort conventions.
- Added `import time` to the top-of-file stdlib import group (after `os`).
- Removed the in-method `import time`.

## Verification
- `python3 -m py_compile orchestrator/app/main.py` → OK
- `pytest tests/test_asgi_middleware.py` → 8 passed

Fixes #354