### PR TITLE
Fix #443/#442: DNS-resolving SSRF guard on MCP discovery path

### DIFF
--- a/orchestrator/app/api/mcp_servers.py
+++ b/orchestrator/app/api/mcp_servers.py
@@ -60,41 +60,78 @@ def _mcp_allow_private() -> bool:
     return os.getenv("MCP_ALLOW_PRIVATE_URLS", "").strip().lower() in ("1", "true", "yes")
 
 
+def _forbidden_ip_reason(ip) -> str | None:
+    """Return a rejection reason if ``ip`` is an SSRF-forbidden address, else None.
+
+    Link-local (incl. the 169.254.169.254 cloud-metadata endpoint), multicast,
+    reserved and unspecified addresses are rejected unconditionally; private and
+    loopback ranges are rejected unless ``MCP_ALLOW_PRIVATE_URLS`` is set.
+    """
+    if ip.is_link_local or ip.is_multicast or ip.is_reserved or ip.is_unspecified:
+        return f"MCP host resolves to a forbidden address ({ip})"
+    if (ip.is_private or ip.is_loopback) and not _mcp_allow_private():
+        return (
+            f"MCP host resolves to a private address ({ip}); "
+            "set MCP_ALLOW_PRIVATE_URLS=true to allow internal MCP servers"
+        )
+    return None
+
+
+async def _resolve_host_ips(hostname: str, port: int) -> list:
+    """Resolve ``hostname`` to a list of ip_address objects (may raise socket.gaierror)."""
+    loop = asyncio.get_running_loop()
+    infos = await loop.getaddrinfo(hostname, port, proto=socket.IPPROTO_TCP)
+    return [ip_address(info[4][0]) for info in infos]
+
+
 async def _assert_mcp_url_allowed(url: str) -> None:
     """SSRF guard for a manual ``tools/call`` invocation. Raises HTTPException(400) if blocked.
 
     Resolves the hostname and checks every returned address (so a name that
     resolves to one public and one internal IP is still rejected), unlike
-    :func:`_validate_mcp_url` which only catches IP-literal hosts. Link-local
-    (incl. the 169.254.169.254 cloud-metadata endpoint), multicast, reserved and
-    unspecified addresses are rejected unconditionally; private/loopback ranges
-    are rejected unless ``MCP_ALLOW_PRIVATE_URLS`` is set.
+    :func:`_validate_mcp_url` which only catches IP-literal hosts. Fail-closed: an
+    unresolvable host is rejected, since a manual call must not proceed on an
+    unverifiable target.
     """
     parsed = urlparse((url or "").strip())
     if parsed.scheme not in ("http", "https") or not parsed.hostname:
         raise HTTPException(status_code=400, detail="MCP server URL must be a valid http(s) URL")
     port = parsed.port or (443 if parsed.scheme == "https" else 80)
-    loop = asyncio.get_running_loop()
     try:
-        infos = await loop.getaddrinfo(parsed.hostname, port, proto=socket.IPPROTO_TCP)
+        ips = await _resolve_host_ips(parsed.hostname, port)
     except socket.gaierror as e:
         raise HTTPException(status_code=400, detail=f"Cannot resolve MCP host: {parsed.hostname}") from e
-    if not infos:
+    if not ips:
         raise HTTPException(status_code=400, detail=f"Cannot resolve MCP host: {parsed.hostname}")
-    allow_private = _mcp_allow_private()
-    for info in infos:
-        ip = ip_address(info[4][0])
-        if ip.is_link_local or ip.is_multicast or ip.is_reserved or ip.is_unspecified:
-            raise HTTPException(
-                status_code=400,
-                detail=f"MCP host resolves to a forbidden address ({ip})",
-            )
-        if (ip.is_private or ip.is_loopback) and not allow_private:
-            raise HTTPException(
-                status_code=400,
-                detail=f"MCP host resolves to a private address ({ip}); "
-                       "set MCP_ALLOW_PRIVATE_URLS=true to allow internal MCP servers",
-            )
+    for ip in ips:
+        reason = _forbidden_ip_reason(ip)
+        if reason:
+            raise HTTPException(status_code=400, detail=reason)
+
+
+async def _assert_discovery_host_allowed(url: str) -> None:
+    """DNS-resolving SSRF guard for the add/refresh/probe discovery path.
+
+    Raises :class:`McpDiscoveryError` (so the failure is health-classified like every
+    other discovery error) if the host resolves to a forbidden/private address. This
+    closes the gap where :func:`_validate_mcp_url` only blocks IP *literals*, letting a
+    name like ``http://redis/`` through. Fail-open on resolution failure: an
+    unresolvable host carries no SSRF risk and is left to the httpx layer, which
+    classifies it as UNREACHABLE. Scheme/IP-literal checks are already done by
+    :func:`_validate_mcp_url`, which callers run first.
+    """
+    parsed = urlparse((url or "").strip())
+    if not parsed.hostname:
+        return
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    try:
+        ips = await _resolve_host_ips(parsed.hostname, port)
+    except socket.gaierror:
+        return
+    for ip in ips:
+        reason = _forbidden_ip_reason(ip)
+        if reason:
+            raise McpDiscoveryError(MCP_HEALTH_PROTOCOL_ERROR, reason)
 
 
 class McpServerCreate(BaseModel):
