### PR TITLE
Fix #356: retry DB connect in background sweeps (resilient_session)

### DIFF
--- a/orchestrator/app/db/session.py
+++ b/orchestrator/app/db/session.py
@@ -42,21 +42,26 @@ async def resilient_session(
     exponential backoff + jitter, so a brief DB blip (connect timeout / refused)
     doesn't kill an entire background sweep tick (see #356).
 
+    A true drop-in for ``async with factory() as db``: it uses the session's
+    async-context protocol, so ``session_factory`` is the usual
+    ``async_session_factory`` (or any callable returning an async-context session).
+
     Only the connect/checkout is retried: the session is forced live up-front via
-    a ``SELECT 1`` pre-ping, so a connect-level ``TimeoutError`` surfaces here —
-    where it can be retried — instead of deep inside the sweep body. Once the
-    connection is live it is handed to the caller unchanged; exceptions raised
-    *inside* the ``async with resilient_session()`` body are NOT retried and
-    propagate normally.
+    a ``SELECT 1`` pre-ping, so a connect-level ``TimeoutError`` surfaces before
+    the ``yield`` — where it can be retried — instead of deep inside the sweep
+    body. Once the connection is live it is handed to the caller unchanged;
+    exceptions raised *inside* the ``async with resilient_session()`` body are
+    NOT retried and propagate normally.
     """
     factory = session_factory or async_session_factory
     attempt = 0
     while True:
-        session = factory()
+        cm = factory()
+        session = await cm.__aenter__()
         try:
             await session.execute(sa_text("SELECT 1"))
         except Exception as e:
-            await session.close()
+            await cm.__aexit__(type(e), e, e.__traceback__)
             attempt += 1
             if attempt > retries:
                 raise
@@ -69,8 +74,11 @@ async def resilient_session(
             continue
         try:
             yield session
-        finally:
-            await session.close()
+        except BaseException as e:
+            await cm.__aexit__(type(e), e, e.__traceback__)
+            raise
+        else:
+            await cm.__aexit__(None, None, None)
         return
 
 

--- a/orchestrator/app/db/session.py
+++ b/orchestrator/app/db/session.py
@@ -1,9 +1,20 @@
-from collections.abc import AsyncGenerator
+import asyncio
+import logging
+import random
+from collections.abc import AsyncGenerator, Callable
+from contextlib import asynccontextmanager
 
 from sqlalchemy import text as sa_text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Explicit connect-level timeout (seconds) for asyncpg's establishment of a NEW
+# TCP/auth connection. This is deliberately tunable instead of relying on the
+# asyncpg default, and is distinct from pool_timeout (checkout wait). See #356.
+_CONNECT_TIMEOUT = 10
 
 engine = create_async_engine(
     settings.database_url,
@@ -16,8 +27,51 @@ engine = create_async_engine(
     pool_recycle=300,   # Recycle connections every 5 min (prevents stale)
     pool_pre_ping=True, # Verify connection is alive before using
     pool_timeout=10,    # Fail fast if PG itself is overloaded (seconds)
+    connect_args={"timeout": _CONNECT_TIMEOUT},  # bound the NEW-connection handshake (#356)
 )
 async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+
+@asynccontextmanager
+async def resilient_session(
+    retries: int = 3,
+    base_delay: float = 0.5,
+    session_factory: Callable[[], AsyncSession] | None = None,
+) -> AsyncGenerator[AsyncSession, None]:
+    """Yield an AsyncSession whose *connection establishment* is retried with
+    exponential backoff + jitter, so a brief DB blip (connect timeout / refused)
+    doesn't kill an entire background sweep tick (see #356).
+
+    Only the connect/checkout is retried: the session is forced live up-front via
+    a ``SELECT 1`` pre-ping, so a connect-level ``TimeoutError`` surfaces here —
+    where it can be retried — instead of deep inside the sweep body. Once the
+    connection is live it is handed to the caller unchanged; exceptions raised
+    *inside* the ``async with resilient_session()`` body are NOT retried and
+    propagate normally.
+    """
+    factory = session_factory or async_session_factory
+    attempt = 0
+    while True:
+        session = factory()
+        try:
+            await session.execute(sa_text("SELECT 1"))
+        except Exception as e:
+            await session.close()
+            attempt += 1
+            if attempt > retries:
+                raise
+            delay = base_delay * (2 ** (attempt - 1)) + random.uniform(0, base_delay)
+            logger.warning(
+                "[resilient_session] connect attempt %s/%s failed (%s: %s); retrying in %.2fs",
+                attempt, retries, type(e).__name__, e, delay,
+            )
+            await asyncio.sleep(delay)
+            continue
+        try:
+            yield session
+        finally:
+            await session.close()
+        return
 
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:

--- a/orchestrator/app/services/disk_monitor.py
+++ b/orchestrator/app/services/disk_monitor.py
@@ -41,7 +41,8 @@ class DiskMonitorService:
 
     # ------------------------------------------------------------------
     async def _check_all_agents(self) -> None:
-        async with self._sf() as db:
+        from app.db.session import resilient_session
+        async with resilient_session(session_factory=self._sf) as db:
             result = await db.execute(
                 select(Agent).where(
                     Agent.state.in_([AgentState.RUNNING, AgentState.IDLE, AgentState.WORKING])

--- a/orchestrator/app/services/scheduler_service.py
+++ b/orchestrator/app/services/scheduler_service.py
@@ -15,7 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.agent_manager import PROACTIVE_PROMPT
 from app.core.load_balancer import LoadBalancer
 from app.core.task_router import TaskRouter
-from app.db.session import async_session_factory
+from app.db.session import resilient_session
 from app.models.schedule import Schedule
 from app.models.task import Task
 from app.services.redis_service import RedisService
@@ -170,14 +170,14 @@ class SchedulerService:
         or, as a safety net, once scheduled_for (the cap) is reached."""
         from datetime import datetime, timezone
         from sqlalchemy import select, and_, or_
-        from app.db.session import async_session_factory
+        from app.db.session import resilient_session
         from app.models.meeting_room import MeetingRoom
         from app.models.task import Task, TaskStatus
         from app.api.meeting_rooms import _run_meeting, _start_moderator_container, _running_rooms
 
         now = datetime.now(timezone.utc)
         started = 0
-        async with async_session_factory() as db:
+        async with resilient_session() as db:
             rows = (await db.execute(
                 select(MeetingRoom).where(and_(
                     MeetingRoom.state == "idle",
@@ -221,13 +221,13 @@ class SchedulerService:
         dispatch the coordinator's integration task (assemble the shared work dir into
         one runnable deliverable). Fires once per meeting (deliverable_integrated guard)."""
         from sqlalchemy import select, and_
-        from app.db.session import async_session_factory
+        from app.db.session import resilient_session
         from app.models.meeting_room import MeetingRoom
         from app.models.task import Task, TaskStatus
         from app.api.meeting_rooms import dispatch_integration_task
 
         dispatched = 0
-        async with async_session_factory() as db:
+        async with resilient_session() as db:
             rooms = (await db.execute(
                 select(MeetingRoom).where(and_(
                     MeetingRoom.deliverable == True,
@@ -263,7 +263,7 @@ class SchedulerService:
         from app.services.settings_service import SettingsService
         from app.services.profile_extractor import extract_profile
         from app.models.agent import Agent
-        async with async_session_factory() as db:
+        async with resilient_session() as db:
             enabled = (await SettingsService(db).get("dreaming_enabled")) or ""
             if enabled.lower() not in ("true", "1", "yes"):
                 return 0
@@ -291,7 +291,7 @@ class SchedulerService:
         are eligible for deletion.
         """
         now = datetime.now(timezone.utc)
-        async with async_session_factory() as db:
+        async with resilient_session() as db:
             try:
                 result = await db.execute(
                     select(Task).where(
@@ -318,7 +318,7 @@ class SchedulerService:
     async def _check_due_schedules(self) -> None:
         now = datetime.now(timezone.utc)
 
-        async with async_session_factory() as db:
+        async with resilient_session() as db:
             result = await db.execute(
                 select(Schedule).where(
                     Schedule.enabled == True,  # noqa: E712
@@ -463,7 +463,7 @@ class SchedulerService:
             return
         self._failure_watchdog_last_run = now
 
-        async with async_session_factory() as db:
+        async with resilient_session() as db:
             schedules = (
                 await db.execute(select(Schedule).where(Schedule.enabled == True))  # noqa: E712
             ).scalars().all()
@@ -518,7 +518,7 @@ class SchedulerService:
         import json as _json
 
         now = datetime.now(timezone.utc)
-        async with async_session_factory() as db:
+        async with resilient_session() as db:
             stale = await find_stale_tasks(db, now)
             if not stale:
                 return
@@ -568,7 +568,7 @@ class SchedulerService:
         import json as _json
 
         now = datetime.now(timezone.utc)
-        async with async_session_factory() as db:
+        async with resilient_session() as db:
             missed = await find_missed_schedules(db, now)
             for s in missed:
                 slot_key = as_utc(s.next_run_at).isoformat()
@@ -605,13 +605,13 @@ class SchedulerService:
         """
         from datetime import datetime, timezone, timedelta
         from sqlalchemy import select
-        from app.db.session import async_session_factory
+        from app.db.session import resilient_session
         from app.models.agent import Agent, AgentState
         from app.models.platform_settings import PlatformSettings
         from app.models.task import Task, TaskStatus
 
         stopped = 0
-        async with async_session_factory() as db:
+        async with resilient_session() as db:
             ps = await db.get(PlatformSettings, "max_idle_minutes")
             try:
                 global_max = int(ps.value) if ps and ps.value else None

--- a/orchestrator/app/services/user_lifecycle.py
+++ b/orchestrator/app/services/user_lifecycle.py
@@ -68,7 +68,8 @@ class UserLifecycleService:
 
     async def _sweep(self) -> None:
         """One sweep: find inactive users and stop their idle agents."""
-        async with self.db_factory() as db:
+        from app.db.session import resilient_session
+        async with resilient_session(session_factory=self.db_factory) as db:
             global_timeout = await _get_timeout_minutes(db)
             now = datetime.now(timezone.utc)
 

--- a/orchestrator/tests/test_resilient_session.py
+++ b/orchestrator/tests/test_resilient_session.py
@@ -16,11 +16,22 @@ from app.db.session import resilient_session
 
 
 class _FakeSession:
+    """Doubles as the async-context "connection" and the session it yields —
+    mirrors how a real AsyncSession returned by ``async_session_factory()`` both
+    enters a context and executes queries."""
+
     def __init__(self, fail_ping: bool) -> None:
         self._fail_ping = fail_ping
         self._pinged = False
         self.closed = False
         self.body_calls = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        self.closed = True
+        return False
 
     async def execute(self, _stmt):
         if not self._pinged:
@@ -30,9 +41,6 @@ class _FakeSession:
             return "ping-ok"
         self.body_calls += 1
         return "body-ok"
-
-    async def close(self):
-        self.closed = True
 
 
 def _factory(fail_first_n: int):

--- a/orchestrator/tests/test_resilient_session.py
+++ b/orchestrator/tests/test_resilient_session.py
@@ -1,0 +1,97 @@
+"""Tests for ``resilient_session`` — the connect-retry wrapper for background
+sweeps (issue #356).
+
+A brief DB blip used to make ``asyncpg.connect`` time out, bubble up, and kill an
+entire background sweep tick (50+ ERRORs from a single ~1h outage). The helper
+retries only the *connection establishment* (via a ``SELECT 1`` pre-ping) with
+exponential backoff + jitter, so a few seconds of unavailability are bridged
+instead of skipping the whole tick. Errors raised inside the body must NOT be
+retried.
+"""
+
+import unittest
+
+from app.db import session as db_session
+from app.db.session import resilient_session
+
+
+class _FakeSession:
+    def __init__(self, fail_ping: bool) -> None:
+        self._fail_ping = fail_ping
+        self._pinged = False
+        self.closed = False
+        self.body_calls = 0
+
+    async def execute(self, _stmt):
+        if not self._pinged:
+            self._pinged = True
+            if self._fail_ping:
+                raise TimeoutError("simulated connect timeout")
+            return "ping-ok"
+        self.body_calls += 1
+        return "body-ok"
+
+    async def close(self):
+        self.closed = True
+
+
+def _factory(fail_first_n: int):
+    state = {"attempts": 0}
+    created: list[_FakeSession] = []
+
+    def factory() -> _FakeSession:
+        state["attempts"] += 1
+        sess = _FakeSession(fail_ping=state["attempts"] <= fail_first_n)
+        created.append(sess)
+        return sess
+
+    return factory, created
+
+
+class TestResilientSession(unittest.IsolatedAsyncioTestCase):
+    async def test_retries_then_succeeds(self):
+        factory, created = _factory(fail_first_n=2)
+        async with resilient_session(
+            retries=3, base_delay=0.001, session_factory=factory
+        ) as db:
+            result = await db.execute("do work")
+        self.assertEqual(result, "body-ok")
+        # 2 failed connects + 1 successful = 3 sessions created.
+        self.assertEqual(len(created), 3)
+        # The two failed sessions were closed; the live one was closed on exit.
+        self.assertTrue(all(s.closed for s in created))
+        self.assertIs(db, created[-1])
+
+    async def test_gives_up_after_retries_and_closes(self):
+        factory, created = _factory(fail_first_n=99)
+        with self.assertRaises(TimeoutError):
+            async with resilient_session(
+                retries=3, base_delay=0.001, session_factory=factory
+            ):
+                self.fail("body must not run when connect never succeeds")
+        # 1 initial attempt + 3 retries = 4 sessions, all closed.
+        self.assertEqual(len(created), 4)
+        self.assertTrue(all(s.closed for s in created))
+
+    async def test_body_errors_are_not_retried(self):
+        factory, created = _factory(fail_first_n=0)
+
+        class _BodyError(Exception):
+            pass
+
+        with self.assertRaises(_BodyError):
+            async with resilient_session(
+                retries=3, base_delay=0.001, session_factory=factory
+            ):
+                raise _BodyError()
+        # Connect succeeded once → exactly one session, and it was closed.
+        self.assertEqual(len(created), 1)
+        self.assertTrue(created[0].closed)
+
+    async def test_defaults_to_module_factory(self):
+        # When no session_factory is passed, the module-level factory is used.
+        self.assertIsNotNone(db_session.async_session_factory)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orchestrator/tests/test_schedule_failure_alerts.py
+++ b/orchestrator/tests/test_schedule_failure_alerts.py
@@ -211,7 +211,7 @@ async def test_watchdog_fires_on_stale_drift():
     svc = _make_watchdog_service(redis)
     schedule = _stale_schedule(total=10, ok=7, fail=1)  # drift=2
 
-    with patch("app.services.scheduler_service.async_session_factory", return_value=_mock_db_ctx([schedule])):
+    with patch("app.db.session.async_session_factory", return_value=_mock_db_ctx([schedule])):
         await svc._tick_failure_watchdog()
 
     redis.client.publish.assert_awaited_once()
@@ -235,7 +235,7 @@ async def test_watchdog_no_re_alert_on_same_drift():
     svc._watchdog_alerted = {"sched-1": 2}  # already alerted at drift=2
     schedule = _stale_schedule(total=10, ok=7, fail=1)  # drift still 2
 
-    with patch("app.services.scheduler_service.async_session_factory", return_value=_mock_db_ctx([schedule])):
+    with patch("app.db.session.async_session_factory", return_value=_mock_db_ctx([schedule])):
         await svc._tick_failure_watchdog()
 
     redis.client.publish.assert_not_awaited()
@@ -255,7 +255,7 @@ async def test_watchdog_re_alerts_when_drift_increases():
     svc._watchdog_alerted = {"sched-1": 2}  # previously alerted at drift=2
     schedule = _stale_schedule(total=11, ok=7, fail=1)  # drift now=3
 
-    with patch("app.services.scheduler_service.async_session_factory", return_value=_mock_db_ctx([schedule])):
+    with patch("app.db.session.async_session_factory", return_value=_mock_db_ctx([schedule])):
         await svc._tick_failure_watchdog()
 
     redis.client.publish.assert_awaited_once()
@@ -274,7 +274,7 @@ async def test_watchdog_skips_small_drift():
     svc = _make_watchdog_service(redis)
     schedule = _stale_schedule(total=10, ok=9, fail=0)  # drift=1
 
-    with patch("app.services.scheduler_service.async_session_factory", return_value=_mock_db_ctx([schedule])):
+    with patch("app.db.session.async_session_factory", return_value=_mock_db_ctx([schedule])):
         await svc._tick_failure_watchdog()
 
     redis.client.publish.assert_not_awaited()
@@ -305,7 +305,7 @@ async def test_watchdog_skips_recent_last_run():
         fail_count=1,  # drift=2 but not stale enough
     )
 
-    with patch("app.services.scheduler_service.async_session_factory", return_value=_mock_db_ctx([schedule])):
+    with patch("app.db.session.async_session_factory", return_value=_mock_db_ctx([schedule])):
         await svc._tick_failure_watchdog()
 
     redis.client.publish.assert_not_awaited()
@@ -326,7 +326,7 @@ async def test_watchdog_1h_global_throttle():
     svc._failure_watchdog_last_run = datetime.now(timezone.utc) - timedelta(minutes=30)
     schedule = _stale_schedule(total=10, ok=7, fail=1)  # would normally alert
 
-    with patch("app.services.scheduler_service.async_session_factory", return_value=_mock_db_ctx([schedule])):
+    with patch("app.db.session.async_session_factory", return_value=_mock_db_ctx([schedule])):
         await svc._tick_failure_watchdog()
 
     # DB should never even be queried; no publish
@@ -342,6 +342,6 @@ async def test_watchdog_no_redis_no_crash():
     svc.redis = None
     schedule = _stale_schedule(total=10, ok=7, fail=1)
 
-    with patch("app.services.scheduler_service.async_session_factory", return_value=_mock_db_ctx([schedule])):
+    with patch("app.db.session.async_session_factory", return_value=_mock_db_ctx([schedule])):
         # Must not raise
         await svc._tick_failure_watchdog()


### PR DESCRIPTION
Fixes #356.

## Problem
A **connect-level** `asyncpg.TimeoutError` (establishing a NEW TCP/auth connection — *not* the `pool_timeout` checkout wait) in the periodic background sweeps bubbled to the outer `try/except`, which logged ERROR and slept — **discarding the whole tick**. A single ~1h DB blip therefore produced 50+ ERRORs and skipped sweeps.

Evidence (`/shared/platform-errors.log`): recurring on 2026-07-20/22/23 and a 53-error burst 2026-07-28 02:19–03:18 UTC (`scheduler_service`, `user_lifecycle`, `disk_monitor`), each self-healed once PG recovered.

## Fix
- **`resilient_session(retries, base_delay, session_factory)`** (`app/db/session.py`): forces the connection live via a `SELECT 1` pre-ping so a connect-level timeout surfaces where it can be retried, then retries **only the establishment** with exponential backoff + jitter. Body errors are **not** retried.
- Explicit **`connect_args={"timeout": 10}`** on the engine (deliberate/tunable, distinct from `pool_timeout`).
- Wired into the `scheduler_service`, `user_lifecycle` and `disk_monitor` sweeps.

## Tests
- New `tests/test_resilient_session.py` (4 cases) — all pass; `test_disk_monitor.py` still green. Sandbox has no live PG / `pytest_asyncio`, so sweep behavior is covered by unit tests + import smoke; CI runs the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)