### PR TITLE
fix(scheduler): transient DB blips log WARNING, not full-traceback ERROR

### DIFF
--- a/orchestrator/app/services/scheduler_service.py
+++ b/orchestrator/app/services/scheduler_service.py
@@ -10,6 +10,7 @@ except ImportError:
     _CRONITER_AVAILABLE = False
 
 from sqlalchemy import and_, delete, select
+from sqlalchemy.exc import DBAPIError, OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.agent_manager import PROACTIVE_PROMPT
@@ -28,6 +29,13 @@ from app.services.watchdog import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Connect-level DB errors that resilient_session already retried and exhausted
+# during a brief DB blip (restart/failover). They self-heal on the next tick, so
+# the two bare DB-touching sub-ticks below log them as a clean WARNING instead of
+# letting them surface as a full-traceback ERROR via the outer loop handler —
+# matching how every other sub-tick in run() reports its own failures.
+_TRANSIENT_DB_ERRORS = (OperationalError, DBAPIError, ConnectionError, TimeoutError)
 
 # GC runs every 60 seconds
 _GC_INTERVAL_SECONDS = 60
@@ -75,7 +83,13 @@ class SchedulerService:
                     await self._tick_missed_schedule_watchdog()
                 except Exception as e:
                     logger.warning("[Scheduler] MissedScheduleWatchdog error: %s", e)
-                await self._check_due_schedules()
+                try:
+                    await self._check_due_schedules()
+                except _TRANSIENT_DB_ERRORS as e:
+                    logger.warning(
+                        "[Scheduler] DueSchedules DB unavailable (transient, "
+                        "retrying next tick): %s", e,
+                    )
                 # Stale-task watchdog: flag RUNNING tasks with no heartbeat >30min.
                 try:
                     await self._tick_stale_task_watchdog()
@@ -98,7 +112,12 @@ class SchedulerService:
                 self._gc_counter += 30
                 if self._gc_counter >= _GC_INTERVAL_SECONDS:
                     self._gc_counter = 0
-                    await self._gc_expired_tasks()
+                    try:
+                        await self._gc_expired_tasks()
+                    except _TRANSIENT_DB_ERRORS as e:
+                        logger.warning(
+                            "[Scheduler] GC DB unavailable (transient): %s", e,
+                        )
                 self._idle_stop_counter += 30
                 if self._idle_stop_counter >= 300:  # every 5 min
                     self._idle_stop_counter = 0