@@ -339,6 +376,7 @@ async def _discover_tools(
     ``x-api-key``) are merged on top so non-Bearer servers can authenticate.
     """
     safe_url = _validate_mcp_url(url)
+    await _assert_discovery_host_allowed(safe_url)
     headers = _build_headers(bearer_token, extra_headers)
 
     async with httpx.AsyncClient(timeout=15.0) as client:

--- a/orchestrator/tests/test_mcp_tool_call.py
+++ b/orchestrator/tests/test_mcp_tool_call.py
@@ -7,7 +7,7 @@ from fastapi import HTTPException
 
 from app.api import mcp_servers
 from app.api.mcp_servers import _call_tool, call_mcp_tool
-from app.models.audit_log import AuditEventType
+from app.models.audit_log import AuditEventType, AuditLog
 
 
 def _httpx_ctx(responses):
@@ -86,7 +86,7 @@ def _server():
 def _added_audit(db):
     for c in db.add.call_args_list:
         arg = c.args[0]
-        if arg.__class__.__name__ == "AuditLog":
+        if isinstance(arg, AuditLog):
             return arg
     return None
 
@@ -218,3 +218,49 @@ async def test_guard_still_blocks_metadata_even_when_private_allowed(monkeypatch
         with pytest.raises(HTTPException) as ei:
             await mcp_servers._assert_mcp_url_allowed("http://metadata/mcp")
     assert "forbidden" in ei.value.detail.lower()
+
+
+# --- Discovery-path SSRF guard (_assert_discovery_host_allowed, #443) --------
+
+@pytest.mark.asyncio
+async def test_discovery_guard_blocks_private_hostname():
+    """A hostname (not an IP literal) that resolves to a private IP must be blocked
+    on the add/refresh/probe path — the gap _validate_mcp_url alone left open."""
+    with patch("app.api.mcp_servers.asyncio.get_running_loop",
+               return_value=_fake_loop_resolving_to("10.0.0.5")):
+        with pytest.raises(mcp_servers.McpDiscoveryError) as ei:
+            await mcp_servers._assert_discovery_host_allowed("http://redis/mcp")
+    assert ei.value.status == mcp_servers.MCP_HEALTH_PROTOCOL_ERROR
+
+
+@pytest.mark.asyncio
+async def test_discovery_guard_blocks_cloud_metadata_hostname():
+    with patch("app.api.mcp_servers.asyncio.get_running_loop",
+               return_value=_fake_loop_resolving_to("169.254.169.254")):
+        with pytest.raises(mcp_servers.McpDiscoveryError):
+            await mcp_servers._assert_discovery_host_allowed("http://metadata/mcp")
+
+
+@pytest.mark.asyncio
+async def test_discovery_guard_allows_public_hostname():
+    with patch("app.api.mcp_servers.asyncio.get_running_loop",
+               return_value=_fake_loop_resolving_to("93.184.216.34")):
+        await mcp_servers._assert_discovery_host_allowed("https://mcp.example.test/mcp")
+
+
+@pytest.mark.asyncio
+async def test_discovery_guard_fail_open_on_unresolvable_host():
+    """Fail-open: an unresolvable host carries no SSRF risk and is left to httpx
+    (which classifies it as UNREACHABLE), so the guard must not raise here."""
+    loop = MagicMock()
+    loop.getaddrinfo = AsyncMock(side_effect=__import__("socket").gaierror("nxdomain"))
+    with patch("app.api.mcp_servers.asyncio.get_running_loop", return_value=loop):
+        await mcp_servers._assert_discovery_host_allowed("https://does-not-resolve.invalid/mcp")
+
+
+@pytest.mark.asyncio
+async def test_discovery_guard_allows_private_when_env_set(monkeypatch):
+    monkeypatch.setenv("MCP_ALLOW_PRIVATE_URLS", "true")
+    with patch("app.api.mcp_servers.asyncio.get_running_loop",
+               return_value=_fake_loop_resolving_to("10.0.0.5")):
+        await mcp_servers._assert_discovery_host_allowed("http://redis/mcp")


### PR DESCRIPTION
## Summary
Two follow-up issues from the PR #416 code review.

- **#443 (security, W3 — strongest):** `_validate_mcp_url` only blocks IP *literals*, so a hostname like `http://redis/` or `http://internal-service/` slipped past the add / refresh / probe endpoints. Added `_assert_discovery_host_allowed`, a DNS-resolving SSRF guard invoked inside `_discover_tools` right after `_validate_mcp_url`. It raises `McpDiscoveryError` so the block is health-classified exactly like every other discovery failure — preserving the health-state pipeline that made a straight swap to `_assert_mcp_url_allowed` (which raises `HTTPException`) unsafe.
  - **Fail-open on resolution failure:** an unresolvable host carries no SSRF risk and is left to httpx (classified UNREACHABLE). The manual `tools/call` guard stays **fail-closed** (rejects unresolvable hosts), since a hand-invoked call must not proceed on an unverifiable target.
  - Extracted a shared core (`_forbidden_ip_reason`, `_resolve_host_ips`); `_assert_mcp_url_allowed` now reuses it, so both gates stay in lockstep — addresses the reviewer's "single SSRF gate" suggestion without breaking health classification.
- **#442 (test hygiene, W2):** replaced fragile `arg.__class__.__name__ == "AuditLog"` with `isinstance(arg, AuditLog)` in the `_added_audit` test helper (+ import).

## Test plan
- [x] `pytest tests/test_mcp_tool_call.py tests/test_mcp_server_health.py` — 26 passed (5 new discovery-guard tests: private hostname blocked, cloud-metadata blocked, public allowed, fail-open on NXDOMAIN, private allowed when `MCP_ALLOW_PRIVATE_URLS=true`)
- [x] Full orchestrator suite — 553 passed
- Existing `_assert_mcp_url_allowed` guard tests and `_validate_mcp_url` health tests unchanged and green (behavior preserved)

**Deploy gate:** Orchestrator image rebuild required after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)