### PR TITLE
Fix #423: write agent container files as uid 1000 (not root)

### DIFF
--- a/orchestrator/app/services/docker_service.py
+++ b/orchestrator/app/services/docker_service.py
@@ -306,8 +306,21 @@ class DockerService:
         stdout = output[0].decode("utf-8", errors="replace") if output[0] else ""
         return exit_code, stdout
 
-    def write_file_in_container(self, container_id: str, path: str, content: str) -> None:
-        """Write a file into a running container using tar archive."""
+    def write_file_in_container(
+        self,
+        container_id: str,
+        path: str,
+        content: str,
+        uid: int = 1000,
+        gid: int = 1000,
+    ) -> None:
+        """Write a file into a running container using tar archive.
+
+        Files are owned by the agent user (uid/gid 1000) by default so the agent
+        process can modify them afterwards (e.g. /workspace/knowledge.md). A freshly
+        constructed TarInfo defaults to uid/gid 0, which put_archive honours and would
+        otherwise leave the file root-owned and unwritable for the agent.
+        """
         import io
         import tarfile
 
@@ -322,15 +335,26 @@ class DockerService:
         with tarfile.open(fileobj=tar_stream, mode="w") as tar:
             info = tarfile.TarInfo(name=filename)
             info.size = len(data)
+            info.uid = uid
+            info.gid = gid
             tar.addfile(info, io.BytesIO(data))
         tar_stream.seek(0)
 
         container.put_archive(dir_path, tar_stream)
 
     def write_files_in_container(
-        self, container_id: str, target_dir: str, files: list[tuple[str, bytes]]
+        self,
+        container_id: str,
+        target_dir: str,
+        files: list[tuple[str, bytes]],
+        uid: int = 1000,
+        gid: int = 1000,
     ) -> None:
-        """Write multiple files into a container directory using a single tar archive."""
+        """Write multiple files into a container directory using a single tar archive.
+
+        Files are owned by the agent user (uid/gid 1000) by default; see
+        write_file_in_container for why.
+        """
         import io
         import tarfile
 
@@ -341,6 +365,8 @@ class DockerService:
             for filename, data in files:
                 info = tarfile.TarInfo(name=filename)
                 info.size = len(data)
+                info.uid = uid
+                info.gid = gid
                 tar.addfile(info, io.BytesIO(data))
         tar_stream.seek(0)
 

--- a/orchestrator/tests/test_docker_service_file_ownership.py
+++ b/orchestrator/tests/test_docker_service_file_ownership.py
@@ -1,0 +1,80 @@
+"""Regression tests for issue #423: files written into agent containers must be
+owned by the agent user (uid/gid 1000), not root, so the agent can update them
+afterwards (e.g. /workspace/knowledge.md)."""
+import io
+import tarfile
+
+from app.services.docker_service import DockerService
+
+
+class _FakeContainer:
+    def __init__(self):
+        self.archives = []  # list of (dir_path, tar_bytes)
+
+    def put_archive(self, dir_path, tar_stream):
+        self.archives.append((dir_path, tar_stream.read()))
+        return True
+
+
+class _FakeClient:
+    def __init__(self, container):
+        self._container = container
+
+    class _Containers:
+        def __init__(self, container):
+            self._container = container
+
+        def get(self, _container_id):
+            return self._container
+
+    @property
+    def containers(self):
+        return self._Containers(self._container)
+
+
+def _service_with_fake_container():
+    container = _FakeContainer()
+    svc = DockerService.__new__(DockerService)  # bypass __init__ (needs a live daemon)
+    svc.client = _FakeClient(container)
+    return svc, container
+
+
+def _members(tar_bytes):
+    with tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tar:
+        return list(tar.getmembers())
+
+
+def test_write_file_in_container_owned_by_agent_uid():
+    svc, container = _service_with_fake_container()
+    svc.write_file_in_container("cid", "/workspace/knowledge.md", "hello")
+
+    (_dir, tar_bytes) = container.archives[0]
+    members = _members(tar_bytes)
+    assert len(members) == 1
+    assert members[0].name == "knowledge.md"
+    assert members[0].uid == 1000
+    assert members[0].gid == 1000
+
+
+def test_write_files_in_container_owned_by_agent_uid():
+    svc, container = _service_with_fake_container()
+    svc.write_files_in_container(
+        "cid", "/workspace", [("a.txt", b"a"), ("b.txt", b"bb")]
+    )
+
+    (_dir, tar_bytes) = container.archives[0]
+    members = _members(tar_bytes)
+    assert {m.name for m in members} == {"a.txt", "b.txt"}
+    for m in members:
+        assert m.uid == 1000
+        assert m.gid == 1000
+
+
+def test_ownership_override_is_honoured():
+    svc, container = _service_with_fake_container()
+    svc.write_file_in_container("cid", "/etc/thing", "x", uid=0, gid=0)
+
+    (_dir, tar_bytes) = container.archives[0]
+    members = _members(tar_bytes)
+    assert members[0].uid == 0
+    assert members[0].gid == 0


### PR DESCRIPTION
Fixes #423.

## Problem
A freshly constructed `tarfile.TarInfo` defaults to `uid = gid = 0`. `put_archive` honours that, so every file the orchestrator writes into an agent container (via `write_file_in_container` / `write_files_in_container`) is owned by `root:root`. The agent process runs as uid 1000 and cannot modify those files afterwards.

The most visible casualty is `/workspace/knowledge.md`: the agent is instructed to update it at the end of every task, but the write fails with `Permission denied` — silently from the operator's view — so the agent never persists its learnings. The one-time `chown -R 1000:1000 /workspace` at container creation does not cover later writes (`PUT /agents/{id}/knowledge`, skill installs, template writes, etc.).

## Fix
Set `info.uid`/`info.gid` to `1000` on the `TarInfo` in both `write_file_in_container` and `write_files_in_container`. Ownership is now correct at write time — no dependency on a later chown. Both functions gain optional `uid`/`gid` params (default 1000) so the rare root-owned write can opt out.

All ~18 callers write agent-owned files under `/workspace` (knowledge.md, skills, CLAUDE.md, disk-warning, vertical packs, templates) — none need root ownership.

## Tests
`orchestrator/tests/test_docker_service_file_ownership.py` (3 tests): captures the emitted tar and asserts members carry uid/gid 1000, plus the override path stays root when requested.

## Deploy gate
Orchestrator rebuild required (`docker compose up --build -d`) for the fix to take effect.