### PR TITLE
Phase 1 of #433: scripts/update.sh rebuilds the agent image

### DIFF
--- a/frontend/src/components/layout/update-banner.tsx
+++ b/frontend/src/components/layout/update-banner.tsx
@@ -237,7 +237,7 @@ export function UpdateBanner() {
               {/* Footer */}
               <div className="border-t border-foreground/[0.06] px-6 py-3 flex items-center justify-between">
                 <p className="text-[11px] text-muted-foreground/50">
-                  Update: <code className="font-mono text-[10px]">git pull && docker compose up -d --build</code>
+                  Update: <code className="font-mono text-[10px]">./scripts/update.sh</code>
                 </p>
                 <Dialog.Close className="rounded-xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-lg shadow-primary/20 hover:bg-primary/90 transition-colors">
                   Verstanden

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -81,7 +81,7 @@ else
         [ -z "$line" ] && continue
         cid="${line%% *}"
         cname="${line#* }"
-        running_img="$(docker inspect "$cid" --format '{{.Image}}' 2>/dev/null | sed 's/^sha256://')"
+        running_img="$(docker inspect "$cid" --format '{{.Image}}' 2>/dev/null | sed 's/^sha256://' || true)"
         if [ -n "$NEW_AGENT_IMAGE_ID" ] && [ "${running_img#$NEW_AGENT_IMAGE_ID}" = "$running_img" ]; then
             STALE_AGENTS="${STALE_AGENTS}  • ${cname}\n"
         fi

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# AI Employee Platform — Update Script
+# Usage: ./scripts/update.sh
+#
+# Rebuilds EVERY image that ships code, including the dynamically-launched
+# agent image (ai-employee-agent:latest) which `docker compose up --build`
+# never touches because it is not a compose service (see issue #433).
+# Idempotent: safe to run multiple times.
+set -euo pipefail
+
+# ── colours ──────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+ok()   { echo -e "${GREEN}[OK]${NC}    $*"; }
+info() { echo -e "${CYAN}[INFO]${NC}  $*"; }
+warn() { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+die()  { echo -e "${RED}[ERROR]${NC} $*"; exit 1; }
+
+# ── working directory ─────────────────────────────────────────────────────────
+cd "$(dirname "$0")/.."
+
+echo ""
+echo "╔══════════════════════════════════════╗"
+echo "║   AI Employee Platform — Update      ║"
+echo "╚══════════════════════════════════════╝"
+echo ""
+
+# ── 1. Prerequisites ──────────────────────────────────────────────────────────
+info "Checking prerequisites..."
+command -v docker &>/dev/null           || die "Docker not installed. Get it at https://docs.docker.com/get-docker/"
+docker info &>/dev/null 2>&1            || die "Docker is not running. Please start Docker Desktop."
+docker compose version &>/dev/null 2>&1 || die "docker compose plugin not found. Update Docker Desktop for the 'docker compose' plugin (v2)."
+command -v git &>/dev/null              || die "git not found."
+ok "Docker is running"
+
+# ── 2. Pull latest code ───────────────────────────────────────────────────────
+info "Pulling latest code..."
+git pull
+ok "Code up to date"
+
+# ── 3. Rebuild the agent image (NOT a compose service — must be built here) ────
+# Capture the current agent image id so we can tell which running agents are
+# still on the old image after the rebuild.
+OLD_AGENT_IMAGE_ID="$(docker images -q ai-employee-agent:latest 2>/dev/null || true)"
+info "Rebuilding agent image (ai-employee-agent:latest)..."
+docker build -t ai-employee-agent:latest ./agent
+NEW_AGENT_IMAGE_ID="$(docker images -q ai-employee-agent:latest 2>/dev/null || true)"
+if [ -n "$OLD_AGENT_IMAGE_ID" ] && [ "$OLD_AGENT_IMAGE_ID" = "$NEW_AGENT_IMAGE_ID" ]; then
+    ok "Agent image unchanged"
+else
+    ok "Agent image rebuilt ($NEW_AGENT_IMAGE_ID)"
+fi
+
+# ── 4. Rebuild + restart the compose services (orchestrator, frontend, ...) ────
+info "Rebuilding and restarting the stack..."
+docker compose up -d --build
+ok "Stack restarted"
+
+# ── 5. Wait for orchestrator ──────────────────────────────────────────────────
+info "Waiting for orchestrator to be ready..."
+RETRIES=40
+until curl -sf http://localhost:8000/health >/dev/null 2>&1; do
+    RETRIES=$((RETRIES - 1))
+    [ $RETRIES -le 0 ] && die "Orchestrator did not start in time. Run: docker compose logs orchestrator"
+    sleep 3
+done
+ok "Orchestrator is ready"
+
+# ── 6. Report agents still running the OLD image ──────────────────────────────
+# Agent containers are launched dynamically and labelled ai-employee.type=agent.
+# A rebuild retags ai-employee-agent:latest to a new id but leaves running
+# agents on the old one — they need an explicit recreate (which interrupts
+# running work, so it is left to the operator, per issue #433 "Not in scope").
+echo ""
+info "Checking which agents are still on the old image..."
+STALE_AGENTS=""
+AGENT_CONTAINERS="$(docker ps --filter "label=ai-employee.type=agent" --format '{{.ID}} {{.Names}}' 2>/dev/null || true)"
+if [ -z "$AGENT_CONTAINERS" ]; then
+    ok "No running agent containers found — nothing to recreate."
+else
+    while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        cid="${line%% *}"
+        cname="${line#* }"
+        running_img="$(docker inspect "$cid" --format '{{.Image}}' 2>/dev/null | sed 's/^sha256://')"
+        if [ -n "$NEW_AGENT_IMAGE_ID" ] && [ "${running_img#$NEW_AGENT_IMAGE_ID}" = "$running_img" ]; then
+            STALE_AGENTS="${STALE_AGENTS}  • ${cname}\n"
+        fi
+    done <<< "$AGENT_CONTAINERS"
+
+    if [ -z "$STALE_AGENTS" ]; then
+        ok "All running agents are on the latest image."
+    else
+        warn "These agents are still running the OLD image and need to be recreated:"
+        echo -e "$STALE_AGENTS"
+        warn "Recreate them (this interrupts their running work) via either:"
+        warn "  • the Web UI: agent list → 'Update' action per agent, or"
+        warn "  • the API:    POST /agents/{id}/update  (preserves all data)"
+    fi
+fi
+
+# ── 7. Done ───────────────────────────────────────────────────────────────────
+echo ""
+echo "╔══════════════════════════════════════════════════╗"
+echo "║               Update Complete!                   ║"
+echo "╚══════════════════════════════════════════════════╝"
+echo ""


### PR DESCRIPTION
## Problem (Phase 1 of #433)

`docker compose up --build` never rebuilds `ai-employee-agent:latest` because agent containers are launched dynamically by the orchestrator and the image is **not a compose service**. As a result every agent-side fix silently fails to ship through the documented update path, and nothing tells the operator their agents are still on old code. This is the structural cause behind the chronic "Agent-Image rebuild required" deploy gates.

## What this PR does

- **`scripts/update.sh`** (new, executable): the complete documented update path.
  1. `git pull`
  2. rebuilds the agent image explicitly (`docker build -t ai-employee-agent:latest ./agent`)
  3. rebuilds + restarts the compose stack (`docker compose up -d --build`)
  4. waits for the orchestrator health check
  5. **reports which running agents are still on the old image** by comparing each `ai-employee.type=agent` container's image id against the freshly built one, and points the operator at the existing recreate paths (Web UI "Update" action / `POST /agents/{id}/update`).
- **Update banner** now points at `./scripts/update.sh` instead of the bare `docker compose up -d --build` that leaves agents behind.

## Scope

This is **Phase 1** — the "complete documented update path" (suggested fix #1 in the issue). Recreating agents stays an explicit operator action (per the issue's "Not in scope"), because recreation interrupts running work. Issue kept open for:
- **Phase 2**: surface `image_outdated` in the agent API + a UI badge (suggested fix #2)
- **Phase 3**: optional "Update all outdated agents" bulk action honouring the Codex serialization lock (suggested fix #3)

## Verification

- `bash -n scripts/update.sh` → syntax OK.
- Stale-detection logic verified by hand: `docker images -q` returns the short id which is a prefix of the full `{{.Image}}` sha256 id; a container is flagged stale when its image id does not start with the freshly-built id.
- Docker daemon is not available inside the agent container, so the live rebuild path was not executed here (static-checked).

Refs #433