### PR TITLE
Fix #449: cache image_outdated tag lookup per agent-list request

### DIFF
--- a/orchestrator/app/api/agents.py
+++ b/orchestrator/app/api/agents.py
@@ -573,11 +573,23 @@ async def list_agents(
             ))
         return AgentListResponse(agents=agent_responses, total=len(agent_responses))
 
+    # Resolve the ai-employee-agent:latest image id once for the whole list instead
+    # of once per agent (issue #449: N*2 -> 1+N Docker socket calls).
+    loop = asyncio.get_event_loop()
+    current_image_id = await loop.run_in_executor(
+        None, manager.docker.get_image_id, "ai-employee-agent:latest"
+    )
+
     # Run sequentially — AsyncSession does not support concurrent queries
     # on the same connection (asyncpg: "another operation is in progress").
     metrics_list = []
     for agent in agents:
-        metrics_list.append(await manager.get_agent_with_metrics(agent.id, include_stats=False))
+        metrics_list.append(await manager.get_agent_with_metrics(
+            agent.id,
+            include_stats=False,
+            image_id_resolved=True,
+            current_image_id=current_image_id,
+        ))
     agent_responses = [AgentResponse(**m) for m in metrics_list]
     return AgentListResponse(agents=agent_responses, total=len(agent_responses))
 

--- a/orchestrator/app/core/agent_manager.py
+++ b/orchestrator/app/core/agent_manager.py
@@ -3,6 +3,7 @@ import json
 import logging
 import uuid
 from datetime import datetime, timedelta, timezone
+from functools import partial
 
 from docker.errors import APIError, NotFound
 from sqlalchemy import delete as sql_delete, select, update as sql_update
@@ -1580,7 +1581,13 @@ class AgentManager:
         await self.db.delete(agent)
         await self.db.commit()
 
-    async def get_agent_with_metrics(self, agent_id: str, include_stats: bool = True) -> dict:
+    async def get_agent_with_metrics(
+        self,
+        agent_id: str,
+        include_stats: bool = True,
+        image_id_resolved: bool = False,
+        current_image_id: str | None = None,
+    ) -> dict:
         agent = await self._get_agent(agent_id)
 
         # Sync DB state with actual Docker container status (lightweight check).
@@ -1623,15 +1630,26 @@ class AgentManager:
         # Check if the running container is on a stale agent image (issue #433):
         # the ai-employee-agent:latest tag can be rebuilt without agents being
         # recreated, so a live agent may silently serve two-day-old code.
+        # image_id_resolved lets a caller iterating many agents (the list endpoint)
+        # resolve the ai-employee-agent:latest image id once and pass it in here,
+        # instead of one images.get() call per agent (issue #449).
         image_outdated = False
         if agent.container_id and agent.state in (
             AgentState.RUNNING, AgentState.IDLE, AgentState.WORKING
         ):
             loop = asyncio.get_event_loop()
             try:
-                image_outdated = await loop.run_in_executor(
-                    None, self.docker.is_container_image_outdated, agent.container_id
-                )
+                if image_id_resolved and current_image_id is None:
+                    image_outdated = False
+                else:
+                    image_outdated = await loop.run_in_executor(
+                        None,
+                        partial(
+                            self.docker.is_container_image_outdated,
+                            agent.container_id,
+                            current_image_id=current_image_id,
+                        ),
+                    )
             except Exception:
                 image_outdated = False
 

--- a/orchestrator/app/services/docker_service.py
+++ b/orchestrator/app/services/docker_service.py
@@ -277,7 +277,10 @@ class DockerService:
             return None
 
     def is_container_image_outdated(
-        self, container_id: str, image_name: str = "ai-employee-agent:latest"
+        self,
+        container_id: str,
+        image_name: str = "ai-employee-agent:latest",
+        current_image_id: str | None = None,
     ) -> bool:
         """True if the container runs an older image than the current image_name tag.
 
@@ -286,8 +289,12 @@ class DockerService:
         silently stay on a stale image. Compares the container's build image id
         against the id the tag currently points to. Fail-closed to False when
         either id is unknown, so an unresolvable state never shows a false alarm.
+
+        Pass current_image_id (from a single prior get_image_id call) when checking
+        many containers against the same tag, to avoid one images.get() per container
+        (issue #449).
         """
