### PR TITLE
Phase 2 of #433: surface stale agent-image as image_outdated flag + UI badge

### DIFF
--- a/frontend/src/components/dashboard/agent-card.tsx
+++ b/frontend/src/components/dashboard/agent-card.tsx
@@ -143,6 +143,15 @@ export function AgentCard({ agent, updating = false }: AgentCardProps) {
                 {updating ? "Aktualisiere…" : "Update"}
               </div>
             )}
+            {!updating && !agent.update_available && agent.image_outdated && (
+              <div
+                title="Läuft auf einem veralteten Agent-Image. Auf dem Host ./scripts/update.sh ausführen und den Agent neu erstellen."
+                className="inline-flex items-center gap-1 rounded-full border px-2 py-1 text-[10px] font-medium bg-orange-500/10 text-orange-400 border-orange-500/20"
+              >
+                <ArrowUpCircle className="h-3 w-3" />
+                Image veraltet
+              </div>
+            )}
             {agent.budget_usd != null && agent.budget_usd > 0 && agent.monthly_cost_usd >= agent.budget_usd && (
               <div className={cn(
                 "inline-flex items-center gap-1 rounded-full border px-2 py-1 text-[10px] font-medium",

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -95,6 +95,7 @@ export interface Agent {
   integrations: string[];
   permissions: string[];
   update_available: boolean;
+  image_outdated?: boolean;
   budget_usd: number | null;
   budget_exceeded_action: "haiku" | "stop";
   monthly_cost_usd: number;

--- a/orchestrator/app/core/agent_manager.py
+++ b/orchestrator/app/core/agent_manager.py
@@ -1620,6 +1620,21 @@ class AgentManager:
         if stored_version != get_agent_version():
             update_available = True
 
+        # Check if the running container is on a stale agent image (issue #433):
+        # the ai-employee-agent:latest tag can be rebuilt without agents being
+        # recreated, so a live agent may silently serve two-day-old code.
+        image_outdated = False
+        if agent.container_id and agent.state in (
+            AgentState.RUNNING, AgentState.IDLE, AgentState.WORKING
+        ):
+            loop = asyncio.get_event_loop()
+            try:
+                image_outdated = await loop.run_in_executor(
+                    None, self.docker.is_container_image_outdated, agent.container_id
+                )
+            except Exception:
+                image_outdated = False
+
         # Build safe LLM config for response (no API key!)
         llm_config_response = None
         if agent.mode == "custom_llm" and agent.llm_config:
@@ -1695,6 +1710,7 @@ class AgentManager:
             "integrations": config.get("integrations", []),
             "permissions": config.get("permissions", DEFAULT_PERMISSIONS),
             "update_available": update_available,
+            "image_outdated": image_outdated,
             "budget_usd": agent.budget_usd,
             "budget_exceeded_action": agent.budget_exceeded_action,
             "monthly_cost_usd": monthly_cost_usd,

--- a/orchestrator/app/services/docker_service.py
+++ b/orchestrator/app/services/docker_service.py
@@ -276,6 +276,23 @@ class DockerService:
         except Exception:
             return None
 
+    def is_container_image_outdated(
+        self, container_id: str, image_name: str = "ai-employee-agent:latest"
+    ) -> bool:
+        """True if the container runs an older image than the current image_name tag.
+
+        Agent containers are launched from ai-employee-agent:latest but are NOT
+        recreated when that tag is rebuilt (issue #433), so a running agent can
+        silently stay on a stale image. Compares the container's build image id
+        against the id the tag currently points to. Fail-closed to False when
+        either id is unknown, so an unresolvable state never shows a false alarm.
+        """
+        current = self.get_image_id(image_name)
+        running = self.get_container_image_id(container_id)
+        if current is None or running is None:
+            return False
+        return current != running
+
     def get_container_status(self, container_id: str) -> str:
         try:
             container = self.client.containers.get(container_id)

--- a/orchestrator/tests/test_docker_service_image_outdated.py
+++ b/orchestrator/tests/test_docker_service_image_outdated.py
@@ -1,0 +1,79 @@
+"""Tests for issue #433 Phase 2: detect agent containers running a stale image.
+
+Agent containers are started from ai-employee-agent:latest but are not recreated
+when that tag is rebuilt, so a live agent can silently serve old code. The API
+surfaces this as an `image_outdated` flag driven by
+DockerService.is_container_image_outdated."""
+from app.services.docker_service import DockerService
+
+
+class _FakeImage:
+    def __init__(self, image_id):
+        self.id = image_id
+
+
+class _FakeContainer:
+    def __init__(self, image_id):
+        self.image = _FakeImage(image_id)
+
+
+class _FakeClient:
+    def __init__(self, tag_image_id, container_image_id, raise_on_tag=False,
+                 raise_on_container=False):
+        self._tag_image_id = tag_image_id
+        self._container_image_id = container_image_id
+        self._raise_on_tag = raise_on_tag
+        self._raise_on_container = raise_on_container
+
+    class _Images:
+        def __init__(self, outer):
+            self._outer = outer
+
+        def get(self, _image_name):
+            if self._outer._raise_on_tag:
+                raise RuntimeError("image not found")
+            return _FakeImage(self._outer._tag_image_id)
+
+    class _Containers:
+        def __init__(self, outer):
+            self._outer = outer
+
+        def get(self, _container_id):
+            if self._outer._raise_on_container:
+                raise RuntimeError("no such container")
+            return _FakeContainer(self._outer._container_image_id)
+
+    @property
+    def images(self):
+        return self._Images(self)
+
+    @property
+    def containers(self):
+        return self._Containers(self)
+
+
+def _service(**kwargs):
+    svc = DockerService.__new__(DockerService)  # bypass __init__ (needs a live daemon)
+    svc.client = _FakeClient(**kwargs)
+    return svc
+
+
+def test_outdated_when_container_image_differs_from_tag():
+    svc = _service(tag_image_id="sha256:new", container_image_id="sha256:old")
+    assert svc.is_container_image_outdated("cid") is True
+
+
+def test_not_outdated_when_ids_match():
+    svc = _service(tag_image_id="sha256:same", container_image_id="sha256:same")
+    assert svc.is_container_image_outdated("cid") is False
+
+
+def test_not_outdated_when_tag_id_unknown():
+    # Fail-closed: an unresolvable tag must never raise a false alarm.
+    svc = _service(tag_image_id="x", container_image_id="y", raise_on_tag=True)
+    assert svc.is_container_image_outdated("cid") is False
+
+
+def test_not_outdated_when_container_id_unknown():
+    svc = _service(tag_image_id="x", container_image_id="y", raise_on_container=True)
+    assert svc.is_container_image_outdated("cid") is False


### PR DESCRIPTION
## Summary
Part of #433 (also addresses part 2 of #406). Phase 1 (#447) added `scripts/update.sh`, which reports agents still on an old `ai-employee-agent:latest` image — but only on the host CLI. Nothing in the UI showed the mismatch, so a partially-failed or forgotten agent rebuild stays invisible.

This surfaces it in the product:
- **`DockerService.is_container_image_outdated(container_id)`** — compares the container's build image id against the id the `ai-employee-agent:latest` tag currently points to. Fail-closed to `False` when either id is unknown (no false alarms).
- **`agent_manager`** adds `image_outdated` to the agent response. Computed only for running/idle/working agents, off the event loop (`run_in_executor`), wrapped in try/except.
- **Frontend** shows a distinct orange **"Image veraltet"** badge on the agent card when the code version already matches (`update_available` false) but the image is stale — i.e. exactly the silent case from #406.

Scope stays deliberately narrow: this is detection/visibility only. Phase 3 (bulk "update all outdated agents") and the frontend/backend version handshake (#406 part 3) remain open — #433 is intentionally left open.

## Test plan
- [x] `test_docker_service_image_outdated.py` — 4 cases (differs → outdated, equal → not, tag id unknown → not, container id unknown → not). Verified locally against a stubbed docker client (pytest not installed in the agent container; runs in CI).
- [x] `py_compile` clean on both changed backend modules.
- [x] Frontend badge reuses the already-imported `ArrowUpCircle` and `orange-500` classes already present in `settings/view.tsx` (no new imports/palette). **Note:** `next build` is not runnable in the agent container and is not a CI gate — the TSX change is a self-contained badge and was verified by inspection only.

Deploy gate: orchestrator rebuild (backend change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)