### PR TITLE
fix(telegram): re-establish chat listener after restart (follow-up #408)

### DIFF
--- a/orchestrator/app/telegram/handlers/commands.py
+++ b/orchestrator/app/telegram/handlers/commands.py
@@ -261,6 +261,25 @@ async def _handle_rating_callback(query, data: str) -> None:
         await query.edit_message_text(f"❌ Fehler beim Bewerten: {e}")
 
 
+def _ensure_listener(bot, chat_id: int, agent_id: str, restart: bool = False) -> None:
+    """Ensure a response listener task is running for ``chat_id``.
+
+    ``restart=True`` always (re)creates the task (used by /chat). Otherwise the
+    listener is only started when none is currently running for this chat — the
+    lazy path that re-establishes the process-local task after a restart, since
+    only the chat mapping (not the asyncio.Task) survives in Redis.
+    """
+    existing = _chat_listeners.get(chat_id)
+    alive = existing is not None and not existing.done()
+    if alive and not restart:
+        return
+    if existing is not None:
+        existing.cancel()
+    _chat_listeners[chat_id] = asyncio.create_task(
+        _listen_agent_responses(bot, chat_id, agent_id)
+    )
+
+
 async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle regular text messages - forward to active chat agent."""
     chat_id = update.effective_chat.id
@@ -272,6 +291,12 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             "Kein aktiver Chat. Starte mit /chat einen Chat mit einem Agent."
         )
         return
+
+    # The chat mapping is persisted in Redis (survives restarts) but the response
+    # listener is a process-local asyncio.Task that is lost on restart. Re-establish
+    # it here, otherwise the agent's reply is published to Redis but never forwarded
+    # to Telegram — the bot would accept messages and stay silent (#408).
+    _ensure_listener(update.message.get_bot(), chat_id, agent_id)
 
     text = update.message.text
 
@@ -309,15 +334,9 @@ async def _start_chat_session(
     """Start a chat session with an agent and set up response listener."""
     await set_active_chat(chat_id, agent_id)
 
-    # Cancel existing listener if any
-    if chat_id in _chat_listeners:
-        _chat_listeners[chat_id].cancel()
-
-    # Start response listener
+    # (Re)start the response listener for this chat.
     bot = update.get_bot() if callback_query else update.message.get_bot()
-    _chat_listeners[chat_id] = asyncio.create_task(
-        _listen_agent_responses(bot, chat_id, agent_id)
-    )
+    _ensure_listener(bot, chat_id, agent_id, restart=True)
 
     msg = (
         f"💬 Chat mit Agent `{agent_id}` gestartet!\n\n"

--- a/orchestrator/tests/test_telegram_relisten_after_restart.py
+++ b/orchestrator/tests/test_telegram_relisten_after_restart.py
@@ -1,0 +1,111 @@
+"""Regression test for the #408 follow-up: re-establish the response listener.
+
+The chat-to-agent mapping persists in Redis (issue #408), but the per-chat
+response listener is a process-local ``asyncio.Task`` that is lost on restart.
+Before this fix, after a restart the bot would accept a message on a persisted
+chat (mapping still present) and forward it to the agent, but nobody was
+listening on ``agent:<id>:chat:response`` — so the agent's reply never reached
+Telegram and the bot appeared to hang silently.
+
+These tests verify that a message on a persisted chat with NO live listener
+lazily (re)starts one, and that an already-running listener is left untouched.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.telegram.handlers import commands
+
+
+@pytest.fixture(autouse=True)
+def _clear_listeners():
+    commands._chat_listeners.clear()
+    yield
+    for task in commands._chat_listeners.values():
+        task.cancel()
+    commands._chat_listeners.clear()
+
+
+def _make_update(chat_id: int, text: str = "hello"):
+    """Build a minimal fake telegram Update for handle_message."""
+    bot = object()
+    message = AsyncMock()
+    message.text = text
+    message.message_id = 1
+    message.get_bot = lambda: bot  # get_bot is synchronous in python-telegram-bot
+
+    update = AsyncMock()
+    update.effective_chat.id = chat_id
+    update.effective_user.username = "grevvy"
+    update.effective_user.first_name = "Grevvy"
+    update.message = message
+    return update
+
+
+@pytest.mark.asyncio
+async def test_message_on_persisted_chat_restarts_listener():
+    chat_id = 4242
+    # Simulate post-restart state: mapping persists, no in-process listener.
+    assert chat_id not in commands._chat_listeners
+
+    async def _noop_listener(bot, cid, aid):
+        await asyncio.sleep(3600)
+
+    with patch.object(commands, "get_active_chat", AsyncMock(return_value="agent-1")), \
+         patch.object(commands, "_listen_agent_responses", _noop_listener), \
+         patch.object(commands.aioredis, "from_url") as from_url:
+        redis = AsyncMock()
+        from_url.return_value = redis
+
+        update = _make_update(chat_id)
+        await commands.handle_message(update, None)
+
+        # The listener must have been lazily (re)established.
+        assert chat_id in commands._chat_listeners
+        assert not commands._chat_listeners[chat_id].done()
+        # And the message was still forwarded to the agent.
+        redis.lpush.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_existing_live_listener_is_not_replaced():
+    chat_id = 7777
+
+    async def _noop_listener(bot, cid, aid):
+        await asyncio.sleep(3600)
+
+    with patch.object(commands, "get_active_chat", AsyncMock(return_value="agent-2")), \
+         patch.object(commands, "_listen_agent_responses", _noop_listener), \
+         patch.object(commands.aioredis, "from_url") as from_url:
+        from_url.return_value = AsyncMock()
+
+        # Prime a live listener as if /chat had already been issued this process.
+        commands._ensure_listener(object(), chat_id, "agent-2", restart=True)
+        first = commands._chat_listeners[chat_id]
+
+        update = _make_update(chat_id)
+        await commands.handle_message(update, None)
+
+        # Same task object — a healthy listener must not be churned per message.
+        assert commands._chat_listeners[chat_id] is first
+
+
+@pytest.mark.asyncio
+async def test_dead_listener_is_replaced():
+    chat_id = 9001
+
+    async def _noop_listener(bot, cid, aid):
+        await asyncio.sleep(3600)
+
+    with patch.object(commands, "_listen_agent_responses", _noop_listener):
+        # A finished (dead) task stands in for a listener whose loop exited.
+        dead = asyncio.create_task(asyncio.sleep(0))
+        await dead
+        commands._chat_listeners[chat_id] = dead
+
+        commands._ensure_listener(object(), chat_id, "agent-3")
+
+        assert commands._chat_listeners[chat_id] is not dead
+        assert not commands._chat_listeners[chat_id].done()


### PR DESCRIPTION
## Deeper review of #409 (already merged) — a defect the first approve missed

#409 (merged as `80b2d37`) correctly persists the Telegram `chat_id → agent_id`
mapping in Redis so it survives an orchestrator restart. But it left a gap that
means **issue #408's user-visible symptom is not actually resolved**.

### The defect
The per-chat **response listener** (`_chat_listeners[chat_id]`) is a process-local
`asyncio.Task`, started **only** in `_start_chat_session` (on `/chat`). It is lost
on restart. After a restart:

1. `handle_message` calls `get_active_chat(chat_id)` → returns the agent_id (mapping persists ✅)
2. the message is `lpush`ed to `agent:<id>:chat` and a "typing" indicator shows
3. …but **nobody is subscribed** to `agent:<id>:chat:response`, so the agent's
   reply is published to Redis and dropped.

Net effect: the bot silently accepts the message, shows a hung "typing" indicator,
and never replies — and it no longer even shows the `Kein aktiver Chat. Starte mit /chat`
hint (the mapping now says a chat is active). That is arguably **worse** than the
pre-#409 behavior #408 set out to fix.

### The fix
`handle_message` now lazily re-establishes the listener via a small
`_ensure_listener(bot, chat_id, agent_id)` helper whenever a persisted mapping
exists but no live task is running. `/chat` keeps its force-restart semantics
(`restart=True`). A healthy running listener is never churned per-message; a dead
task is replaced.

### Tests
`tests/test_telegram_relisten_after_restart.py`:
- message on a persisted chat with no live listener → listener re-established, message still forwarded
- an already-running listener is left untouched (no per-message churn)
- a dead/finished task is replaced

Both new and existing (`test_telegram_active_chats.py`) suites pass locally; app import smoke OK.

Follow-up to #409 / #408.