-        current = self.get_image_id(image_name)
+        current = current_image_id if current_image_id is not None else self.get_image_id(image_name)
         running = self.get_container_image_id(container_id)
         if current is None or running is None:
             return False

--- a/orchestrator/tests/test_docker_service_image_outdated.py
+++ b/orchestrator/tests/test_docker_service_image_outdated.py
@@ -24,12 +24,14 @@ class _FakeClient:
         self._container_image_id = container_image_id
         self._raise_on_tag = raise_on_tag
         self._raise_on_container = raise_on_container
+        self.images_get_calls = 0
 
     class _Images:
         def __init__(self, outer):
             self._outer = outer
 
         def get(self, _image_name):
+            self._outer.images_get_calls += 1
             if self._outer._raise_on_tag:
                 raise RuntimeError("image not found")
             return _FakeImage(self._outer._tag_image_id)
@@ -77,3 +79,20 @@ def test_not_outdated_when_tag_id_unknown():
 def test_not_outdated_when_container_id_unknown():
     svc = _service(tag_image_id="x", container_image_id="y", raise_on_container=True)
     assert svc.is_container_image_outdated("cid") is False
+
+
+def test_current_image_id_skips_tag_lookup():
+    # issue #449: when the caller already resolved the tag's image id (e.g. once
+    # for a whole agent list), is_container_image_outdated must not call
+    # images.get() again per container.
+    svc = _service(tag_image_id="sha256:new", container_image_id="sha256:old")
+    result = svc.is_container_image_outdated("cid", current_image_id="sha256:new")
+    assert result is True
+    assert svc.client.images_get_calls == 0
+
+
+def test_current_image_id_none_still_resolves_via_tag_lookup():
+    svc = _service(tag_image_id="sha256:same", container_image_id="sha256:same")
+    result = svc.is_container_image_outdated("cid", current_image_id=None)
+    assert result is False
+    assert svc.client.images_get_calls == 1


### PR DESCRIPTION
Fixes #449

## Summary
PR #448 added `image_outdated` to the agent response, but `DockerService.is_container_image_outdated()` called `images.get("ai-employee-agent:latest")` once per agent even though every agent shares the same tag — N*2 Docker socket calls on the list endpoint. CodeReview flagged this as W1 on #448.

## Fix (Option B from the issue)
- `DockerService.is_container_image_outdated()` gains an optional `current_image_id` param; when passed, it skips the `images.get()` call and only resolves the container's own image id.
- `AgentManager.get_agent_with_metrics()` gains `image_id_resolved` / `current_image_id` params. When the caller has already resolved the tag id (even to `None` — image missing), the per-agent check is skipped entirely (fail-closed `False`) instead of retrying the lookup.
- `GET /agents/` (list endpoint) resolves the tag's image id once via `run_in_executor`, then passes it into each per-agent `get_agent_with_metrics()` call: N*2 → 1+N Docker calls.
- Single-agent endpoints (detail view, create, update, etc.) are unchanged — they keep the default lazy per-call resolution.

## Tests
- `tests/test_docker_service_image_outdated.py`: 2 new cases — `current_image_id` passed skips `images.get()` (asserted via a call counter on the fake client); `current_image_id=None` still falls back to resolving via the tag. All 6 tests in the file pass (`python -m pytest`, using a stub docker SDK install since the repo has no local Docker daemon).
- `agent/`, `agents.py` wiring verified via `py_compile`; no live-list smoke test possible without a Docker daemon in this container (same limitation as PR #448).

Deploy gate: orchestrator image rebuild required after merge (same as #448/#444/#445).