### PR TITLE
Fix #424: pass bearer tokens/headers to 'claude mcp add'

### DIFF
--- a/agent/app/main.py
+++ b/agent/app/main.py
@@ -53,6 +53,55 @@ def _run_mcp_add(args: list[str]) -> bool:
         return False
 
 
+def _load_custom_mcp_auth() -> dict:
+    """Parse CUSTOM_MCP_AUTH ({server_name: bearer_token}) from the environment."""
+    raw = os.environ.get("CUSTOM_MCP_AUTH", "")
+    if not raw:
+        return {}
+    try:
+        auth = json.loads(raw)
+        return auth if isinstance(auth, dict) else {}
+    except (json.JSONDecodeError, TypeError):
+        print("[Agent] Warning: Could not parse CUSTOM_MCP_AUTH")
+        return {}
+
+
+def _load_custom_mcp_headers() -> dict:
+    """Parse CUSTOM_MCP_HEADERS ({server_name: {header: value}}) from the environment."""
+    raw = os.environ.get("CUSTOM_MCP_HEADERS", "")
+    if not raw:
+        return {}
+    try:
+        hdrs = json.loads(raw)
+        return hdrs if isinstance(hdrs, dict) else {}
+    except (json.JSONDecodeError, TypeError):
+        print("[Agent] Warning: Could not parse CUSTOM_MCP_HEADERS")
+        return {}
+
+
+def _auth_headers_for(name: str, auth: dict, headers: dict) -> dict:
+    """Return the merged {header: value} map for a server (keyed by original name).
+
+    A bearer token from CUSTOM_MCP_AUTH becomes an Authorization header; explicit
+    CUSTOM_MCP_HEADERS entries are added on top (and win on key collision).
+    """
+    result: dict[str, str] = {}
+    token = auth.get(name)
+    if token:
+        result["Authorization"] = f"Bearer {token}"
+    extra = headers.get(name)
+    if isinstance(extra, dict):
+        for key, value in extra.items():
+            if key and value is not None:
+                result[str(key)] = str(value)
+    return result
+
+
+def _auth_header_args(name: str, auth: dict, headers: dict) -> list[str]:
+    """Return `claude mcp add --header` values ("Key: Value") for a server."""
+    return [f"{k}: {v}" for k, v in _auth_headers_for(name, auth, headers).items()]
+
+
 def register_mcp_servers() -> None:
     """Register MCP servers via `claude mcp add` so Claude Code discovers them in -p mode.
 
@@ -197,13 +246,18 @@ def register_mcp_servers() -> None:
     # Custom HTTP servers from env (passed by orchestrator)
     custom_mcp = os.environ.get("CUSTOM_MCP_SERVERS", "")
     if custom_mcp:
+        auth = _load_custom_mcp_auth()
+        headers = _load_custom_mcp_headers()
         try:
             servers = json.loads(custom_mcp)
             for name, url in servers.items():
                 safe_name = _sanitize_mcp_name(name)
                 cmd_args = ["--transport", "http", safe_name, url]
+                for header in _auth_header_args(name, auth, headers):
+                    cmd_args += ["--header", header]
                 if _run_mcp_add(cmd_args):
-                    print(f"[Agent] Registered MCP server: {safe_name} -> {url} (http)")
+                    suffix = " (authenticated)" if len(cmd_args) > 4 else ""
+                    print(f"[Agent] Registered MCP server: {safe_name} -> {url} (http){suffix}")
                 else:
                     print(f"[Agent] WARN: Failed to register MCP server: {safe_name}")
         except (json.JSONDecodeError, AttributeError) as e:
@@ -231,9 +285,15 @@ def _write_mcp_json_fallback() -> None:
     # Custom servers
     custom_mcp = os.environ.get("CUSTOM_MCP_SERVERS", "")
     if custom_mcp:
+        auth = _load_custom_mcp_auth()
+        headers = _load_custom_mcp_headers()
         try:
             for name, url in json.loads(custom_mcp).items():
-                mcp_config["mcpServers"][_sanitize_mcp_name(name)] = {"url": url}
+                entry: dict = {"url": url}
+                hdrs = _auth_headers_for(name, auth, headers)
+                if hdrs:
+                    entry["headers"] = hdrs
+                mcp_config["mcpServers"][_sanitize_mcp_name(name)] = entry
         except (json.JSONDecodeError, AttributeError):
             pass
 

--- a/agent/tests/test_mcp_auth_headers.py
+++ b/agent/tests/test_mcp_auth_headers.py
@@ -1,0 +1,65 @@
+"""Regression tests for issue #424: bearer tokens from CUSTOM_MCP_AUTH (and custom
+headers from CUSTOM_MCP_HEADERS) must be passed to `claude mcp add` and into the
+.mcp.json fallback, otherwise authenticated MCP servers register without credentials
+and are unusable."""
+import json
+
+from app import main
+
+
+def test_auth_headers_for_builds_bearer():
+    hdrs = main._auth_headers_for("composio", {"composio": "tok123"}, {})
+    assert hdrs == {"Authorization": "Bearer tok123"}
+
+
+def test_auth_headers_for_merges_custom_headers():
+    hdrs = main._auth_headers_for(
+        "srv", {"srv": "t"}, {"srv": {"X-Api-Key": "k", "empty": None}}
+    )
+    assert hdrs == {"Authorization": "Bearer t", "X-Api-Key": "k"}
+
+
+def test_auth_headers_for_no_credentials():
+    assert main._auth_headers_for("srv", {}, {}) == {}
+
+
+def test_auth_header_args_format():
+    args = main._auth_header_args("srv", {"srv": "t"}, {"srv": {"X-Api-Key": "k"}})
+    assert "Authorization: Bearer t" in args
+    assert "X-Api-Key: k" in args
+
+
+def test_register_passes_header_to_claude_mcp_add(monkeypatch):
+    monkeypatch.setenv("CUSTOM_MCP_SERVERS", json.dumps({"composio": "https://x/mcp"}))
+    monkeypatch.setenv("CUSTOM_MCP_AUTH", json.dumps({"composio": "tok123"}))
+    monkeypatch.delenv("CUSTOM_MCP_HEADERS", raising=False)
+    # Neutralise the other registration paths so only the custom loop runs.
+    monkeypatch.delenv("COMPUTER_USE_BRIDGE_MCP_URL", raising=False)
+
+    calls = []
+    monkeypatch.setattr(main, "_run_mcp_add", lambda args: calls.append(args) or True)
+    monkeypatch.setattr(main, "_write_mcp_json_fallback", lambda: None)
+    # Skip built-in stdio + msgraph registration side effects.
+    monkeypatch.setattr(main, "_sanitize_mcp_name", lambda n: n)
+
+    main.register_mcp_servers()
+
+    custom_calls = [c for c in calls if "https://x/mcp" in c]
+    assert len(custom_calls) == 1
+    args = custom_calls[0]
+    assert "--header" in args
+    assert "Authorization: Bearer tok123" in args
+
+
+def test_mcp_json_fallback_includes_headers(monkeypatch, tmp_path):
+    monkeypatch.setenv("CUSTOM_MCP_SERVERS", json.dumps({"composio": "https://x/mcp"}))
+    monkeypatch.setenv("CUSTOM_MCP_AUTH", json.dumps({"composio": "tok123"}))
+    monkeypatch.delenv("CUSTOM_MCP_HEADERS", raising=False)
+    monkeypatch.setattr(main.settings, "workspace_dir", str(tmp_path))
+
+    main._write_mcp_json_fallback()
+
+    cfg = json.loads((tmp_path / ".mcp.json").read_text())
+    entry = cfg["mcpServers"]["composio"]
+    assert entry["url"] == "https://x/mcp"
+    assert entry["headers"] == {"Authorization": "Bearer tok123"}


### PR DESCRIPTION
Fixes #424.

## Problem
The orchestrator hands each agent container a bearer token per custom MCP server via `CUSTOM_MCP_AUTH`, but `register_mcp_servers()` in `agent/app/main.py` never read it. `claude mcp add` was called with no `--header`, so the Claude Code CLI — the agent's main runtime — registered every authenticated server without credentials:

```
composio: https://connect.composio.dev/mcp (HTTP) - ! Needs authentication
```

The `.mcp.json` fallback had the same gap. (This is also the root cause behind #425's "green but 401" mismatch: the orchestrator path used the token, the agent path did not.)

## Fix
Both the `claude mcp add` path and the `.mcp.json` fallback now read:
- `CUSTOM_MCP_AUTH` — `{server_name: bearer_token}` → `Authorization: Bearer <token>`
- `CUSTOM_MCP_HEADERS` — `{server_name: {header: value}}` → extra headers (x-api-key etc.)

merged per server (keyed by original name, matching `mcp_client.py` / `codex_runner.py` which already read these vars). `claude mcp add` receives `--header "Key: Value"`; `.mcp.json` gets a `headers` block.

## Security
Header values are passed as individual list arguments to `subprocess.run` (no `shell=True`), so a token cannot break out into a shell command. Tokens are never logged (the success line prints only "(authenticated)").

## Tests
`agent/tests/test_mcp_auth_headers.py` (6 tests): header merge/format, the register loop emitting `--header`, and the `.mcp.json` headers block. Full agent suite green except a pre-existing, unrelated `test_present_file_marker` failure (also fails on `main`).

## Deploy gate
Agent image rebuild required for the fix to take effect.