### PR TITLE
Fix #407: Caddy conf.d include so deployment routes survive updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,9 @@ konkurrenzanalyse-*.pdf
 SECURITY-TODO.md
 todo.md
 CLAUDE.md
+
+# Deployment-specific Caddy routes — operators drop *.caddy files into conf.d/.
+# The directory placeholder and its README stay tracked; operator routes do not.
+/conf.d/*
+!/conf.d/.gitkeep
+!/conf.d/README.md

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,5 +1,15 @@
 # Internal reverse proxy - Cloudflare Tunnel terminates TLS
 # Caddy routes requests to the correct backend service
+#
+# Deployment-specific routes: do NOT edit this tracked file (a git pull would
+# clobber your changes). Drop your own `*.caddy` snippets into ./conf.d/ instead
+# — they are imported below and are git-ignored, so they survive every update.
+#
+# Reload caveat: this file is bind-mounted as a SINGLE file
+# (./Caddyfile:/etc/caddy/Caddyfile:ro). Editing it with `sed -i` replaces the
+# inode, so the container keeps serving the OLD config while `caddy validate`
+# and `caddy reload` both report success against the stale file. After such an
+# edit, run `docker restart ai-employee-caddy` to actually pick up the change.
 
 :80 {
 	# Security headers (defence in depth — also set by FastAPI middleware)
@@ -11,6 +21,12 @@
 		Permissions-Policy "camera=(), microphone=(self), geolocation=()"
 		-Server
 	}
+
+	# Deployment-specific routes. Operators add their own handle/route blocks as
+	# ./conf.d/*.caddy files (see conf.d/README.md). handle blocks are matched
+	# most-specific-first, so custom specific paths win over the catch-all below.
+	# An empty glob (no *.caddy files) is not an error in Caddy v2.
+	import conf.d/*.caddy
 
 	# Kiosk is LOCAL-ONLY. Requests coming through the Cloudflare tunnel carry a
 	# Cf-Ray header → 404. Requests from the Pi's own browser hit Caddy directly

--- a/conf.d/README.md
+++ b/conf.d/README.md
@@ -1,0 +1,42 @@
+# Deployment-specific Caddy routes
+
+Drop your own Caddy route snippets here as `*.caddy` files. They are imported by
+the main `Caddyfile` (`import conf.d/*.caddy`, inside the `:80 { ... }` site
+block) and are **git-ignored**, so they survive every `git pull` / update — you
+never have to edit the tracked `Caddyfile` and never hit a merge conflict on it.
+
+## Example
+
+Create `conf.d/mytool.caddy`:
+
+```caddy
+# Route an extra hostname/path to a custom service. handle blocks are matched
+# most-specific-first, so this wins over the catch-all frontend route.
+handle /mytool* {
+	reverse_proxy my-tool-service:9000
+}
+```
+
+Only put the **directives that belong inside the existing `:80 { ... }` site
+block** here (e.g. `handle`, `route`, `reverse_proxy`, `redir`). Do not open a
+new site block — these snippets are imported *inside* the existing one.
+
+## Applying changes
+
+`conf.d/` is bind-mounted as a directory, so edits are visible to the container.
+Reload with:
+
+```sh
+docker exec ai-employee-caddy caddy reload --config /etc/caddy/Caddyfile
+```
+
+> Note: the top-level `Caddyfile` itself is bind-mounted as a *single file*.
+> Editing it with `sed -i` replaces the inode and Caddy keeps serving the stale
+> config even though `caddy reload` reports success — use
+> `docker restart ai-employee-caddy` after editing that file. Files in this
+> directory do not have that problem.
+
+## What is tracked
+
+Only `.gitkeep` and this `README.md` are tracked. Your `*.caddy` files are
+ignored (see the repo `.gitignore`).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -263,6 +263,10 @@ services:
     container_name: ai-employee-caddy
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      # Deployment-specific routes: drop *.caddy snippets into ./conf.d/ (git-ignored,
+      # imported by Caddyfile). Mounting the directory (not a single file) also avoids
+      # the inode-replacement reload trap documented in the Caddyfile.
+      - ./conf.d:/etc/caddy/conf.d:ro
     depends_on:
       - orchestrator
       - frontend


### PR DESCRIPTION
Fixes #407

## Problem
`Caddyfile` is tracked, has no include mechanism and no example variant, and is not in `.gitignore`. Any deployment-specific route an operator adds therefore lives in a tracked file and collides with every `git pull`. The shipped config already assumes a fronting proxy (Cloudflare Tunnel), so adding routes is the expected case, not exotic (cf. #374).

## Fix (option 1 from the issue — the smaller change)
- **Caddyfile:** `import conf.d/*.caddy` inside the `:80 { ... }` site block. Operators drop their own `*.caddy` snippets into `conf.d/` and never touch the tracked file. An empty glob is not an error in Caddy v2. `handle` blocks are matched most-specific-first, so custom routes win over the catch-all.
- **docker-compose.yml:** bind-mount `./conf.d:/etc/caddy/conf.d:ro` so the imported files are actually visible in the container. Mounting the directory (not a single file) also sidesteps the inode trap below.
- **.gitignore:** ignore operator `conf.d/*.caddy` files, keep the tracked `conf.d/.gitkeep` + `conf.d/README.md`.
- **Documented the reload trap** in the Caddyfile: the top-level file is bind-mounted as a single file, so `sed -i` replaces the inode and Caddy keeps serving the stale config while `caddy validate`/`caddy reload` report success — needs `docker restart ai-employee-caddy`.
- **conf.d/README.md** explains usage + the trap for operators.

## Verification
- `.gitignore` behaviour confirmed with `git check-ignore`: `conf.d/zztest.caddy` ignored; `.gitkeep`/`README.md` tracked.
- `docker-compose.yml` parses cleanly; caddy volumes now include the `conf.d` mount.