### PR TITLE
fix(bridge): activate tray modal panels

### DIFF
--- a/computer-use-bridge/tray_app.py
+++ b/computer-use-bridge/tray_app.py
@@ -472,7 +472,6 @@ def _make_panel(title, w, h):
     p.setTitle_(title)
     p.center()
     p.setReleasedWhenClosed_(False)
-    p.setLevel_(8)  # NSFloatingWindowLevel
     return p
 
 
@@ -695,6 +694,7 @@ def show_setup_dialog(cfg: dict) -> dict | None:
     cancel_btn.setTarget_(h); cancel_btn.setAction_("cancel:")
     save_btn.setTarget_(h);   save_btn.setAction_("save:")
 
+    NSApp.activateIgnoringOtherApps_(True)
     NSApp.runModalForWindow_(panel)
     panel.close()
     return result_box[0]
@@ -784,6 +784,7 @@ def show_permissions_dialog(cfg: dict) -> None:
     del_btn.setTarget_(h);    del_btn.setAction_("delPath:")
     save_btn.setTarget_(h);   save_btn.setAction_("save:")
 
+    NSApp.activateIgnoringOtherApps_(True)
     NSApp.runModalForWindow_(panel)
     panel.close()
 
@@ -891,6 +892,7 @@ def show_status_window(cfg: dict) -> None:
     close_btn.setTarget_(h)
     close_btn.setAction_("close:")
 
+    NSApp.activateIgnoringOtherApps_(True)
     NSApp.runModalForWindow_(panel)
     panel.close()
 


### PR DESCRIPTION
## Summary
- activate the LSUIElement tray app immediately before each AppKit modal panel is run
- drop the shared floating window level from modal panels now that the app is explicitly activated

## Context
This builds on #421, which added the hidden Edit menu for tray-only AppKit dialogs. Reporter tiko0 confirmed that root cause #1 was fixed in the `bridge-latest` DMG built from commit `8ee69ad`, but identified a second cause in the 2026-08-03T10:01:51Z comment on #420: the LSUIElement app was not activated before opening modal panels, so macOS could route Cmd+V to the previously active app even while the floating panel appeared focused.

## Verification
- `python -m py_compile computer-use-bridge/tray_app.py`
- `rg -n "runModalForWindow_|activateIgnoringOtherApps_|setLevel_" computer-use-bridge/tray_app.py`
- `git diff --check`

Fixes #420
