### PR TITLE
chore(agent): PR #428 review follow-ups (W1/W2/W3)

### DIFF
--- a/agent/app/main.py
+++ b/agent/app/main.py
@@ -87,7 +87,7 @@ def _auth_headers_for(name: str, auth: dict, headers: dict) -> dict:
     """
     result: dict[str, str] = {}
     token = auth.get(name)
-    if token:
+    if token is not None and token:
         result["Authorization"] = f"Bearer {token}"
     extra = headers.get(name)
     if isinstance(extra, dict):
@@ -252,11 +252,12 @@ def register_mcp_servers() -> None:
             servers = json.loads(custom_mcp)
             for name, url in servers.items():
                 safe_name = _sanitize_mcp_name(name)
+                header_args = _auth_header_args(name, auth, headers)
                 cmd_args = ["--transport", "http", safe_name, url]
-                for header in _auth_header_args(name, auth, headers):
+                for header in header_args:
                     cmd_args += ["--header", header]
                 if _run_mcp_add(cmd_args):
-                    suffix = " (authenticated)" if len(cmd_args) > 4 else ""
+                    suffix = " (authenticated)" if header_args else ""
                     print(f"[Agent] Registered MCP server: {safe_name} -> {url} (http){suffix}")
                 else:
                     print(f"[Agent] WARN: Failed to register MCP server: {safe_name}")

--- a/agent/tests/test_mcp_auth_headers.py
+++ b/agent/tests/test_mcp_auth_headers.py
@@ -51,6 +51,31 @@ def test_register_passes_header_to_claude_mcp_add(monkeypatch):
     assert "Authorization: Bearer tok123" in args
 
 
+def test_register_uses_original_name_for_auth_but_sanitized_for_add(monkeypatch):
+    """Auth is keyed by the ORIGINAL server name, while the server is registered
+    under the sanitized name — a mismatch must not drop the credential (W2 / #430)."""
+    monkeypatch.setenv("CUSTOM_MCP_SERVERS", json.dumps({"My Server": "https://x/mcp"}))
+    monkeypatch.setenv("CUSTOM_MCP_AUTH", json.dumps({"My Server": "tok123"}))
+    monkeypatch.delenv("CUSTOM_MCP_HEADERS", raising=False)
+    monkeypatch.delenv("COMPUTER_USE_BRIDGE_MCP_URL", raising=False)
+
+    calls = []
+    monkeypatch.setattr(main, "_run_mcp_add", lambda args: calls.append(args) or True)
+    monkeypatch.setattr(main, "_write_mcp_json_fallback", lambda: None)
+    monkeypatch.setattr(main, "_sanitize_mcp_name", lambda n: n.replace(" ", "-"))
+
+    main.register_mcp_servers()
+
+    custom_calls = [c for c in calls if "https://x/mcp" in c]
+    assert len(custom_calls) == 1
+    args = custom_calls[0]
+    # Registered under the sanitized name...
+    assert "My-Server" in args
+    assert "My Server" not in args
+    # ...but the credential (looked up by original name) is still present.
+    assert "Authorization: Bearer tok123" in args
+
+
 def test_mcp_json_fallback_includes_headers(monkeypatch, tmp_path):
     monkeypatch.setenv("CUSTOM_MCP_SERVERS", json.dumps({"composio": "https://x/mcp"}))
     monkeypatch.setenv("CUSTOM_MCP_AUTH", json.dumps({"composio": "tok123"}))


### PR DESCRIPTION
Addresses the three deferred non-blocking follow-ups from the PR #428 review, all touching `_run_mcp_add` / the custom-MCP registration loop in `agent/app/main.py`.

## Changes
- **W1 (Fixes #429)** — the `(authenticated)` log suffix no longer relies on the fragile `len(cmd_args) > 4` heuristic. It now checks whether any `header_args` were actually produced.
- **W2 (Fixes #430)** — new regression test `test_register_uses_original_name_for_auth_but_sanitized_for_add`: a server whose name needs sanitizing (e.g. `"My Server"`) must still register under the sanitized name (`My-Server`) while its credential — looked up by the **original** name — is preserved.
- **W3 (Fixes #431)** — the empty-string token guard is now explicit: `token is not None and token` instead of `if token:`.

## Verification
- `pytest agent/tests/test_mcp_auth_headers.py` → **7 passed** (6 existing + 1 new).
- No behavior change on the happy path; cosmetic/clarity + added coverage.

Auth-path touch → routed to CodeReview, not self-merged.

Fixes #429
Fixes #430
Fixes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)