--- a/orchestrator/tests/test_scheduler_transient_db_guard.py
+++ b/orchestrator/tests/test_scheduler_transient_db_guard.py
@@ -1,0 +1,104 @@
+"""Guard test: the two bare DB-touching sub-ticks in ``SchedulerService.run``
+(``_check_due_schedules`` and ``_gc_expired_tasks``) must catch transient
+connect-level DB errors as a clean WARNING instead of letting them fall through
+to the outer loop handler as a full-traceback ERROR.
+
+Background: resilient_session already retries connect blips; when its retries are
+exhausted during a real DB restart it re-raises (e.g. TimeoutError/OperationalError).
+Every other sub-tick in run() wraps its own await in try/except -> WARNING, but these
+two were unwrapped, producing recurring alarming "[Scheduler] ERROR" tracebacks for
+transient, self-healing conditions (seen ~25x in platform-errors.log).
+
+Source-level AST guard so it runs without sqlalchemy/a live DB in the container.
+"""
+
+import ast
+import unittest
+from pathlib import Path
+
+_SERVICE = (
+    Path(__file__).resolve().parent.parent
+    / "app" / "services" / "scheduler_service.py"
+)
+
+# Sub-tick calls that touch the DB directly and must be guarded against transient
+# connect errors in run().
+_GUARDED_CALLS = ("_check_due_schedules", "_gc_expired_tasks")
+
+
+def _module() -> ast.Module:
+    return ast.parse(_SERVICE.read_text())
+
+
+def _find_run(mod: ast.Module) -> ast.AsyncFunctionDef:
+    for node in ast.walk(mod):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "run":
+            return node
+    raise AssertionError("SchedulerService.run not found")
+
+
+def _calls_in(node: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for n in ast.walk(node):
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute):
+            names.add(n.func.attr)
+    return names
+
+
+def _handler_names(handler: ast.ExceptHandler) -> set[str]:
+    names: set[str] = set()
+    if handler.type is not None:
+        for n in ast.walk(handler.type):
+            if isinstance(n, ast.Name):
+                names.add(n.id)
+    return names
+
+
+class TestSchedulerTransientDbGuard(unittest.TestCase):
+    def test_transient_db_errors_constant_defined(self):
+        mod = _module()
+        found = False
+        for node in ast.walk(mod):
+            if isinstance(node, ast.Assign):
+                targets = {t.id for t in node.targets if isinstance(t, ast.Name)}
+                if "_TRANSIENT_DB_ERRORS" in targets:
+                    found = True
+                    members = {
+                        n.id for n in ast.walk(node.value) if isinstance(n, ast.Name)
+                    }
+                    self.assertIn(
+                        "OperationalError", members,
+                        "_TRANSIENT_DB_ERRORS must include OperationalError",
+                    )
+        self.assertTrue(found, "_TRANSIENT_DB_ERRORS constant not defined")
+
+    def test_bare_db_subticks_are_guarded(self):
+        run = _find_run(_module())
+        for call in _GUARDED_CALLS:
+            guarded = False
+            for try_node in (n for n in ast.walk(run) if isinstance(n, ast.Try)):
+                if call not in _calls_in_body(try_node):
+                    continue
+                for handler in try_node.handlers:
+                    if "_TRANSIENT_DB_ERRORS" in _handler_names(handler):
+                        guarded = True
+                        break
+                if guarded:
+                    break
+            self.assertTrue(
+                guarded,
+                f"{call}() in run() must be wrapped in a try/except "
+                f"_TRANSIENT_DB_ERRORS handler so a transient DB blip logs a "
+                f"WARNING instead of a full-traceback ERROR",
+            )
+
+
+def _calls_in_body(try_node: ast.Try) -> set[str]:
+    names: set[str] = set()
+    for stmt in try_node.body:
+        names |= _calls_in(stmt)
+    return names
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
`platform-errors.log` shows a recurring signature — **25× all-time** `[Scheduler] ERROR` with a full asyncpg/sqlalchemy traceback ending in `TimeoutError`/`CancelledError` (latest 2026-07-30 16:29). Root cause: a brief DB connect blip (restart/failover) that outlasts `resilient_session`'s 3 connect retries.

The scheduler loop **already survives** this (outer handler sleeps 30s and continues, and later ticks self-heal — the very next log lines are clean `resilient_session` retry WARNINGs). The problem is purely log hygiene: the alarming ERROR-level traceback is emitted for a transient, self-healing condition.

## Why only these two
`SchedulerService.run()` wraps **every** sub-tick (missed-schedule watchdog, stale-task watchdog, follow-ups, taskforce, idle-stop, feeds, failure watchdog, trend, dreaming, reflection, codex) in its own `try/except … logger.warning(...)`. The **only two** DB-touching sub-ticks without individual handling were `_check_due_schedules()` and `_gc_expired_tasks()` — so a transient DB error in them fell through to the outer `logger.error(..., exc_info=True)`.

## Fix
- Add `_TRANSIENT_DB_ERRORS = (OperationalError, DBAPIError, ConnectionError, TimeoutError)`.
- Wrap the two bare awaits so connect-level DB errors log a clean one-line WARNING, consistent with all sibling sub-ticks.
- **Genuine (non-DB) exceptions still propagate** to the outer handler and surface as a full-traceback ERROR — no real bug gets swallowed.

## Test
`orchestrator/tests/test_scheduler_transient_db_guard.py` — AST-based source guard (runs without sqlalchemy/a live DB in the agent container): asserts the constant is defined with `OperationalError` and that both sub-tick calls are wrapped in a `try/except _TRANSIENT_DB_ERRORS` handler inside `run()`. Passes locally; full pytest suite requires sqlalchemy (CI only).

## Deploy gate
Orchestrator image rebuild required for this to take effect (same as other recent backend fixes).