### PR TITLE
Fix #358: extend resilient_session to remaining background loops

### DIFF
--- a/orchestrator/app/services/embedding_backfill.py
+++ b/orchestrator/app/services/embedding_backfill.py
@@ -10,6 +10,7 @@ import logging
 from sqlalchemy import select, text as sa_text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.db.session import resilient_session
 from app.models.memory import AgentMemory
 from app.models.knowledge import KnowledgeEntry
 from app.services.embedding_service import get_embedding_service
@@ -143,7 +144,7 @@ async def run_backfill_loop(db_factory) -> None:
     total_skills = 0
     while True:
         try:
-            async with db_factory() as db:
+            async with resilient_session(session_factory=db_factory) as db:
                 mem_count = await backfill_memory_embeddings(db)
                 total_memories += mem_count
                 kb_count = await backfill_knowledge_embeddings(db)

--- a/orchestrator/app/services/improvement_engine.py
+++ b/orchestrator/app/services/improvement_engine.py
@@ -124,9 +124,9 @@ class ImprovementEngine:
 
         Returns the analysis interval for the next sleep cycle.
         """
-        from app.db.session import async_session_factory
+        from app.db.session import resilient_session
 
-        async with async_session_factory() as db:
+        async with resilient_session() as db:
             thresholds = await _load_thresholds(db)
             interval = thresholds["analysis_interval"]
 

--- a/orchestrator/app/services/knowledge_feed_service.py
+++ b/orchestrator/app/services/knowledge_feed_service.py
@@ -40,7 +40,7 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db.session import async_session_factory
+from app.db.session import resilient_session
 from app.models.knowledge_feed import KnowledgeFeed, KnowledgeFeedItem
 from app.services.redis_service import RedisService
 
@@ -338,7 +338,7 @@ class KnowledgeFeedService:
         summary = {"ran": 0, "errors": 0, "new_items": 0}
         now = datetime.now(timezone.utc)
 
-        async with async_session_factory() as session:
+        async with resilient_session() as session:
             result = await session.execute(
                 select(KnowledgeFeed).where(KnowledgeFeed.enabled.is_(True))
             )
@@ -381,7 +381,7 @@ class KnowledgeFeedService:
 
     async def run_now(self, feed_id: int) -> dict[str, Any]:
         """Manually trigger one feed (used by the API endpoint)."""
-        async with async_session_factory() as session:
+        async with resilient_session() as session:
             feed = await session.get(KnowledgeFeed, feed_id)
             if not feed:
                 raise ValueError(f"feed {feed_id} not found")

--- a/orchestrator/app/services/reflection_service.py
+++ b/orchestrator/app/services/reflection_service.py
@@ -29,7 +29,7 @@ from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
-from app.db.session import async_session_factory
+from app.db.session import resilient_session
 from app.models.agent import Agent
 from app.models.audit_log import AuditLog
 from app.models.chat_message import ChatMessage
@@ -104,7 +104,7 @@ class ReflectionService:
         """Run once per day at the configured local hour. Cheap when disabled."""
         if self._running:
             return None
-        async with async_session_factory() as db:
+        async with resilient_session() as db:
             cfg = await self._load_config(db)
             if not cfg["enabled"]:
                 return None
@@ -134,7 +134,7 @@ class ReflectionService:
             self._running = False
 
     async def _run_inner(self, trigger: str) -> dict:
-        async with async_session_factory() as db:
+        async with resilient_session() as db:
             cfg = await self._load_config(db)
             run = ReflectionRun(mode=cfg["mode"], trigger=trigger, stats={})
             db.add(run)
@@ -152,7 +152,7 @@ class ReflectionService:
         run_started = datetime.now(timezone.utc)
 
         try:
-            async with async_session_factory() as db:
+            async with resilient_session() as db:
                 watermarks = await self._load_watermarks(db)
                 agents = (await db.execute(
                     select(Agent).where(Agent.user_id.isnot(None))
@@ -206,7 +206,7 @@ class ReflectionService:
             logger.error("[Reflection] run failed: %s", e, exc_info=True)
 
         # Finalize run row + audit + digest
-        async with async_session_factory() as db:
+        async with resilient_session() as db:
             run = await db.get(ReflectionRun, run_id)
             if run:
                 run.finished_at = datetime.now(timezone.utc)

--- a/orchestrator/app/services/self_test_service.py
+++ b/orchestrator/app/services/self_test_service.py
@@ -17,7 +17,7 @@ from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
-from app.db.session import async_session_factory
+from app.db.session import resilient_session
 from app.models.agent import Agent
 from app.models.notification import Notification
 from app.models.task import Task, TaskStatus
@@ -86,7 +86,7 @@ class SelfTestService:
         start = time.monotonic()
         results: list[TestResult] = []
 
-        async with async_session_factory() as db:
+        async with resilient_session() as db:
             # Create test run record
             test_run = TestRun(
                 started_at=datetime.now(timezone.utc),

--- a/orchestrator/app/services/skill_crawler.py
+++ b/orchestrator/app/services/skill_crawler.py
@@ -220,11 +220,11 @@ class SkillCrawlerService:
     async def _sync_to_db(self, skills: list[dict]) -> None:
         """Sync crawled skills to the DB marketplace (upsert by name)."""
         try:
-            from app.db.session import async_session_factory
+            from app.db.session import resilient_session
             from app.models.skill import Skill, SkillStatus
             from sqlalchemy import select
 
-            async with async_session_factory() as db:
+            async with resilient_session() as db:
                 imported = 0
                 for s in skills:
                     existing = (await db.execute(

--- a/orchestrator/app/services/trend_service.py
+++ b/orchestrator/app/services/trend_service.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta, timezone
 
 import httpx
 
-from app.db.session import async_session_factory
+from app.db.session import resilient_session
 from app.models.skill import Skill, SkillCategory, SkillStatus
 
 logger = logging.getLogger(__name__)
@@ -135,7 +135,7 @@ class TrendService:
     async def _get_existing_source_repos(self) -> set[str]:
         """Return set of source_repos already in DB to avoid duplicates."""
         from sqlalchemy import select
-        async with async_session_factory() as db:
+        async with resilient_session() as db:
             result = await db.execute(select(Skill.source_repo).where(Skill.source_repo.isnot(None)))
             return {row[0] for row in result.all()}
 
@@ -232,7 +232,7 @@ class TrendService:
     async def _save_skill(self, skill: dict) -> None:
         """Persist a generated skill as DRAFT."""
         from sqlalchemy import select
-        async with async_session_factory() as db:
+        async with resilient_session() as db:
             # Skip if name already exists
             existing = await db.scalar(select(Skill).where(Skill.name == skill["name"]))
             if existing:

--- a/orchestrator/tests/test_resilient_session_wiring.py
+++ b/orchestrator/tests/test_resilient_session_wiring.py
@@ -1,0 +1,53 @@
+"""Guard test for issue #358: the background loop services listed below must
+open their DB sessions through ``resilient_session`` (connect-retry) instead of
+a bare ``async_session_factory``, so a brief DB blip doesn't kill a whole sweep
+tick (same failure mode as #356).
+
+This is a source-level guard: it asserts every converted call site routes
+through ``resilient_session`` and that no bare ``async_session_factory()`` call
+remains, catching any future regression that reintroduces the unprotected
+pattern.
+"""
+
+import unittest
+from pathlib import Path
+
+# Services converted in PR for #358 (were still on bare async_session_factory).
+_SERVICES_DIR = Path(__file__).resolve().parent.parent / "app" / "services"
+_CONVERTED = [
+    "reflection_service",
+    "trend_service",
+    "knowledge_feed_service",
+    "embedding_backfill",
+    "improvement_engine",
+    "self_test_service",
+    "skill_crawler",
+]
+
+
+class TestResilientSessionWiring(unittest.TestCase):
+    def _source(self, name: str) -> str:
+        return (_SERVICES_DIR / f"{name}.py").read_text()
+
+    def test_services_use_resilient_session(self):
+        for name in _CONVERTED:
+            src = self._source(name)
+            with self.subTest(service=name):
+                self.assertIn(
+                    "resilient_session", src,
+                    f"{name} should open sessions via resilient_session (#358)",
+                )
+
+    def test_no_bare_session_factory_call_remains(self):
+        for name in _CONVERTED:
+            src = self._source(name)
+            with self.subTest(service=name):
+                self.assertNotIn(
+                    "async_session_factory(", src,
+                    f"{name} still calls async_session_factory() directly — "
+                    f"route it through resilient_session (#358)",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #358.

## Summary
Extends the #356/#357 connect-retry hardening to the background loop services that were still opening bare `async_session_factory` sessions and were therefore unprotected against the connect-level `TimeoutError` that caused the #356 53-error burst.

Converted services:
- `reflection_service`
- `trend_service`
- `knowledge_feed_service`
- `embedding_backfill`
- `improvement_engine`
- `self_test_service`
- `skill_crawler`

## Approach (mirrors PR #357 exactly)
- Direct-import services: swap `from app.db.session import async_session_factory` → `resilient_session`, and `async with async_session_factory() as db:` → `async with resilient_session() as db:`.
- `embedding_backfill` receives an injected factory, so it keeps it via `resilient_session(session_factory=db_factory)` (same pattern as `disk_monitor`/`user_lifecycle`).
- `get_db` (FastAPI request-scope dependency) is **left unchanged** — connect-retry is undesirable there.

## Tests
- New `test_resilient_session_wiring.py`: source-level guard asserting every converted service routes through `resilient_session` and no bare `async_session_factory()` call remains (regression guard).
- Full suite green: **369 passed** (excluding the two known env-gap tests `test_bot_manager` [telegram] and `test_autonomy_enforcement` [aiosqlite], unrelated to this change).

## Acceptance criteria
- [x] All listed services use `resilient_session()` instead of `async with async_session_factory() as db`
- [x] Existing tests remain green; new test covers the changed call sites
- [x] `get_db` remains unchanged