### PR TITLE
test(#342): CI smoke test + runtime diagnostic for MCP arg-stripping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,27 @@ jobs:
           KIOSK_ENABLED: "false"
         run: pytest -q
 
+  # ── Agent MCP arg-parse smoke: guards the #342/#285 regression class where
+  #    Responses-API tool arguments delivered only on the `.done` event get
+  #    dropped, so every string parameter reaches the server empty. The agent
+  #    suite is not otherwise run in CI, so this targeted job is the guard. ──
+  agent-argparse-smoke:
+    name: Agent MCP arg-parse smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Install agent (+ test deps)
+        working-directory: agent
+        run: |
+          pip install --no-cache-dir -e .
+          pip install --no-cache-dir pytest pytest-asyncio
+      - name: Run arg-parse regression tests
+        working-directory: agent
+        run: pytest -q tests/test_openai_responses_tool_args.py tests/test_responses_stream_smoke.py
+
   # ── Compose validity: would have caught a broken docker-compose.yml before deploy. ──
   compose-config:
     name: docker compose config

--- a/agent/app/health.py
+++ b/agent/app/health.py
@@ -10,10 +10,37 @@ async def health_handler(request: web.Request) -> web.Response:
     )
 
 
+def _arg_parse_selftest() -> bool:
+    """Return True if the RUNNING image parses Responses-API tool arguments that
+    arrive only on the final ``.done`` event (the #342/#285 regression case).
+
+    A stale/rolled-back image that predates the fix returns False here even while
+    the source on ``main`` is correct — this is the signal that distinguishes a
+    deploy regression from a code regression.
+    """
+    from app.providers.openai_provider import OpenAIProvider
+
+    parsed = OpenAIProvider._parse_function_arguments("", '{"content":"kept"}')
+    return parsed == {"content": "kept"}
+
+
+async def diag_handler(request: web.Request) -> web.Response:
+    """Runtime self-diagnostic — surfaces whether the deployed image is affected
+    by the MCP arg-stripping regression (#342). Returns HTTP 500 when degraded so
+    a health probe / monitor can page on a stale deploy."""
+    arg_parse_ok = _arg_parse_selftest()
+    body = {
+        "agent_id": request.app["agent_id"],
+        "checks": {"mcp_arg_parse": "ok" if arg_parse_ok else "FAILED"},
+    }
+    return web.json_response(body, status=200 if arg_parse_ok else 500)
+
+
 async def start_health_server(agent_id: str, port: int = 8080) -> web.AppRunner:
     app = web.Application()
     app["agent_id"] = agent_id
     app.router.add_get("/health", health_handler)
+    app.router.add_get("/diag", diag_handler)
     runner = web.AppRunner(app)
     await runner.setup()
     site = web.TCPSite(runner, "0.0.0.0", port)

