### PR TITLE
Fix #451: use asyncio.get_running_loop() instead of deprecated get_event_loop()

### DIFF
--- a/orchestrator/app/api/agents.py
+++ b/orchestrator/app/api/agents.py
@@ -575,7 +575,7 @@ async def list_agents(
 
     # Resolve the ai-employee-agent:latest image id once for the whole list instead
     # of once per agent (issue #449: N*2 -> 1+N Docker socket calls).
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     current_image_id = await loop.run_in_executor(
         None, manager.docker.get_image_id, "ai-employee-agent:latest"
     )

--- a/orchestrator/app/api/computer_use.py
+++ b/orchestrator/app/api/computer_use.py
@@ -58,7 +58,7 @@ async def _refresh_screenshot_cache(session_id: str) -> str | None:
     if not session or not session["bridge_connected"] or not session["bridge_ws"]:
         return None
     cmd_id = uuid.uuid4().hex[:8]
-    result_future: asyncio.Future = asyncio.get_event_loop().create_future()
+    result_future: asyncio.Future = asyncio.get_running_loop().create_future()
     session["pending_results"][cmd_id] = result_future
     try:
         await session["bridge_ws"].send_text(json.dumps({
@@ -401,7 +401,7 @@ async def send_command(
         "ts": time.time(),
     })
 
-    result_future: asyncio.Future = asyncio.get_event_loop().create_future()
+    result_future: asyncio.Future = asyncio.get_running_loop().create_future()
     session["pending_results"][cmd_id] = result_future
 
     try:
@@ -502,7 +502,7 @@ async def get_screenshot(
         "id": cmd_id,
         "command": {"action": "screenshot", "params": {"scale": 0.5}},
     })
-    result_future: asyncio.Future = asyncio.get_event_loop().create_future()
+    result_future: asyncio.Future = asyncio.get_running_loop().create_future()
     session["pending_results"][cmd_id] = result_future
 
     try:
@@ -542,7 +542,7 @@ async def _send_bridge_action(session: dict, action: str, timeout: float = 10.0)
     if not session["bridge_connected"] or not session["bridge_ws"]:
         raise HTTPException(status_code=503, detail="Bridge not connected")
     cmd_id = uuid.uuid4().hex[:8]
-    future: asyncio.Future = asyncio.get_event_loop().create_future()
+    future: asyncio.Future = asyncio.get_running_loop().create_future()
     session["pending_results"][cmd_id] = future
     try:
         await session["bridge_ws"].send_text(json.dumps({

--- a/orchestrator/app/api/mcp_agent.py
+++ b/orchestrator/app/api/mcp_agent.py
@@ -480,7 +480,7 @@ async def _call_tool(name: str, args: dict, agent: Agent, db: AsyncSession, redi
         command_msg = json.dumps({"type": "command", "id": cmd_id, "command": {"action": action, "params": params}})
         session["action_count"] = session.get("action_count", 0) + 1
         session.setdefault("audit_log", []).append({"cmd_id": cmd_id, "action": action, "params": params, "caller": str(agent.id), "ts": __import__("time").time()})
-        result_future: _asyncio.Future = _asyncio.get_event_loop().create_future()
+        result_future: _asyncio.Future = _asyncio.get_running_loop().create_future()
         session.setdefault("pending_results", {})[cmd_id] = result_future
         try:
             await session["bridge_ws"].send_text(command_msg)

--- a/orchestrator/app/api/ws.py
+++ b/orchestrator/app/api/ws.py
@@ -569,9 +569,9 @@ async def ws_agent_chat(websocket: WebSocket, agent_id: str, token: str | None =
         has_pending = bool(_pending_message_ids) or bool(_streaming_responses)
         if not has_pending:
             return  # Nothing to wait for
-        deadline = asyncio.get_event_loop().time() + 120  # Wait up to 2 min
+        deadline = asyncio.get_running_loop().time() + 120  # Wait up to 2 min
         try:
-            while (_pending_message_ids or _streaming_responses) and asyncio.get_event_loop().time() < deadline:
+            while (_pending_message_ids or _streaming_responses) and asyncio.get_running_loop().time() < deadline:
                 message = await pubsub.get_message(
                     ignore_subscribe_messages=True, timeout=1.0
                 )

--- a/orchestrator/app/core/agent_manager.py
+++ b/orchestrator/app/core/agent_manager.py
@@ -1637,7 +1637,7 @@ class AgentManager:
         if agent.container_id and agent.state in (
             AgentState.RUNNING, AgentState.IDLE, AgentState.WORKING
         ):
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             try:
                 if image_id_resolved and current_image_id is None:
                     image_outdated = False
@@ -1773,7 +1773,7 @@ class AgentManager:
 
         # Add Docker stats if running (run in thread pool to avoid blocking)
         if include_stats and agent.container_id and agent.state in (AgentState.RUNNING, AgentState.IDLE, AgentState.WORKING):
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             try:
                 stats = await loop.run_in_executor(
                     None, self.docker.get_container_stats, agent.container_id

--- a/orchestrator/app/services/agent_chat_bridge.py
+++ b/orchestrator/app/services/agent_chat_bridge.py
@@ -56,9 +56,9 @@ async def ask_agent_via_chat(
     await redis.client.lpush(f"agent:{agent_id}:chat", json.dumps(payload))
 
     collected: list[str] = []
-    deadline = asyncio.get_event_loop().time() + timeout
+    deadline = asyncio.get_running_loop().time() + timeout
     try:
-        while asyncio.get_event_loop().time() < deadline:
+        while asyncio.get_running_loop().time() < deadline:
             msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=0.5)
             if not msg or msg.get("type") != "message":
                 continue

--- a/orchestrator/app/services/disk_monitor.py
+++ b/orchestrator/app/services/disk_monitor.py
@@ -50,7 +50,7 @@ class DiskMonitorService:
             )
             agents = list(result.scalars().all())
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         for agent in agents:
             if not agent.container_id:
                 continue
@@ -118,7 +118,7 @@ class DiskMonitorService:
         try:
             # Write a final warning before stopping so the user sees why
             self._write_warning(agent.container_id, stats)
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             await loop.run_in_executor(None, self.docker.stop_container, agent.container_id)
         except Exception as exc:
             logger.error("Failed to stop disk-full agent %s: %s", agent.id, exc)

--- a/orchestrator/app/telegram/agent_bot.py
+++ b/orchestrator/app/telegram/agent_bot.py
@@ -741,7 +741,7 @@ class TelegramAgentBot:
 
             response_buffer = ""
             full_response = ""  # whole turn's text — for the voice-first reply
-            last_flush = asyncio.get_event_loop().time()
+            last_flush = asyncio.get_running_loop().time()
 
             # Detect agent mode: custom_llm streams slower → flush per sentence
             _is_local_llm = False
@@ -765,7 +765,7 @@ class TelegramAgentBot:
                 message = await pubsub.get_message(
                     ignore_subscribe_messages=True, timeout=0.5
                 )
-                now = asyncio.get_event_loop().time()
+                now = asyncio.get_running_loop().time()
 
                 if message and message["type"] == "message":
                     data = json.loads(message["data"])


### PR DESCRIPTION
Fixes #451

## What
Replaces all 16 occurrences of `asyncio.get_event_loop()` with `asyncio.get_running_loop()` across the orchestrator.

## Why
`asyncio.get_event_loop()` is deprecated in async contexts since Python 3.10 and emits `DeprecationWarning` under Python 3.12+. Pure housekeeping — no user-visible behavior change.

## Safety
Every call site was verified to live inside an `async def` function, where a running loop is guaranteed. `get_running_loop()` is therefore a semantically-identical, non-deprecated replacement (it raises only when no loop is running, which cannot happen here).

Files touched: `api/agents.py`, `api/computer_use.py` (4×), `api/mcp_agent.py`, `api/ws.py` (2×), `core/agent_manager.py` (2×), `services/agent_chat_bridge.py` (2×), `services/disk_monitor.py` (2×), `telegram/agent_bot.py` (2×).

## Verify
- `python -m py_compile` passes on all 8 files.
- No remaining `get_event_loop()` in `orchestrator/app`.

Deploy gate: orchestrator image rebuild required to take effect.