### PR TITLE
Phase 1: Persist and show MCP server health state

### DIFF
--- a/frontend/src/app/integrations/page.tsx
+++ b/frontend/src/app/integrations/page.tsx
@@ -23,6 +23,54 @@ const PROVIDER_ICONS: Record<string, typeof Mail> = {
   Github,
 };
 
+function formatRelativeCheckedAt(value: string | null): string {
+  if (!value) return "noch nicht geprüft";
+  const checkedAt = new Date(value).getTime();
+  if (Number.isNaN(checkedAt)) return "Zeitpunkt unbekannt";
+
+  const diffMs = Math.max(0, Date.now() - checkedAt);
+  const diffMinutes = Math.floor(diffMs / 60000);
+  if (diffMinutes < 1) return "gerade geprüft";
+  if (diffMinutes < 60) return `geprüft vor ${diffMinutes} Min`;
+
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `geprüft vor ${diffHours} Std`;
+
+  const diffDays = Math.floor(diffHours / 24);
+  return `geprüft vor ${diffDays} Tag${diffDays === 1 ? "" : "en"}`;
+}
+
+function formatMcpHealth(server: McpServerInfo): { ok: boolean; label: string; className: string } {
+  const checked = formatRelativeCheckedAt(server.last_checked_at);
+  if (!server.last_status) {
+    return {
+      ok: false,
+      label: `Status unbekannt · ${checked}`,
+      className: "text-muted-foreground/60",
+    };
+  }
+
+  if (server.last_status === "ok") {
+    return {
+      ok: true,
+      label: `erreichbar · ${checked}`,
+      className: "text-emerald-400",
+    };
+  }
+
+  const fallback = {
+    auth_failed: "Authentifizierung fehlgeschlagen",
+    unreachable: "nicht erreichbar",
+    protocol_error: "Protokollfehler",
+  }[server.last_status] ?? "Fehler";
+
+  return {
+    ok: false,
+    label: `${server.last_error || fallback} · ${checked}`,
+    className: server.last_status === "auth_failed" ? "text-amber-400" : "text-red-400",
+  };
+}
+
 export default function IntegrationsPage() {
   const confirm = useConfirm();
   const [integrations, setIntegrations] = useState<Integration[]>([]);
@@ -499,6 +547,7 @@ function McpServersSection({ onToast }: { onToast: (t: { type: "success" | "erro
       setServers((prev) => prev.map((s) => (s.id === id ? updated : s)));
       onToast({ type: "success", message: `Tools aktualisiert (${updated.tools.length} Tools)` });
     } catch (e) {
+      await loadServers();
       onToast({ type: "error", message: e instanceof Error ? e.message : "Refresh fehlgeschlagen" });
     } finally {
       setRefreshing(null);
@@ -697,6 +746,7 @@ function McpServersSection({ onToast }: { onToast: (t: { type: "success" | "erro
           {servers.map((server) => {
             const isExpanded = expandedServer === server.id;
             const toolCount = server.tools?.length || 0;
+            const health = formatMcpHealth(server);
 
             return (
               <div
@@ -734,13 +784,17 @@ function McpServersSection({ onToast }: { onToast: (t: { type: "success" | "erro
                       )}
                       <span className="inline-flex items-center gap-1 rounded-full bg-violet-500/10 px-2 py-0.5 text-[10px] font-medium text-violet-400">
                         <Wrench className="h-2.5 w-2.5" />
-                        {toolCount} Tool{toolCount !== 1 && "s"}
+                        {toolCount} Tool{toolCount !== 1 && "s"} entdeckt
                       </span>
                       {!server.enabled && (
                         <span className="text-[10px] text-muted-foreground/50">deaktiviert</span>
                       )}
                     </div>
                     <p className="text-xs text-muted-foreground/60 font-mono truncate mt-0.5">{server.url}</p>
+                    <div className={cn("mt-1 flex items-center gap-1.5 text-[11px]", health.className)}>
+                      {health.ok ? <CheckCircle2 className="h-3 w-3 shrink-0" /> : <AlertCircle className="h-3 w-3 shrink-0" />}
+                      <span className="truncate">{health.label}</span>
+                    </div>
                   </div>
 
                   {/* Actions */}

--- a/frontend/src/app/integrations/page.tsx
+++ b/frontend/src/app/integrations/page.tsx
@@ -40,13 +40,23 @@ function formatRelativeCheckedAt(value: string | null): string {
   return `geprüft vor ${diffDays} Tag${diffDays === 1 ? "" : "en"}`;
 }
 
-function formatMcpHealth(server: McpServerInfo): { ok: boolean; label: string; className: string } {
+// This status reflects the ORCHESTRATOR → MCP-server discovery check only. The
+// agent container's view (what actually fails a tool call, e.g. a 401 that the
+// orchestrator path never sees) is a separate #425 Phase-2 signal. The tooltip
+// spells that out so a green "erreichbar" is not misread as "agents can use it".
+const MCP_HEALTH_ORCH_ONLY =
+  "Server-seitige Discovery-Prüfung (Orchestrator → MCP-Server). " +
+  "Sie spiegelt nicht die Agent-Sicht wider — ein Server kann für Agent-Aufrufe " +
+  "trotzdem fehlschlagen (z. B. 401). Agent-Perspektive folgt in #425 Phase 2.";
+
+function formatMcpHealth(server: McpServerInfo): { ok: boolean; label: string; className: string; title: string } {
   const checked = formatRelativeCheckedAt(server.last_checked_at);
   if (!server.last_status) {
     return {
       ok: false,
       label: `Status unbekannt · ${checked}`,
       className: "text-muted-foreground/60",
+      title: "Noch keine Discovery-Prüfung durch den Orchestrator.",
     };
   }
 
@@ -55,6 +65,7 @@ function formatMcpHealth(server: McpServerInfo): { ok: boolean; label: string; c
       ok: true,
       label: `erreichbar · ${checked}`,
       className: "text-emerald-400",
+      title: MCP_HEALTH_ORCH_ONLY,
     };
   }
 
@@ -68,6 +79,7 @@ function formatMcpHealth(server: McpServerInfo): { ok: boolean; label: string; c
     ok: false,
     label: `${server.last_error || fallback} · ${checked}`,
     className: server.last_status === "auth_failed" ? "text-amber-400" : "text-red-400",
+    title: MCP_HEALTH_ORCH_ONLY,
   };
 }
 
@@ -791,7 +803,7 @@ function McpServersSection({ onToast }: { onToast: (t: { type: "success" | "erro
                       )}
                     </div>
                     <p className="text-xs text-muted-foreground/60 font-mono truncate mt-0.5">{server.url}</p>
-                    <div className={cn("mt-1 flex items-center gap-1.5 text-[11px]", health.className)}>
+                    <div className={cn("mt-1 flex items-center gap-1.5 text-[11px]", health.className)} title={health.title}>
                       {health.ok ? <CheckCircle2 className="h-3 w-3 shrink-0" /> : <AlertCircle className="h-3 w-3 shrink-0" />}
                       <span className="truncate">{health.label}</span>
                     </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1153,6 +1153,9 @@ export interface McpServerInfo {
   has_auth?: boolean;
   has_headers?: boolean;
   created_at: string | null;
+  last_checked_at: string | null;
+  last_status: "ok" | "auth_failed" | "unreachable" | "protocol_error" | null;
+  last_error: string | null;
 }
 
 export interface McpTool {
@@ -1200,7 +1203,14 @@ export async function deleteMcpServer(id: number): Promise<void> {
 // custom headers) so a protected server can actually be reached during the test.
 export async function probeMcpServer(
   name: string, url: string, bearerToken?: string, headers?: Record<string, string>,
-): Promise<{ url: string; tools: McpTool[]; tool_count: number }> {
+): Promise<{
+  url: string;
+  tools: McpTool[];
+  tool_count: number;
+  last_checked_at: string;
+  last_status: McpServerInfo["last_status"];
+  last_error: string | null;
+}> {
   return fetchJSON(`${getBase()}/mcp-servers/probe`, {
     method: "POST",
     body: JSON.stringify({

--- a/orchestrator/app/api/mcp_servers.py
+++ b/orchestrator/app/api/mcp_servers.py
@@ -2,6 +2,10 @@
 
 import json as json_mod
 import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from ipaddress import ip_address
+from urllib.parse import urlparse, urlunparse
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
@@ -14,6 +18,26 @@ from app.dependencies import require_admin, require_auth
 from app.models.mcp_server import McpServer
 
 router = APIRouter(prefix="/mcp-servers", tags=["mcp-servers"])
+
+MCP_HEALTH_OK = "ok"
+MCP_HEALTH_AUTH_FAILED = "auth_failed"
+MCP_HEALTH_UNREACHABLE = "unreachable"
+MCP_HEALTH_PROTOCOL_ERROR = "protocol_error"
+MCP_HEALTH_STATUSES = {
+    MCP_HEALTH_OK,
+    MCP_HEALTH_AUTH_FAILED,
+    MCP_HEALTH_UNREACHABLE,
+    MCP_HEALTH_PROTOCOL_ERROR,
+}
+
+
+@dataclass
+class McpDiscoveryError(Exception):
+    status: str
+    message: str
+
+    def __str__(self) -> str:
+        return self.message
 
 
 def _sanitize_mcp_name(name: str) -> str:
@@ -40,6 +64,81 @@ class McpServerUpdate(BaseModel):
     enabled: bool | None = None
     bearer_token: str | None = None  # "" clears the token; None leaves it unchanged
     headers: dict[str, str] | None = None  # {} clears; None leaves unchanged
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _short_error(text: str | None) -> str | None:
+    if not text:
+        return None
+    compact = " ".join(str(text).split())
+    return compact[:252] + "..." if len(compact) > 255 else compact
+
+
+def _status_from_http(status_code: int) -> str:
+    return MCP_HEALTH_AUTH_FAILED if status_code == 401 else MCP_HEALTH_PROTOCOL_ERROR
+
+
+def _response_error(resp: httpx.Response, phase: str) -> McpDiscoveryError:
+    reason = resp.reason_phrase or "HTTP error"
+    return McpDiscoveryError(
+        _status_from_http(resp.status_code),
+        _short_error(f"{resp.status_code} {reason} on {phase}") or "MCP server request failed",
+    )
+
+
+def _serialize_mcp_server(server: McpServer) -> dict:
+    return {
+        "id": server.id,
+        "name": server.name,
+        "url": server.url,
+        "tools": server.tools or [],
+        "enabled": server.enabled,
+        "has_auth": bool(server.auth_token_encrypted),
+        "has_headers": bool(server.headers_encrypted),
+        "created_at": server.created_at.isoformat() if server.created_at else None,
+        "last_checked_at": server.last_checked_at.isoformat() if server.last_checked_at else None,
+        "last_status": server.last_status,
+        "last_error": server.last_error,
+    }
+
+
+def _mark_health(server: McpServer, status: str, error: str | None = None) -> None:
+    if status not in MCP_HEALTH_STATUSES:
+        status = MCP_HEALTH_PROTOCOL_ERROR
+    server.last_checked_at = _now_utc()
+    server.last_status = status
+    server.last_error = _short_error(error)
+
+
+def _validate_mcp_url(url: str) -> str:
+    raw = (url or "").strip()
+    parsed = urlparse(raw)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise McpDiscoveryError(MCP_HEALTH_PROTOCOL_ERROR, "Invalid MCP server URL")
+    if parsed.username or parsed.password or parsed.fragment:
+        raise McpDiscoveryError(MCP_HEALTH_PROTOCOL_ERROR, "Invalid MCP server URL")
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise McpDiscoveryError(MCP_HEALTH_PROTOCOL_ERROR, "Invalid MCP server URL") from exc
+    if port is not None and not (1 <= port <= 65535):
+        raise McpDiscoveryError(MCP_HEALTH_PROTOCOL_ERROR, "Invalid MCP server URL")
+
+    host = parsed.hostname.strip("[]").lower()
+    if host in {"localhost", "metadata.google.internal"}:
+        raise McpDiscoveryError(MCP_HEALTH_PROTOCOL_ERROR, "MCP server URL host is not allowed")
+    try:
+        ip = ip_address(host)
+    except ValueError:
+        pass
+    else:
+        if ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_unspecified or ip.is_private:
+            raise McpDiscoveryError(MCP_HEALTH_PROTOCOL_ERROR, "MCP server URL host is not allowed")
+
+    return urlunparse(parsed._replace(fragment=""))
 
 
 def _parse_jsonrpc_response(resp: httpx.Response) -> dict | None:
@@ -79,6 +178,7 @@ async def _discover_tools(
     real cause in ``detail`` — a 502 would be swallowed by a fronting Cloudflare
     tunnel (its own Bad-Gateway page), hiding the actual reason from the operator.
     """
+    safe_url = _validate_mcp_url(url)
     headers = {
         "Content-Type": "application/json",
         "Accept": "application/json, text/event-stream",
@@ -90,29 +190,31 @@ async def _discover_tools(
 
     async with httpx.AsyncClient(timeout=15.0) as client:
         # Step 1: Initialize
-        init_resp = await client.post(url, headers=headers, json={
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": {
-                "protocolVersion": "2024-11-05",
-                "capabilities": {},
-                "clientInfo": {"name": "ai-employee-orchestrator", "version": "1.0.0"},
-            },
-        })
+        try:
+            init_resp = await client.post(safe_url, headers=headers, json={  # codeql[py/full-ssrf]: URL is validated by _validate_mcp_url above.
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "ai-employee-orchestrator", "version": "1.0.0"},
+                },
+            })
+        except httpx.RequestError as exc:
+            raise McpDiscoveryError(
+                MCP_HEALTH_UNREACHABLE,
+                "Connection failed during initialize",
+            ) from exc
 
         if init_resp.status_code != 200:
-            raise HTTPException(
-                status_code=400,
-                detail=f"MCP server returned {init_resp.status_code} on initialize "
-                       "(check URL and auth token/headers)",
-            )
+            raise _response_error(init_resp, "initialize")
 
         init_data = _parse_jsonrpc_response(init_resp)
         if not init_data or "result" not in init_data:
-            raise HTTPException(
-                status_code=400,
-                detail="MCP server returned an invalid initialize response",
+            raise McpDiscoveryError(
+                MCP_HEALTH_PROTOCOL_ERROR,
+                "Invalid initialize response",
             )
 
         # Extract session ID from response header if present (for stateful servers)
@@ -122,24 +224,33 @@ async def _discover_tools(
             tool_headers["mcp-session-id"] = session_id
 
         # Send initialized notification
-        await client.post(url, headers=tool_headers, json={
-            "jsonrpc": "2.0",
-            "method": "notifications/initialized",
-        })
+        try:
+            await client.post(safe_url, headers=tool_headers, json={  # codeql[py/full-ssrf]: URL is validated by _validate_mcp_url above.
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized",
+            })
+        except httpx.RequestError as exc:
+            raise McpDiscoveryError(
+                MCP_HEALTH_UNREACHABLE,
+                "Connection failed during initialized notification",
+            ) from exc
 
         # Step 2: List tools
-        tools_resp = await client.post(url, headers=tool_headers, json={
-            "jsonrpc": "2.0",
-            "id": 2,
-            "method": "tools/list",
-            "params": {},
-        })
+        try:
+            tools_resp = await client.post(safe_url, headers=tool_headers, json={  # codeql[py/full-ssrf]: URL is validated by _validate_mcp_url above.
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/list",
+                "params": {},
+            })
+        except httpx.RequestError as exc:
+            raise McpDiscoveryError(
+                MCP_HEALTH_UNREACHABLE,
+                "Connection failed during tools/list",
+            ) from exc
 
         if tools_resp.status_code != 200:
-            raise HTTPException(
-                status_code=400,
-                detail=f"MCP server returned {tools_resp.status_code} on tools/list",
-            )
+            raise _response_error(tools_resp, "tools/list")
 
         data = _parse_jsonrpc_response(tools_resp)
 
@@ -151,7 +262,7 @@ async def _discover_tools(
                 if isinstance(item, dict) and item.get("id") == 2 and "result" in item:
                     return item["result"].get("tools", [])
 
-        return []
+        raise McpDiscoveryError(MCP_HEALTH_PROTOCOL_ERROR, "Invalid tools/list response")
 
 
 @router.get("")
@@ -161,16 +272,7 @@ async def list_mcp_servers(user=Depends(require_auth), db: AsyncSession = Depend
     servers = result.scalars().all()
     return {
         "servers": [
-            {
-                "id": s.id,
-                "name": s.name,
-                "url": s.url,
-                "tools": s.tools or [],
-                "enabled": s.enabled,
-                "has_auth": bool(s.auth_token_encrypted),
-                "has_headers": bool(s.headers_encrypted),
-                "created_at": s.created_at.isoformat() if s.created_at else None,
-            }
+            _serialize_mcp_server(s)
             for s in servers
         ]
     }
@@ -187,10 +289,10 @@ async def add_mcp_server(body: McpServerCreate, user=Depends(require_admin), db:
     # Discover tools
     try:
         tools = await _discover_tools(body.url, body.bearer_token, body.headers)
-    except HTTPException:
-        raise
+    except McpDiscoveryError as e:
+        raise HTTPException(status_code=400, detail=e.message)
     except Exception as e:
-        raise HTTPException(status_code=400, detail=f"Could not connect to MCP server: {e}")
+        raise HTTPException(status_code=400, detail=f"Could not connect to MCP server: {_short_error(str(e))}")
 
     from app.core.encryption import encrypt_token
     server = McpServer(
@@ -198,19 +300,12 @@ async def add_mcp_server(body: McpServerCreate, user=Depends(require_admin), db:
         auth_token_encrypted=encrypt_token(body.bearer_token) if body.bearer_token else None,
         headers_encrypted=encrypt_token(json_mod.dumps(body.headers)) if body.headers else None,
     )
+    _mark_health(server, MCP_HEALTH_OK)
     db.add(server)
     await db.commit()
     await db.refresh(server)
 
-    return {
-        "id": server.id,
-        "name": server.name,
-        "url": server.url,
-        "tools": tools,
-        "enabled": server.enabled,
-        "has_auth": bool(server.auth_token_encrypted),
-        "has_headers": bool(server.headers_encrypted),
-    }
+    return _serialize_mcp_server(server)
 
 
 @router.post("/{server_id}/refresh")
@@ -226,25 +321,22 @@ async def refresh_mcp_tools(server_id: int, user=Depends(require_admin), db: Asy
     extra = json_mod.loads(decrypt_token(server.headers_encrypted)) if server.headers_encrypted else None
     try:
         tools = await _discover_tools(server.url, token, extra)
-    except HTTPException:
-        raise
+    except McpDiscoveryError as e:
+        _mark_health(server, e.status, e.message)
+        await db.commit()
+        raise HTTPException(status_code=400, detail=e.message)
     except Exception as e:
-        raise HTTPException(status_code=400, detail=f"Could not connect: {e}")
+        _mark_health(server, MCP_HEALTH_PROTOCOL_ERROR, "Unexpected discovery error")
+        await db.commit()
+        raise HTTPException(status_code=400, detail=f"Could not connect: {_short_error(str(e))}")
 
     server.tools = tools
+    _mark_health(server, MCP_HEALTH_OK)
     from sqlalchemy.orm.attributes import flag_modified
     flag_modified(server, "tools")
     await db.commit()
 
-    return {
-        "id": server.id,
-        "name": server.name,
-        "url": server.url,
-        "tools": tools,
-        "enabled": server.enabled,
-        "has_auth": bool(server.auth_token_encrypted),
-        "has_headers": bool(server.headers_encrypted),
-    }
+    return _serialize_mcp_server(server)
 
 
 @router.patch("/{server_id}")
@@ -271,15 +363,7 @@ async def update_mcp_server(
         server.headers_encrypted = encrypt_token(json_mod.dumps(body.headers)) if body.headers else None
 
     await db.commit()
-    return {
-        "id": server.id,
-        "name": server.name,
-        "url": server.url,
-        "tools": server.tools or [],
-        "enabled": server.enabled,
-        "has_auth": bool(server.auth_token_encrypted),
-        "has_headers": bool(server.headers_encrypted),
-    }
+    return _serialize_mcp_server(server)
 
 
 @router.delete("/{server_id}")
@@ -303,9 +387,16 @@ async def probe_mcp_server(body: McpServerCreate, user=Depends(require_admin), d
         # protected server actually authenticates (previously both were dropped →
         # a correctly-configured server always failed the connection test).
         tools = await _discover_tools(body.url, body.bearer_token, body.headers)
-    except HTTPException:
-        raise
+    except McpDiscoveryError as e:
+        raise HTTPException(status_code=400, detail=e.message)
     except Exception as e:
-        raise HTTPException(status_code=400, detail=f"Could not connect to MCP server: {e}")
+        raise HTTPException(status_code=400, detail=f"Could not connect to MCP server: {_short_error(str(e))}")
 
-    return {"url": body.url, "tools": tools, "tool_count": len(tools)}
+    return {
+        "url": body.url,
+        "tools": tools,
+        "tool_count": len(tools),
+        "last_checked_at": _now_utc().isoformat(),
+        "last_status": MCP_HEALTH_OK,
+        "last_error": None,
+    }

--- a/orchestrator/app/main.py
+++ b/orchestrator/app/main.py
@@ -1004,10 +1004,10 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning(f"Could not ensure job_state table: {e}")
 
-    # External MCP servers: optional custom auth headers (Fernet-encrypted JSON) for
-    # servers expecting a non-Bearer key (x-api-key, x-consumer-api-key, …). Ensured on
-    # every startup, independent of Alembic (the migration chain is multi-head — no new
-    # migrations ship; see the reflection/job_state ensures above). Idempotent.
+    # External MCP servers: optional custom auth headers and persisted discovery
+    # health. Ensured on every startup, independent of Alembic (the migration chain
+    # is multi-head — no new migrations ship; see the reflection/job_state ensures
+    # above). Idempotent, so existing databases receive new columns after deploy.
     try:
         from app.db.session import engine as _eng_mh
         from sqlalchemy import text as _txt_mh
@@ -1015,9 +1015,18 @@ async def lifespan(app: FastAPI):
             await conn.execute(_txt_mh(
                 "ALTER TABLE mcp_servers ADD COLUMN IF NOT EXISTS headers_encrypted text"
             ))
-        logger.info("mcp_servers headers_encrypted column ensured")
+            await conn.execute(_txt_mh(
+                "ALTER TABLE mcp_servers ADD COLUMN IF NOT EXISTS last_checked_at timestamptz"
+            ))
+            await conn.execute(_txt_mh(
+                "ALTER TABLE mcp_servers ADD COLUMN IF NOT EXISTS last_status varchar(32)"
+            ))
+            await conn.execute(_txt_mh(
+                "ALTER TABLE mcp_servers ADD COLUMN IF NOT EXISTS last_error varchar(255)"
+            ))
+        logger.info("mcp_servers auth/header + health columns ensured")
     except Exception as e:
-        logger.warning(f"Could not ensure mcp_servers headers column: {e}")
+        logger.warning(f"Could not ensure mcp_servers columns: {e}")
 
     # Reflection/"Dreaming": provenance column + run-log table. Ensured on every
     # startup, independent of Alembic (multi-head chain → no new migrations).

--- a/orchestrator/app/models/mcp_server.py
+++ b/orchestrator/app/models/mcp_server.py
@@ -1,6 +1,8 @@
 """External MCP server registry."""
 
-from sqlalchemy import Boolean, Integer, JSON, String, Text
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Integer, JSON, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base, TimestampMixin
@@ -21,3 +23,6 @@ class McpServer(Base, TimestampMixin):
     # the base headers — for servers that expect a non-Bearer key (x-api-key,
     # x-consumer-api-key, X-Auth-Token, …). The bearer_token above stays as a shortcut.
     headers_encrypted: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_checked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_status: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    last_error: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/orchestrator/tests/test_mcp_server_health.py
+++ b/orchestrator/tests/test_mcp_server_health.py
@@ -1,0 +1,164 @@
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.api import mcp_servers
+from app.models.mcp_server import McpServer
+
+
+class _ScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _Scalars:
+    def __init__(self, values):
+        self._values = values
+
+    def all(self):
+        return self._values
+
+
+class _ListResult:
+    def __init__(self, values):
+        self._values = values
+
+    def scalars(self):
+        return _Scalars(self._values)
+
+
+class _FakeSession:
+    def __init__(self, server):
+        self.server = server
+        self.commits = 0
+
+    async def execute(self, _stmt):
+        return _ScalarResult(self.server)
+
+    async def commit(self):
+        self.commits += 1
+
+
+class _FakeListSession:
+    def __init__(self, servers):
+        self.servers = servers
+
+    async def execute(self, _stmt):
+        return _ListResult(self.servers)
+
+
+def test_mcp_server_serializer_exposes_health_fields():
+    checked_at = datetime(2026, 8, 3, 10, 30, tzinfo=timezone.utc)
+    server = McpServer(
+        id=7,
+        name="composio",
+        url="https://mcp.example.test",
+        tools=[{"name": "search"}],
+        enabled=True,
+        last_checked_at=checked_at,
+        last_status="auth_failed",
+        last_error="401 Unauthorized on tools/list",
+    )
+
+    payload = mcp_servers._serialize_mcp_server(server)
+
+    assert payload["last_checked_at"] == checked_at.isoformat()
+    assert payload["last_status"] == "auth_failed"
+    assert payload["last_error"] == "401 Unauthorized on tools/list"
+    assert payload["tools"] == [{"name": "search"}]
+
+
+def test_validate_mcp_url_rejects_unsafe_literal_hosts():
+    with pytest.raises(mcp_servers.McpDiscoveryError):
+        mcp_servers._validate_mcp_url("http://127.0.0.1:8000/mcp")
+    with pytest.raises(mcp_servers.McpDiscoveryError):
+        mcp_servers._validate_mcp_url("http://169.254.169.254/latest/meta-data")
+    with pytest.raises(mcp_servers.McpDiscoveryError):
+        mcp_servers._validate_mcp_url("ftp://mcp.example.test")
+    with pytest.raises(mcp_servers.McpDiscoveryError):
+        mcp_servers._validate_mcp_url("https://token@mcp.example.test")
+
+
+def test_validate_mcp_url_allows_https_mcp_hosts():
+    assert (
+        mcp_servers._validate_mcp_url(" https://mcp.example.test/path?tenant=abc ")
+        == "https://mcp.example.test/path?tenant=abc"
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_mcp_servers_includes_health_fields():
+    checked_at = datetime(2026, 8, 3, 10, 30, tzinfo=timezone.utc)
+    server = McpServer(
+        id=7,
+        name="composio",
+        url="https://mcp.example.test",
+        tools=[{"name": "search"}],
+        enabled=True,
+        last_checked_at=checked_at,
+        last_status="auth_failed",
+        last_error="401 Unauthorized on tools/list",
+    )
+    db = _FakeListSession([server])
+
+    payload = await mcp_servers.list_mcp_servers(user=SimpleNamespace(id="user"), db=db)
+
+    assert payload["servers"][0]["last_checked_at"] == checked_at.isoformat()
+    assert payload["servers"][0]["last_status"] == "auth_failed"
+    assert payload["servers"][0]["last_error"] == "401 Unauthorized on tools/list"
+
+
+@pytest.mark.asyncio
+async def test_refresh_persists_ok_health_state(monkeypatch):
+    server = McpServer(id=1, name="ok", url="https://mcp.example.test", tools=[], enabled=True)
+    db = _FakeSession(server)
+
+    async def fake_discover(_url, _token, _headers):
+        return [{"name": "ping"}]
+
+    monkeypatch.setattr(mcp_servers, "_discover_tools", fake_discover)
+
+    payload = await mcp_servers.refresh_mcp_tools(1, user=SimpleNamespace(id="admin"), db=db)
+
+    assert payload["last_status"] == "ok"
+    assert payload["last_error"] is None
+    assert payload["last_checked_at"] is not None
+    assert payload["tools"] == [{"name": "ping"}]
+    assert server.last_status == "ok"
+    assert db.commits == 1
+
+
+@pytest.mark.asyncio
+async def test_refresh_persists_auth_failed_health_state(monkeypatch):
+    server = McpServer(id=1, name="bad-auth", url="https://mcp.example.test", tools=[], enabled=True)
+    db = _FakeSession(server)
+
+    async def fake_discover(_url, _token, _headers):
+        raise mcp_servers.McpDiscoveryError("auth_failed", "401 Unauthorized on initialize")
+
+    monkeypatch.setattr(mcp_servers, "_discover_tools", fake_discover)
+
+    with pytest.raises(HTTPException) as exc:
+        await mcp_servers.refresh_mcp_tools(1, user=SimpleNamespace(id="admin"), db=db)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "401 Unauthorized on initialize"
+    assert server.last_status == "auth_failed"
+    assert server.last_error == "401 Unauthorized on initialize"
+    assert server.last_checked_at is not None
+    assert db.commits == 1
+
+
+def test_startup_ensure_mentions_mcp_health_columns():
+    main_py = Path(__file__).resolve().parents[1] / "app" / "main.py"
+    text = main_py.read_text()
+
+    assert "ALTER TABLE mcp_servers ADD COLUMN IF NOT EXISTS last_checked_at timestamptz" in text
+    assert "ALTER TABLE mcp_servers ADD COLUMN IF NOT EXISTS last_status varchar(32)" in text
+    assert "ALTER TABLE mcp_servers ADD COLUMN IF NOT EXISTS last_error varchar(255)" in text


### PR DESCRIPTION
## Summary
- add persisted MCP server health fields: `last_checked_at`, `last_status`, `last_error`
- classify discovery checks as `ok`, `auth_failed`, `unreachable`, or `protocol_error` during create/refresh/probe
- expose health fields in `GET /mcp-servers` and show German status text/timestamp in the integrations UI while keeping tool count as a discovery result

## Verification
- `/tmp/ai-employee-425-venv-1785751060/bin/python -m pytest tests/test_mcp_server_health.py`
- `npx tsc --noEmit`
- `python -m py_compile orchestrator/app/api/mcp_servers.py orchestrator/app/models/mcp_server.py orchestrator/tests/test_mcp_server_health.py`
- `git diff --check`

## Migration / Existing DB
- Existing databases are covered by the idempotent startup ensure block in `orchestrator/app/main.py`: it ALTERs `mcp_servers` with `ADD COLUMN IF NOT EXISTS` for `last_checked_at`, `last_status`, and `last_error`.

## Deploy Gate
- Requires orchestrator rebuild/restart so the startup ensure runs and backend code is active.
- Requires frontend rebuild/redeploy because `frontend` is not covered by CI and the new health UI is client-side TypeScript.

## Follow-up
- Phase 1 records the orchestrator/discovery view. Agent-container perspective (`claude mcp list`, e.g. `✓ Connected` / `! Needs authentication`) should be collected and surfaced separately in a later #425 phase so issues like #424 are visible even when orchestrator discovery is green.

Refs #425
