### PR TITLE
Fix #361: fence off Nova Sonic input stream after server completes it

### DIFF
--- a/orchestrator/app/services/voice_providers/realtime_nova_sonic.py
+++ b/orchestrator/app/services/voice_providers/realtime_nova_sonic.py
@@ -105,6 +105,11 @@ class NovaSonicSession:
         self._recv_task: asyncio.Task | None = None
         self._closed = False
         self._audio_started = False
+        # Set once the server has completed the HTTP/2 stream (receive loop ended).
+        # Further input writes to a completed stream make awscrt raise
+        # AWS_ERROR_HTTP_STREAM_HAS_COMPLETED from an internal task whose exception
+        # is never retrieved — so all sends short-circuit once this is True.
+        self._input_dead = False
         # Serializes multi-event sequences (contentStart→content→contentEnd) so
         # concurrently-fired tool results / text injections can't interleave on the
         # wire. Single-event audio sends stay lock-free (own persistent content block).
@@ -138,6 +143,10 @@ class NovaSonicSession:
         )
 
     async def _send_event(self, event: dict) -> None:
+        # Never write to a stream the server has already completed — awscrt would
+        # raise AWS_ERROR_HTTP_STREAM_HAS_COMPLETED from an unretrieved internal task.
+        if self._input_dead or self._stream is None:
+            return
         from aws_sdk_bedrock_runtime.models import (
             InvokeModelWithBidirectionalStreamInputChunk as InChunk,
             BidirectionalInputPayloadPart as Payload,
@@ -204,7 +213,7 @@ class NovaSonicSession:
 
     async def send_audio(self, pcm_16k: bytes) -> None:
         """Stream one chunk of 16 kHz/16-bit/mono PCM to the model."""
-        if self._closed or not self._audio_started:
+        if self._closed or self._input_dead or not self._audio_started:
             return
         b64 = base64.b64encode(pcm_16k).decode("ascii")
         await self._send_event({"audioInput": {
@@ -293,6 +302,9 @@ class NovaSonicSession:
                 logger.warning("NovaSonic receive loop error: %s", e, exc_info=True)
                 await self._safe_emit("error", {"message": str(e)})
         finally:
+            # The server has completed the stream; any further input write would
+            # crash awscrt with an unretrieved-task exception. Fence off all sends.
+            self._input_dead = True
             await self._safe_emit("done", {})
 
     async def _dispatch(self, kind: str, event: dict) -> None:
@@ -362,6 +374,10 @@ class NovaSonicSession:
             await self._stream.input_stream.close()
         except Exception:  # noqa: BLE001
             logger.debug("NovaSonic close cleanup error", exc_info=True)
+        finally:
+            # Input stream is closed now — block any concurrent send from racing a
+            # write onto the completed stream during teardown.
+            self._input_dead = True
         if self._recv_task and not self._recv_task.done():
             self._recv_task.cancel()
             try:

--- a/orchestrator/tests/test_nova_sonic_input_guard.py
+++ b/orchestrator/tests/test_nova_sonic_input_guard.py
@@ -1,0 +1,90 @@
+"""Regression test for the Nova Sonic input-stream dead-guard.
+
+When the AWS server completes the bidirectional HTTP/2 stream (after a transient
+"Invalid event bytes"/"unexpected error" or a normal end), the receive loop
+exits. Before this guard the session was never fenced off, so the caller kept
+pushing mic PCM via ``send_audio`` → ``input_stream.send`` onto a completed
+stream. awscrt then raised ``AWS_ERROR_HTTP_STREAM_HAS_COMPLETED`` from an
+internal task whose exception was never retrieved (recurring asyncio ERROR in
+the platform log).
+
+The fix: once the receive loop ends (or ``close()`` runs), ``_input_dead`` is set
+and every subsequent send short-circuits before touching the dead stream.
+"""
+
+import unittest
+
+from app.services.voice_providers.realtime_nova_sonic import NovaSonicSession
+
+
+class _FakeInputStream:
+    def __init__(self) -> None:
+        self.sends = 0
+        self.closed = False
+
+    async def send(self, _chunk) -> None:
+        if self.closed:
+            # Mirror awscrt raising once the stream has completed.
+            raise RuntimeError("AWS_ERROR_HTTP_STREAM_HAS_COMPLETED")
+        self.sends += 1
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _FakeStream:
+    def __init__(self) -> None:
+        self.input_stream = _FakeInputStream()
+
+
+def _make_session() -> NovaSonicSession:
+    async def _noop(_kind, _data):
+        return None
+
+    sess = NovaSonicSession(
+        region="us-east-1",
+        access_key="a",
+        secret_key="b",
+        system_prompt="hi",
+        on_event=_noop,
+    )
+    sess._stream = _FakeStream()
+    sess._audio_started = True
+    return sess
+
+
+class TestNovaSonicInputGuard(unittest.IsolatedAsyncioTestCase):
+    async def test_send_audio_works_while_stream_alive(self):
+        sess = _make_session()
+        await sess.send_audio(b"\x00\x01")
+        self.assertEqual(sess._stream.input_stream.sends, 1)
+
+    async def test_no_send_after_input_dead(self):
+        sess = _make_session()
+        sess._input_dead = True  # receive loop ended
+        await sess.send_audio(b"\x00\x01")
+        await sess.inject_user_text("late report")
+        await sess.send_tool_result("id-1", "answer")
+        self.assertEqual(
+            sess._stream.input_stream.sends,
+            0,
+            "no writes may reach a completed stream once input is dead",
+        )
+
+    async def test_send_event_short_circuits_without_stream(self):
+        sess = _make_session()
+        sess._stream = None
+        # Must not raise AttributeError on the missing stream.
+        await sess._send_event({"noop": {}})
+
+    async def test_close_marks_input_dead_and_blocks_further_sends(self):
+        sess = _make_session()
+        await sess.close()
+        self.assertTrue(sess._input_dead)
+        before = sess._stream.input_stream.sends
+        await sess.send_audio(b"\x00\x01")
+        self.assertEqual(sess._stream.input_stream.sends, before)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #361

## Problem
Nach Abschluss des bidirektionalen HTTP/2-Streams durch den AWS-Server (transienter Fehler oder normales Turn-Ende) endete `_receive_loop`, die Session wurde aber nie als tot markiert. Weitere `send_audio()`-Aufrufe schrieben auf den abgeschlossenen Stream → awscrt-interner Task crasht mit `AWS_ERROR_HTTP_STREAM_HAS_COMPLETED`, dessen Exception niemand abholt (`asyncio: Task exception was never retrieved`, wiederkehrend im platform-errors.log 07-29/07-30).

## Änderung
- Neues `_input_dead`-Flag, gesetzt in `_receive_loop`-`finally` (Stream fertig) und in `close()` (nach `input_stream.close()`).
- `_send_event` kurzschließt bei `_input_dead` **oder** fehlendem Stream — kein Write mehr auf einen toten Stream.
- `send_audio` prüft `_input_dead` zusätzlich zu `_closed`.
- Happy-Path unverändert: bei lebendem Stream (`_input_dead=False`) senden `close()`-Teardown-Events (contentEnd/promptEnd/sessionEnd) normal.

## Test
- `tests/test_nova_sonic_input_guard.py`: alive-Send funktioniert; keine Sends nach `_input_dead`; `_send_event` no-op ohne Stream; `close()` setzt `_input_dead` und blockt danach.
- Lokal via isolierter Modul-Load + gestubbtem AWS-SDK verifiziert (alle Guard-Assertions grün, close()-Teardown = 3 Lifecycle-Events dann Fence).

## Test plan
- [ ] CI: orchestrator pytest grün (inkl. neuer Test)
- [ ] Nach Deploy: Voice-Session beenden/abbrechen → kein `AWS_ERROR_HTTP_STREAM_HAS_COMPLETED` "Task exception was never retrieved" mehr im Log