--- a/agent/tests/test_responses_stream_smoke.py
+++ b/agent/tests/test_responses_stream_smoke.py
@@ -1,0 +1,108 @@
+"""End-to-end smoke test for the Responses API streaming tool-call path (#342).
+
+The `_parse_function_arguments` unit test guards the parser in isolation, but the
+arg-stripping regression (#285/#342) actually lives in the *stream loop*: some
+Responses-compatible providers emit NO ``response.function_call_arguments.delta``
+events and deliver the complete JSON only on the ``.done`` event. If the loop
+ignores that final payload, every string argument reaches the server empty. This
+test drives a synthetic SSE stream (deltas absent, args only on ``.done``)
+through ``_stream_responses`` and asserts the emitted tool_call keeps its args.
+"""
+import json
+
+import pytest
+
+from app.providers.base import LLMEvent
+from app.providers.openai_provider import OpenAIProvider
+
+
+class _FakeStreamCtx:
+    """Minimal async-context stand-in for ``httpx.AsyncClient.stream(...)``."""
+
+    def __init__(self, lines: list[str]):
+        self._lines = lines
+        self.status_code = 200
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def aiter_lines(self):
+        for line in self._lines:
+            yield line
+
+    async def aread(self) -> bytes:
+        return b""
+
+
+class _FakeHttp:
+    def __init__(self, lines: list[str]):
+        self._lines = lines
+        self.is_closed = False
+
+    def stream(self, method, url, json=None, headers=None):  # noqa: A002
+        return _FakeStreamCtx(self._lines)
+
+
+def _sse(event: dict) -> str:
+    return "data: " + json.dumps(event)
+
+
+async def _collect(provider: OpenAIProvider) -> list[LLMEvent]:
+    return [ev async for ev in provider._stream_responses("http://x/responses", [], None)]
+
+
+@pytest.mark.asyncio
+async def test_args_only_on_done_event_survive_streaming():
+    # The exact #342 shape: function_call added with empty args, NO delta events,
+    # complete JSON delivered only on the `.done` event.
+    args = {"category": "learning", "key": "lesson", "content": "must survive"}
+    lines = [
+        _sse({"type": "response.output_item.added",
+              "item": {"type": "function_call", "id": "fc_1",
+                       "name": "memory_save", "call_id": "call_1"}}),
+        _sse({"type": "response.function_call_arguments.done",
+              "item_id": "fc_1", "arguments": json.dumps(args)}),
+        _sse({"type": "response.completed",
+              "response": {"usage": {"input_tokens": 5, "output_tokens": 7}}}),
+        "data: [DONE]",
+    ]
+    provider = OpenAIProvider(
+        api_endpoint="http://x", api_key="k", model_name="gpt-5.4-codex",
+    )
+    provider._http = _FakeHttp(lines)
+
+    events = await _collect(provider)
+    tool_calls = [e for e in events if e.type == "tool_call"]
+
+    assert len(tool_calls) == 1
+    tc = tool_calls[0]
+    assert tc.tool_name == "memory_save"
+    assert tc.tool_id == "call_1"
+    # The regression: these string values would be dropped, leaving {}.
+    assert tc.tool_input == args
+
+
+@pytest.mark.asyncio
+async def test_streamed_deltas_still_work():
+    # Providers that DO stream deltas must keep working (args assembled from deltas).
+    provider = OpenAIProvider(
+        api_endpoint="http://x", api_key="k", model_name="gpt-5.4-codex",
+    )
+    provider._http = _FakeHttp([
+        _sse({"type": "response.output_item.added",
+              "item": {"type": "function_call", "id": "fc_2",
+                       "name": "rate_task", "call_id": "call_2"}}),
+        _sse({"type": "response.function_call_arguments.delta",
+              "item_id": "fc_2", "delta": '{"rating":5,'}),
+        _sse({"type": "response.function_call_arguments.delta",
+              "item_id": "fc_2", "delta": '"note":"ok"}'}),
+        _sse({"type": "response.function_call_arguments.done", "item_id": "fc_2"}),
+        "data: [DONE]",
+    ])
+
+    tool_calls = [e for e in await _collect(provider) if e.type == "tool_call"]
+    assert len(tool_calls) == 1
+    assert tool_calls[0].tool_input == {"rating": 5, "note": "ok"}


### PR DESCRIPTION
## Context
#342 is a **deploy regression**, not a source bug: the `#291` fix (parse tool
arguments from the Responses-API `.done` event) is intact on `main`, but a
stale/rolled-back running image reintroduces the arg-stripping at runtime — all
string parameters to MCP tools (`memory_save`, `rate_task`, …) reach the server
empty (HTTP 422). Two things were missing to catch this class of failure:

1. **No CI runs the agent test suite.** The existing `#291` regression test
   (`test_openai_responses_tool_args.py`) never executes in CI, so a code-level
   regression could merge unnoticed.
2. **No runtime signal** distinguishes a stale deploy from correct source.

## Changes
- **CI (`agent-argparse-smoke` job)** — runs the arg-parse regression tests on
  every PR. Adds an **end-to-end smoke test** that drives a synthetic SSE stream
  (no `…arguments.delta` events, full JSON only on `…arguments.done`, the exact
  #342 shape) through `_stream_responses` and asserts the emitted `tool_call`
  keeps its arguments. Also covers the normal delta-streaming path.
- **Runtime (`/diag` endpoint)** — the agent health server runs a live
  `_parse_function_arguments` self-test and returns **HTTP 500 when degraded**,
  so a monitor/health-probe can detect a stale image at runtime even while
  `main` is correct.

## Scope note
The job is intentionally **targeted** at the two arg-parse test files rather than
the full `agent/tests/` suite: one unrelated pre-existing test
(`test_present_file_delivered_via_telegram`) currently fails due to the
workspace path-jail tightening, which is out of scope for #342 and tracked
separately.

## Test plan
- [x] `pytest -q tests/test_openai_responses_tool_args.py tests/test_responses_stream_smoke.py` → 5 passed
- [x] `/diag` self-test returns `mcp_arg_parse: ok` on current `main`
- [x] `ci.yml` YAML validates; new job registered

Refs #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)