### PR TITLE
Fix #367: local STT for Telegram voice, OpenAI fallback

### DIFF
--- a/orchestrator/app/telegram/handlers/voice.py
+++ b/orchestrator/app/telegram/handlers/voice.py
@@ -19,10 +19,27 @@ def _get_openai_key() -> str:
 
 
 async def _transcribe_voice(file_bytes: bytes, filename: str = "voice.ogg") -> str:
-    """Transcribe audio bytes via OpenAI Whisper API."""
+    """Transcribe audio bytes via the local STT service (faster-whisper).
+
+    Falls back to the OpenAI Whisper API only if the local service is unreachable.
+    Mirrors the local-first pattern of `_text_to_speech()` and `agent_bot.py`.
+    """
+    stt_url = settings.stt_service_url
+    try:
+        async with httpx.AsyncClient(timeout=120) as client:
+            resp = await client.post(
+                f"{stt_url}/transcribe",
+                files={"file": (filename, io.BytesIO(file_bytes), "audio/ogg")},
+            )
+            resp.raise_for_status()
+            return (resp.json().get("text") or "").strip()
+    except Exception as e:
+        logger.warning(f"Local STT service unavailable ({e}), falling back to OpenAI Whisper")
+
+    # Fallback: OpenAI Whisper API (requires API key)
     api_key = _get_openai_key()
     if not api_key:
-        raise RuntimeError("OPENAI_API_KEY not set")
+        raise RuntimeError("STT service unreachable and OPENAI_API_KEY not set")
 
     async with httpx.AsyncClient(timeout=30) as client:
         resp = await client.post(
@@ -74,12 +91,6 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     if not voice:
         return
 
-    if not _get_openai_key():
-        await update.message.reply_text(
-            "Spracherkennung nicht verfugbar. OPENAI_API_KEY fehlt."
-        )
-        return
-
     # Show recording indicator
     await update.effective_chat.send_action("record_voice")
 
@@ -88,7 +99,7 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         tg_file = await voice.get_file()
         file_bytes = bytes(await tg_file.download_as_bytearray())
 
-        # Transcribe via Whisper
+        # Transcribe via local STT service (OpenAI Whisper fallback)
         transcript = await _transcribe_voice(file_bytes)
 
         if not transcript.strip():

--- a/orchestrator/tests/test_voice_local_stt_first.py
+++ b/orchestrator/tests/test_voice_local_stt_first.py
@@ -1,0 +1,80 @@
+"""Guard test: Telegram voice transcription must try the local STT service first
+and only fall back to the OpenAI Whisper API, mirroring ``_text_to_speech`` and
+``agent_bot.py``.
+
+Background (issue #367): ``_transcribe_voice`` used to call the OpenAI Whisper API
+exclusively, and ``handle_voice`` hard-gated on ``OPENAI_API_KEY`` — so voice
+messages were unusable on installs without a paid key even though a healthy local
+faster-whisper service (``stt-service:8003``) was part of the stack and simply
+never called.
+
+Source-level AST/string guard so it runs without httpx/telegram/sqlalchemy or a
+live service in the container.
+"""
+
+import ast
+import unittest
+from pathlib import Path
+
+_VOICE = (
+    Path(__file__).resolve().parent.parent
+    / "app" / "telegram" / "handlers" / "voice.py"
+)
+
+
+def _module() -> ast.Module:
+    return ast.parse(_VOICE.read_text())
+
+
+def _find_func(mod: ast.Module, name: str) -> ast.AsyncFunctionDef:
+    for node in ast.walk(mod):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name} not found in voice.py")
+
+
+class TestVoiceLocalSttFirst(unittest.TestCase):
+    def setUp(self) -> None:
+        self.src = _VOICE.read_text()
+        self.mod = _module()
+
+    def test_transcribe_uses_local_stt_service(self) -> None:
+        """_transcribe_voice must reference the local STT service URL + endpoint."""
+        fn = _find_func(self.mod, "_transcribe_voice")
+        src = ast.get_source_segment(self.src, fn)
+        self.assertIn("stt_service_url", src)
+        self.assertIn("/transcribe", src)
+
+    def test_transcribe_still_has_openai_fallback(self) -> None:
+        """The OpenAI Whisper endpoint must remain as a fallback path."""
+        fn = _find_func(self.mod, "_transcribe_voice")
+        src = ast.get_source_segment(self.src, fn)
+        self.assertIn("api.openai.com/v1/audio/transcriptions", src)
+        # Local call must appear before the OpenAI fallback.
+        self.assertLess(
+            src.index("/transcribe"),
+            src.index("api.openai.com/v1/audio/transcriptions"),
+            "local STT call must precede the OpenAI fallback",
+        )
+
+    def test_transcribe_local_call_is_guarded(self) -> None:
+        """The local STT call must sit inside a try/except so the fallback can run."""
+        fn = _find_func(self.mod, "_transcribe_voice")
+        guarded = False
+        for node in ast.walk(fn):
+            if isinstance(node, ast.Try):
+                seg = ast.get_source_segment(self.src, node) or ""
+                if "/transcribe" in seg and node.handlers:
+                    guarded = True
+        self.assertTrue(guarded, "local STT call is not wrapped in try/except")
+
+    def test_handle_voice_has_no_hard_openai_gate(self) -> None:
+        """handle_voice must no longer refuse transcription when OPENAI_API_KEY is unset."""
+        fn = _find_func(self.mod, "handle_voice")
+        src = ast.get_source_segment(self.src, fn)
+        self.assertNotIn("OPENAI_API_KEY fehlt", src)
+        self.assertNotIn("_get_openai_key", src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #367

## Problem
`orchestrator/app/telegram/handlers/voice.py` transcribed Telegram voice messages **only** through the OpenAI Whisper API and hard-gated on `OPENAI_API_KEY`, replying *"Spracherkennung nicht verfugbar. OPENAI_API_KEY fehlt."* — even though the stack ships and runs its own faster-whisper STT service (`stt-service:8003`), which was never called. On self-hosted installs without a paid key, voice was unusable; where a key was set, audio was sent to a third party despite a local path existing.

## Fix
Mirror the existing local-first pattern already used by `_text_to_speech()` and `agent_bot.py`:

- `_transcribe_voice()` now calls the local STT service (`{stt_service_url}/transcribe`) first and falls back to the OpenAI Whisper API only if the local service is unreachable.
- Removed the hard `OPENAI_API_KEY` gate in `handle_voice()`. The surrounding `try/except` already reports failures to the user, so nothing is left unhandled.

## Verification
- New stdlib-only AST/string guard test `orchestrator/tests/test_voice_local_stt_first.py` (4 tests, all pass): asserts local-STT-first ordering, that the OpenAI fallback remains, that the local call is guarded by try/except, and that the hard `OPENAI_API_KEY` gate is gone.
- `python3 -m py_compile` clean.

## Deploy note
Orchestrator rebuild required to take effect.

🤖 Generated with Claude Code