### PR TITLE
fix(bridge): Cmd+V/Copy/Paste in macOS modal dialogs (fixes #420)

### DIFF
--- a/computer-use-bridge/tray_app.py
+++ b/computer-use-bridge/tray_app.py
@@ -499,6 +499,38 @@ def _input(cv, x, y, w, placeholder="", secure=False, value=""):
     return f
 
 
+def _install_edit_menu() -> None:
+    """Install a minimal hidden Edit menu so Cmd+V/C/X/A/Z work in modal dialogs.
+
+    An LSUIElement app has no menu bar, so NSApp never translates Cmd+key into
+    responder-chain actions. A main menu that's invisible-to-the-user but present
+    in NSApplication fixes this for all modal NSWindow dialogs at once.
+    """
+    if not IS_MAC:
+        return
+    try:
+        from AppKit import NSApp, NSMenu, NSMenuItem
+        main_menu = NSMenu.alloc().init()
+        app_slot = NSMenuItem.alloc().init()
+        main_menu.addItem_(app_slot)
+
+        edit_menu = NSMenu.alloc().initWithTitle_("Edit")
+        for title, sel, key in (
+            ("Undo",       "undo:",       "z"),
+            ("Redo",       "redo:",       "Z"),   # Cmd+Shift+Z
+            ("Cut",        "cut:",        "x"),
+            ("Copy",       "copy:",       "c"),
+            ("Paste",      "paste:",      "v"),
+            ("Select All", "selectAll:",  "a"),
+        ):
+            # target=None -> action travels down the responder chain to the focused field
+            edit_menu.addItemWithTitle_action_keyEquivalent_(title, sel, key)
+        app_slot.setSubmenu_(edit_menu)
+        NSApp.setMainMenu_(main_menu)
+    except Exception:
+        pass  # non-macOS or AppKit not available - silent no-op
+
+
 def _button(cv, title, x, y, w=120, h=28, key="", style=1):
     from AppKit import NSButton
     b = NSButton.alloc().initWithFrame_(((x, y), (w, h)))
@@ -1485,6 +1517,8 @@ def run_macos(cfg: dict) -> None:
         import rumps
     except ImportError:
         print("Install rumps: pip install rumps"); sys.exit(1)
+
+    _install_edit_menu()
 
     class BridgeApp(rumps.App):
         def __init__(self):

--- a/computer-use-bridge/tray_app.py
+++ b/computer-use-bridge/tray_app.py
@@ -505,11 +505,18 @@ def _install_edit_menu() -> None:
     An LSUIElement app has no menu bar, so NSApp never translates Cmd+key into
     responder-chain actions. A main menu that's invisible-to-the-user but present
     in NSApplication fixes this for all modal NSWindow dialogs at once.
+
+    Note: this runs BEFORE rumps starts its run loop, so the shared NSApplication
+    may not exist yet — the bare `NSApp` global would still be nil here and the
+    menu would silently never install. We call `NSApplication.sharedApplication()`
+    to obtain (creating if needed) the singleton rumps will reuse, so the menu
+    actually sticks.
     """
     if not IS_MAC:
         return
     try:
-        from AppKit import NSApp, NSMenu, NSMenuItem
+        from AppKit import NSApplication, NSMenu, NSMenuItem
+        app = NSApplication.sharedApplication()
         main_menu = NSMenu.alloc().init()
         app_slot = NSMenuItem.alloc().init()
         main_menu.addItem_(app_slot)
@@ -526,9 +533,11 @@ def _install_edit_menu() -> None:
             # target=None -> action travels down the responder chain to the focused field
             edit_menu.addItemWithTitle_action_keyEquivalent_(title, sel, key)
         app_slot.setSubmenu_(edit_menu)
-        NSApp.setMainMenu_(main_menu)
-    except Exception:
-        pass  # non-macOS or AppKit not available - silent no-op
+        app.setMainMenu_(main_menu)
+    except Exception as e:
+        # AppKit unavailable or menu install failed. Don't crash the tray app,
+        # but make it traceable — a silent no-op here is what re-breaks Cmd+V.
+        print(f"[edit-menu] could not install Edit menu: {e}")
 
 
 def _button(cv, title, x, y, w=120, h=28, key="", style=1):


### PR DESCRIPTION
## Problem
The bridge's macOS tray app has no main menu (`LSUIElement`), so Cmd+V never reaches text fields in the setup dialog. Users have to right-click→Paste, which is not discoverable.

## Fix
Install a minimal, invisible Edit+Undo menu via `NSApp.setMainMenu_()` once at startup in `run_macos()`. Actions target `nil` so they travel down the first-responder chain to whatever field is focused — no per-dialog wiring needed.

## Tests
- No automated tests possible (macOS UI) — verify manually: launch the bridge fresh, open the setup dialog, copy a token, Cmd+V into the URL field → value must paste.
- Local: `python -m py_compile computer-use-bridge/tray_app.py`
- Local: `git diff --check`
- The change is entirely inside the macOS path, no other platform affected.

Fixes #420