### PR TITLE
Fix #417: import conf.d snippets at top level for own-hostname site blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,12 @@ todo.md
 CLAUDE.md
 
 # Deployment-specific Caddy routes — operators drop *.caddy files into conf.d/.
-# The directory placeholder and its README stay tracked; operator routes do not.
+# conf.d/ holds whole site blocks (own hostname); conf.d/site/ holds extra paths
+# on the main host. The directory placeholders and README stay tracked; operator
+# routes do not.
 /conf.d/*
 !/conf.d/.gitkeep
 !/conf.d/README.md
+!/conf.d/site/
+/conf.d/site/*
+!/conf.d/site/.gitkeep

--- a/Caddyfile
+++ b/Caddyfile
@@ -11,6 +11,14 @@
 # and `caddy reload` both report success against the stale file. After such an
 # edit, run `docker restart ai-employee-caddy` to actually pick up the change.
 
+# TOP-LEVEL import: whole site blocks that define their OWN hostname (e.g. a
+# Cloudflare-Access "bypass" host that must be a separate site — see #374). A
+# snippet imported here may open its own `example.com:80 { ... }` block. Extra
+# PATHS on the existing host go in conf.d/site/ instead (imported below, inside
+# the :80 block). `import` is evaluated before parsing and may appear anywhere;
+# an empty glob is not an error in Caddy v2. See conf.d/README.md.
+import conf.d/*.caddy
+
 :80 {
 	# Security headers (defence in depth — also set by FastAPI middleware)
 	header {
@@ -22,11 +30,12 @@
 		-Server
 	}
 
-	# Deployment-specific routes. Operators add their own handle/route blocks as
-	# ./conf.d/*.caddy files (see conf.d/README.md). handle blocks are matched
-	# most-specific-first, so custom specific paths win over the catch-all below.
-	# An empty glob (no *.caddy files) is not an error in Caddy v2.
-	import conf.d/*.caddy
+	# Deployment-specific routes on THIS host. Operators add their own handle/route
+	# blocks as ./conf.d/site/*.caddy files (see conf.d/README.md). handle blocks
+	# are matched most-specific-first, so custom specific paths win over the
+	# catch-all below. An empty glob (no *.caddy files) is not an error in Caddy
+	# v2. Snippets that need their OWN hostname go in conf.d/ (top-level import).
+	import conf.d/site/*.caddy
 
 	# Kiosk is LOCAL-ONLY. Requests coming through the Cloudflare tunnel carry a
 	# Cf-Ray header → 404. Requests from the Pi's own browser hit Caddy directly

--- a/conf.d/README.md
+++ b/conf.d/README.md
@@ -1,25 +1,72 @@
 # Deployment-specific Caddy routes
 
 Drop your own Caddy route snippets here as `*.caddy` files. They are imported by
-the main `Caddyfile` (`import conf.d/*.caddy`, inside the `:80 { ... }` site
-block) and are **git-ignored**, so they survive every `git pull` / update — you
-never have to edit the tracked `Caddyfile` and never hit a merge conflict on it.
+the main `Caddyfile` and are **git-ignored**, so they survive every `git pull` /
+update — you never have to edit the tracked `Caddyfile` and never hit a merge
+conflict on it.
 
-## Example
+There are **two directories** because a Caddy snippet can be one of two shapes,
+and each is only valid in one position:
 
-Create `conf.d/mytool.caddy`:
+| Put it in…       | For…                                   | The snippet contains…                     |
+| ---------------- | -------------------------------------- | ----------------------------------------- |
+| `conf.d/`        | an **extra hostname** (own site block) | a full `host:80 { … }` block              |
+| `conf.d/site/`   | **extra paths** on the main `:80` host | directives only (`handle`, `route`, …)    |
+
+The main `Caddyfile` imports `conf.d/*.caddy` at the **top level** (where whole
+site blocks are legal) and `conf.d/site/*.caddy` **inside** the `:80 { … }` block
+(where only directives are legal). Putting a file in the wrong directory produces
+a Caddy parse error — a site block inside `:80 { … }`, or a bare `handle` at the
+top level — so match the shape to the folder.
+
+## Example — extra path on the main host → `conf.d/site/mytool.caddy`
 
 ```caddy
-# Route an extra hostname/path to a custom service. handle blocks are matched
+# Route an extra path to a custom service. handle blocks are matched
 # most-specific-first, so this wins over the catch-all frontend route.
 handle /mytool* {
 	reverse_proxy my-tool-service:9000
 }
 ```
 
-Only put the **directives that belong inside the existing `:80 { ... }` site
-block** here (e.g. `handle`, `route`, `reverse_proxy`, `redir`). Do not open a
-new site block — these snippets are imported *inside* the existing one.
+Only **directives that belong inside the existing `:80 { … }` site block** go
+here (e.g. `handle`, `route`, `reverse_proxy`, `redir`). Do **not** open a new
+site block — these snippets are imported *inside* the existing one.
+
+## Example — extra hostname → `conf.d/bridge.caddy`
+
+Use this when a path set needs its **own hostname**, e.g. a Cloudflare-Access
+*bypass* host: the Computer-Use bridge cannot send `CF-Access-Client-Id` /
+`CF-Access-Client-Secret`, so its hostname must be set to *Bypass* in Cloudflare
+Access, which in Caddy means a **separate site block**:
+
+```caddy
+# A dedicated bypass host: only the narrow set of paths the bridge needs is
+# reachable here, without Access; everything else stays behind Access on the
+# main host. Note: Caddy rejects an inline `handle /x { … }` one-liner
+# ("Unexpected next token after '{' on same line") — put the block on its own
+# lines as below.
+bridge.example.com:80 {
+	handle /ws/computer-use/bridge* {
+		reverse_proxy ai-employee-orchestrator:8000
+	}
+	handle /api/v1/auth/login {
+		reverse_proxy ai-employee-orchestrator:8000
+	}
+	handle /api/v1/computer-use* {
+		reverse_proxy ai-employee-orchestrator:8000
+	}
+	handle /api/v1/agents* {
+		reverse_proxy ai-employee-orchestrator:8000
+	}
+	handle {
+		respond "Not found" 404
+	}
+}
+```
+
+Because this opens its own site block it must live in `conf.d/` (top level), not
+in `conf.d/site/`.
 
 ## Applying changes
 
@@ -34,9 +81,10 @@ docker exec ai-employee-caddy caddy reload --config /etc/caddy/Caddyfile
 > Editing it with `sed -i` replaces the inode and Caddy keeps serving the stale
 > config even though `caddy reload` reports success — use
 > `docker restart ai-employee-caddy` after editing that file. Files in this
-> directory do not have that problem.
+> directory (and `site/`) do not have that problem.
 
 ## What is tracked
 
-Only `.gitkeep` and this `README.md` are tracked. Your `*.caddy` files are
-ignored (see the repo `.gitignore`).
+Only `.gitkeep`, `site/.gitkeep` and this `README.md` are tracked. Your
+`*.caddy` files (in both `conf.d/` and `conf.d/site/`) are ignored (see the repo
+`.gitignore`).


### PR DESCRIPTION
Fixes #417 (follow-up to #407 / e1bae9b).

## Problem
The `conf.d` include added in #407 sat only **inside** the `:80` site block, so a snippet could contain directives but not open its own site block (a parse error there). Extra-**hostname** deployments — e.g. a Cloudflare-Access *bypass* host for the Computer-Use bridge (#374), which must be a separate site block — therefore still had to live in the tracked `Caddyfile` and collided on every `git pull` that touched it. The 1.127.0 → 1.128.0 auto-merge succeeded by luck (different offsets), not by design.

## Fix (the two-directory approach the issue recommends)
- **`conf.d/*.caddy`** imported at the **top level** → whole site blocks (own hostname).
- **`conf.d/site/*.caddy`** imported **inside** `:80 { … }` → extra paths on the main host.

Two directories keep the two meanings apart, so a snippet in the wrong place fails obviously instead of subtly.

- `.gitignore`: tracks `conf.d/site/.gitkeep`, ignores operator `*.caddy` in both dirs.
- `conf.d/README.md`: documents which shape belongs where, with copy-paste-correct examples. Also notes that Caddy rejects inline `handle /x { … }` one-liners ("Unexpected next token after '{' on same line") — examples use multi-line blocks.

## Verification (caddy v2.11.4 `validate`, real binary)
| Case | Result |
| --- | --- |
| Empty globs (tracked default state) | ✅ Valid |
| Extra-path snippet in `conf.d/site/` | ✅ Valid |
| Extra-hostname site block in `conf.d/` | ✅ Valid |
| Site block wrongly placed in `conf.d/site/` | ❌ Fails (as intended) |
| Both README examples together | ✅ Valid |

Default tracked behavior is unchanged (both globs empty → identical to before). Opt-in for operators only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)