### PR TITLE
Fix #437: install Edit menu before first-run setup dialog

### DIFF
--- a/computer-use-bridge/tray_app.py
+++ b/computer-use-bridge/tray_app.py
@@ -1529,8 +1529,6 @@ def run_macos(cfg: dict) -> None:
     except ImportError:
         print("Install rumps: pip install rumps"); sys.exit(1)
 
-    _install_edit_menu()
-
     class BridgeApp(rumps.App):
         def __init__(self):
             super().__init__("AI Employee", quit_button=None)
@@ -1709,6 +1707,8 @@ def run_tray(cfg: dict) -> None:
 # ── Entry point ────────────────────────────────────────────────────────────────
 
 def main():
+    if IS_MAC:
+        _install_edit_menu()
     cfg = load_config()
     if not cfg.get("url") or not cfg.get("token") or not cfg.get("session"):
         updated = show_setup_dialog(cfg)

--- a/orchestrator/tests/test_tray_app_edit_menu_ordering.py
+++ b/orchestrator/tests/test_tray_app_edit_menu_ordering.py
@@ -1,0 +1,78 @@
+"""Guard for issue #437: the Edit menu must exist before the first-run setup
+dialog is shown, not only once run_macos() starts.
+
+An LSUIElement app has no menu bar until _install_edit_menu() runs, so Cmd+V
+does nothing in any dialog shown before it. On a fresh install, main() shows
+show_setup_dialog() before run_macos() (which used to install the menu) ever
+gets called -- the one dialog that most needs paste support never got it.
+
+The bridge/tray app has no CI suite of its own, so this runs in the
+orchestrator pytest job, same pattern as test_bridge_extra_headers.py.
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_TRAY_SRC_PATH = (
+    Path(__file__).resolve().parents[2] / "computer-use-bridge" / "tray_app.py"
+)
+
+
+def _load_tray_module():
+    spec = importlib.util.spec_from_file_location("tray_app_under_test", _TRAY_SRC_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TrayAppEditMenuOrderingSourceGuard(unittest.TestCase):
+    def setUp(self):
+        self.src = _TRAY_SRC_PATH.read_text()
+
+    def test_main_installs_edit_menu_before_setup_dialog(self):
+        main_start = self.src.index("def main():")
+        install_pos = self.src.index("_install_edit_menu()", main_start)
+        dialog_pos = self.src.index("show_setup_dialog(cfg)", main_start)
+        self.assertLess(
+            install_pos,
+            dialog_pos,
+            "_install_edit_menu() must run before show_setup_dialog() in main()",
+        )
+
+    def test_run_macos_no_longer_installs_it_itself(self):
+        macos_start = self.src.index("def run_macos(")
+        macos_end = self.src.index("\ndef ", macos_start + 1)
+        self.assertNotIn("_install_edit_menu()", self.src[macos_start:macos_end])
+
+
+class TrayAppEditMenuOrderingBehaviour(unittest.TestCase):
+    def test_main_calls_install_before_load_config_and_dialog(self):
+        m = _load_tray_module()
+        calls = []
+        with mock.patch.object(m, "IS_MAC", True), \
+             mock.patch.object(m, "_install_edit_menu", side_effect=lambda: calls.append("install")), \
+             mock.patch.object(m, "load_config", side_effect=lambda: calls.append("load") or {}), \
+             mock.patch.object(m, "show_setup_dialog", side_effect=lambda cfg: calls.append("dialog") or None), \
+             mock.patch.object(m, "run_macos", side_effect=lambda cfg: calls.append("run_macos")), \
+             mock.patch.object(m, "sys") as mock_sys:
+            mock_sys.exit.side_effect = SystemExit
+            with self.assertRaises(SystemExit):
+                m.main()
+        self.assertEqual(calls, ["install", "load", "dialog"])
+
+    def test_main_skips_install_on_non_mac(self):
+        m = _load_tray_module()
+        calls = []
+        with mock.patch.object(m, "IS_MAC", False), \
+             mock.patch.object(m, "_install_edit_menu", side_effect=lambda: calls.append("install")), \
+             mock.patch.object(m, "load_config", return_value={"url": "x", "token": "y", "session": "z"}), \
+             mock.patch.object(m, "run_tray", side_effect=lambda cfg: calls.append("run_tray")):
+            m.main()
+        self.assertEqual(calls, ["run_tray"])
+        self.assertNotIn("install", calls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #437

## Problem
Follow-up to #420. `_install_edit_menu()` lived inside `run_macos()`, but `main()` shows the modal setup dialog *before* it ever reaches `run_macos()`. On a fresh install, Cmd+V does nothing in the one dialog whose entire purpose is receiving a token and session id pasted from the web UI — there's also no tray icon yet to fall back to (right-click paste is the only workaround, and even that requires knowing it exists).

## Fix
Move the `_install_edit_menu()` call to the top of `main()` (behind the existing `IS_MAC` guard), before `load_config()`/`show_setup_dialog()` run. Removed the now-redundant call from inside `run_macos()`.

`_install_edit_menu()` itself is untouched — it already no-ops on non-mac and already logs (not raises) if `AppKit` menu install fails.

## Tests
`orchestrator/tests/test_tray_app_edit_menu_ordering.py` (bridge/tray app has no CI suite of its own, same pattern as `test_bridge_extra_headers.py`):
- Source guard: `_install_edit_menu()` appears before `show_setup_dialog()` in `main()`, and no longer appears in `run_macos()`.
- Behaviour: mocked `main()` run confirms call order `install → load_config → show_setup_dialog` on mac, and confirms `_install_edit_menu` is never called on non-mac.

4/4 new tests pass (`python3 -m unittest tests.test_tray_app_edit_menu_ordering -v`), plus the existing 12 bridge tests still pass alongside them.

## Scope
Client-side only (`computer-use-bridge/tray_app.py`), not in the orchestrator/agent startup path — no deploy gate.