### PR TITLE
Fix (Phase 1) #406: correct update-banner command to actually pull code

### DIFF
--- a/frontend/src/components/layout/update-banner.tsx
+++ b/frontend/src/components/layout/update-banner.tsx
@@ -237,7 +237,7 @@ export function UpdateBanner() {
               {/* Footer */}
               <div className="border-t border-foreground/[0.06] px-6 py-3 flex items-center justify-between">
                 <p className="text-[11px] text-muted-foreground/50">
-                  Update: <code className="font-mono text-[10px]">docker compose up --build</code>
+                  Update: <code className="font-mono text-[10px]">git pull && docker compose up -d --build</code>
                 </p>
                 <Dialog.Close className="rounded-xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-lg shadow-primary/20 hover:bg-primary/90 transition-colors">
                   Verstanden


### PR DESCRIPTION
Phase 1 of #406 (keep the issue open — see remaining scope below).

## Problem (part 1 of the issue)
The in-app update banner instructs operators to run `docker compose up --build`. That only rebuilds images from the code already checked out — without a `git pull` first the version stays exactly where it was. Operators follow the banner, see no effect, and repeat the build while the code never changes.

## Fix
`frontend/src/components/layout/update-banner.tsx`: banner command changed to `git pull && docker compose up -d --build`, which actually fetches new code and recreates containers detached.

## Remaining scope (still open in #406, follow-up)
- A guided `scripts/update.sh` (pull → rebuild → restart → verify version), pointed to by the banner.
- A frontend↔backend version handshake (bake the frontend build version, compare against `/api/v1/version` on load, warn on divergence) so a partial build / stale image is visible.
- Docs on the bind-mount (orchestrator, live on pull) vs baked-image (frontend, needs rebuild) asymmetry.

These are larger changes (the version handshake needs frontend build-time baking); splitting keeps this trivial, correct fix independently mergeable.