### PR TITLE
feat: agent-side MCP connection health (Phase 2 of #425)

### DIFF
--- a/frontend/src/app/integrations/page.tsx
+++ b/frontend/src/app/integrations/page.tsx
@@ -13,7 +13,7 @@ import { cn } from "@/lib/utils";
 import * as api from "@/lib/api";
 import { useConfirm } from "@/components/ui/dialog-provider";
 import type { Integration } from "@/lib/types";
-import type { McpServerInfo, McpTool } from "@/lib/api";
+import type { McpServerInfo, McpTool, McpAgentHealth, McpAgentHealthEntry } from "@/lib/api";
 import { useSearchParams } from "next/navigation";
 
 const PROVIDER_ICONS: Record<string, typeof Mail> = {
@@ -81,6 +81,48 @@ function formatMcpHealth(server: McpServerInfo): { ok: boolean; label: string; c
     className: server.last_status === "auth_failed" ? "text-amber-400" : "text-red-400",
     title: MCP_HEALTH_ORCH_ONLY,
   };
+}
+
+// Agent-side view (#425 Phase 2): what each running agent's `claude mcp list`
+// reports for this server, rolled up across agents. Distinct from the
+// orchestrator discovery check above — an agent can fail a server (e.g. a 401
+// on its per-agent token) that the orchestrator reaches fine.
+function formatAgentHealth(
+  entry: McpAgentHealthEntry,
+): { label: string; className: string; ok: boolean } {
+  const total = entry.connected + entry.failed + entry.needs_auth + entry.unknown;
+  if (!entry.agent_status || total === 0) {
+    return { label: "Agent-Sicht: keine Daten", className: "text-muted-foreground/50", ok: false };
+  }
+  if (entry.agent_status === "connected") {
+    return {
+      label: `Agent-Sicht: verbunden (${entry.connected}/${total} Agents)`,
+      className: "text-emerald-400",
+      ok: true,
+    };
+  }
+  if (entry.agent_status === "needs_auth") {
+    return {
+      label: `Agent-Sicht: Authentifizierung nötig (${entry.needs_auth}/${total})`,
+      className: "text-amber-400",
+      ok: false,
+    };
+  }
+  if (entry.agent_status === "failed") {
+    return {
+      label: `Agent-Sicht: nicht erreichbar (${entry.failed}/${total})`,
+      className: "text-red-400",
+      ok: false,
+    };
+  }
+  return { label: "Agent-Sicht: unbekannt", className: "text-muted-foreground/60", ok: false };
+}
+
+// The signal #425 exists to surface: the orchestrator's own check says a server
+// is reachable, but the agents that actually call it disagree.
+function hasOrchAgentDisagreement(server: McpServerInfo, entry: McpAgentHealthEntry | undefined): boolean {
+  if (!entry || !entry.agent_status) return false;
+  return server.last_status === "ok" && (entry.agent_status === "failed" || entry.agent_status === "needs_auth");
 }
 
 export default function IntegrationsPage() {
@@ -419,6 +461,8 @@ function McpServersSection({ onToast }: { onToast: (t: { type: "success" | "erro
   const [expandedServer, setExpandedServer] = useState<number | null>(null);
   const [refreshing, setRefreshing] = useState<number | null>(null);
   const [deleting, setDeleting] = useState<number | null>(null);
+  const [agentHealth, setAgentHealth] = useState<McpAgentHealth | null>(null);
+  const [checkingAgents, setCheckingAgents] = useState(false);
 
   const editingServer = editingId != null ? servers.find((s) => s.id === editingId) ?? null : null;
 
@@ -586,6 +630,22 @@ function McpServersSection({ onToast }: { onToast: (t: { type: "success" | "erro
     }
   };
 
+  const handleCheckAgents = async () => {
+    setCheckingAgents(true);
+    try {
+      const health = await api.getMcpAgentHealth();
+      setAgentHealth(health);
+      onToast({
+        type: "success",
+        message: `Agent-Sicht geprüft (${health.agents_checked}/${health.agents_total} Agents)`,
+      });
+    } catch (e) {
+      onToast({ type: "error", message: e instanceof Error ? e.message : "Agent-Prüfung fehlgeschlagen" });
+    } finally {
+      setCheckingAgents(false);
+    }
+  };
+
   const handleToggle = async (server: McpServerInfo) => {
     try {
       const updated = await api.updateMcpServer(server.id, { enabled: !server.enabled });
@@ -599,13 +659,24 @@ function McpServersSection({ onToast }: { onToast: (t: { type: "success" | "erro
     <div>
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">MCP Servers</h2>
-        <button
-          onClick={() => (showForm ? closeForm() : openAdd())}
-          className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 shadow-lg shadow-primary/20 transition-all"
-        >
-          <Plus className="h-3 w-3" />
-          MCP Server hinzufuegen
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleCheckAgents}
+            disabled={checkingAgents}
+            title="Führt in jedem laufenden Agent-Container `claude mcp list` aus und zeigt, wie die Agents die Server sehen (unabhängig von der Orchestrator-Prüfung)."
+            className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium text-foreground border border-foreground/[0.1] hover:bg-foreground/[0.06] disabled:opacity-50 transition-all"
+          >
+            {checkingAgents ? <Loader2 className="h-3 w-3 animate-spin" /> : <Users className="h-3 w-3" />}
+            Agent-Sicht prüfen
+          </button>
+          <button
+            onClick={() => (showForm ? closeForm() : openAdd())}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 shadow-lg shadow-primary/20 transition-all"
+          >
+            <Plus className="h-3 w-3" />
+            MCP Server hinzufuegen
+          </button>
+        </div>
       </div>
 
       {/* Add / edit form */}
@@ -759,6 +830,9 @@ function McpServersSection({ onToast }: { onToast: (t: { type: "success" | "erro
             const isExpanded = expandedServer === server.id;
             const toolCount = server.tools?.length || 0;
             const health = formatMcpHealth(server);
+            const agentEntry = agentHealth?.servers[String(server.id)];
+            const agentView = agentEntry ? formatAgentHealth(agentEntry) : null;
+            const disagreement = hasOrchAgentDisagreement(server, agentEntry);
 
             return (
               <div
@@ -807,6 +881,21 @@ function McpServersSection({ onToast }: { onToast: (t: { type: "success" | "erro
                       {health.ok ? <CheckCircle2 className="h-3 w-3 shrink-0" /> : <AlertCircle className="h-3 w-3 shrink-0" />}
                       <span className="truncate">{health.label}</span>
                     </div>
+                    {agentView && (
+                      <div
+                        className={cn("mt-1 flex items-center gap-1.5 text-[11px]", agentView.className)}
+                        title="Ergebnis von `claude mcp list` in den laufenden Agent-Containern (Agent-Perspektive, #425)."
+                      >
+                        {agentView.ok ? <CheckCircle2 className="h-3 w-3 shrink-0" /> : <AlertCircle className="h-3 w-3 shrink-0" />}
+                        <span className="truncate">{agentView.label}</span>
+                      </div>
+                    )}
+                    {disagreement && (
+                      <div className="mt-1 flex items-center gap-1.5 text-[11px] text-amber-400" title="Der Orchestrator erreicht den Server, aber mindestens ein Agent nicht — oft ein pro-Agent-Token, das der Server ablehnt.">
+                        <AlertCircle className="h-3 w-3 shrink-0" />
+                        <span className="truncate">Diskrepanz: Orchestrator erreichbar, Agents melden Probleme</span>
+                      </div>
+                    )}
                   </div>
 
                   {/* Actions */}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1200,6 +1200,32 @@ export async function refreshMcpServer(id: number): Promise<McpServerInfo> {
   return fetchJSON(`${getBase()}/mcp-servers/${id}/refresh`, { method: "POST" });
 }
 
+export type AgentMcpStatus = "connected" | "failed" | "needs_auth" | "unknown";
+
+export interface McpAgentHealthEntry {
+  name: string;
+  connected: number;
+  failed: number;
+  needs_auth: number;
+  unknown: number;
+  agent_status: AgentMcpStatus | null;
+  agents: { agent_id: string; agent_name: string; status: AgentMcpStatus }[];
+}
+
+export interface McpAgentHealth {
+  agents_checked: number;
+  agents_total: number;
+  // Keyed by MCP server id (as a string).
+  servers: Record<string, McpAgentHealthEntry>;
+}
+
+// Agent-side MCP connection health (#425 Phase 2): what each running agent's
+// `claude mcp list` reports, independent of the orchestrator's own discovery
+// check. On-demand (admin-only) — each call runs live probes across all agents.
+export async function getMcpAgentHealth(): Promise<McpAgentHealth> {
+  return fetchJSON(`${getBase()}/mcp-servers/agent-health`);
+}
+
 export async function updateMcpServer(
   id: number,
   data: { name?: string; url?: string; enabled?: boolean; bearer_token?: string; headers?: Record<string, string> },

--- a/orchestrator/app/api/mcp_servers.py
+++ b/orchestrator/app/api/mcp_servers.py
@@ -663,6 +663,59 @@ async def probe_mcp_server(body: McpServerCreate, user=Depends(require_admin), d
     }
 
 
+@router.get("/agent-health")
+async def mcp_agent_health(user=Depends(require_admin), db: AsyncSession = Depends(get_db)):
+    """Agent-side MCP connection health (#425 Phase 2).
+
+    Runs ``claude mcp list`` inside every running agent container and reports,
+    per registered external server, how the agents actually see it — a signal
+    independent of the orchestrator's own discovery check (``last_status``). This
+    is what catches the case a green orchestrator status hides: e.g. a per-agent
+    token that a server rejects with 401 on a URL the orchestrator reaches
+    anonymously. Admin-only and on-demand (each check does live connectivity
+    probes across N agents, so it is not run on every page load).
+    """
+    from app.models.agent import Agent, AgentState
+    from app.services.docker_service import DockerService
+    from app.services.mcp_agent_health import collect_agent_mcp_health
+
+    servers_result = await db.execute(select(McpServer))
+    name_to_id = {_sanitize_mcp_name(s.name): s.id for s in servers_result.scalars().all()}
+
+    agents_result = await db.execute(
+        select(Agent).where(
+            Agent.container_id.is_not(None),
+            Agent.state.in_([AgentState.RUNNING, AgentState.IDLE, AgentState.WORKING]),
+        )
+    )
+    agents = list(agents_result.scalars().all())
+
+    docker = DockerService()
+
+    async def _exec_list(container_id: str) -> str | None:
+        def _run() -> str | None:
+            try:
+                _code, out = docker.exec_in_container(container_id, ["claude", "mcp", "list"])
+                return out
+            except Exception:
+                return None
+
+        return await asyncio.to_thread(_run)
+
+    health = await collect_agent_mcp_health(agents, _exec_list, name_to_id.keys())
+
+    servers_by_id = {
+        str(name_to_id[name]): {"name": name, **data}
+        for name, data in health["servers"].items()
+        if name in name_to_id
+    }
+    return {
+        "agents_checked": health["agents_checked"],
+        "agents_total": len(agents),
+        "servers": servers_by_id,
+    }
+
+
 @router.post("/{server_id}/call")
 async def call_mcp_tool(
     server_id: int, body: McpToolCall, user=Depends(require_admin), db: AsyncSession = Depends(get_db),

--- a/orchestrator/app/services/mcp_agent_health.py
+++ b/orchestrator/app/services/mcp_agent_health.py
@@ -1,0 +1,146 @@
+"""Agent-side MCP connection health (#425 Phase 2).
+
+The orchestrator's own discovery check (``app/api/mcp_servers.py``) only proves
+that the *orchestrator* can reach an MCP server. Every agent container registers
+the same external servers via ``claude mcp add`` and may see a different result:
+a per-agent auth token can be rejected (401) on a URL the orchestrator reaches
+anonymously, or a container's egress may be firewalled differently. This module
+surfaces that second, independent signal by running ``claude mcp list`` inside
+each running agent and parsing its per-server connectivity verdict, so a green
+orchestrator status is never mistaken for "agents can actually use it".
+
+The parser is a pure function so it can be unit-tested without Docker; the
+collector takes an injected ``exec_list`` callable for the same reason.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from collections.abc import Awaitable, Callable, Iterable
+
+AGENT_MCP_CONNECTED = "connected"
+AGENT_MCP_FAILED = "failed"
+AGENT_MCP_NEEDS_AUTH = "needs_auth"
+AGENT_MCP_UNKNOWN = "unknown"
+
+# Precedence for rolling many agents' verdicts for one server into a single
+# headline status: a real failure is the most actionable, so it wins; an auth
+# problem is next; "connected" only when nothing worse was observed.
+_ROLLUP_ORDER = [
+    AGENT_MCP_FAILED,
+    AGENT_MCP_NEEDS_AUTH,
+    AGENT_MCP_CONNECTED,
+    AGENT_MCP_UNKNOWN,
+]
+
+# A `claude mcp list` server line: "<name>: <command-or-url> - <verdict>".
+# Server names are sanitized to [A-Za-z0-9_-] before registration, so the name
+# never contains the ": " that separates it from the rest of the line.
+_MCP_LIST_LINE = re.compile(r"^(?P<name>[A-Za-z0-9_-]+):\s+(?P<body>.+)$")
+
+
+def _classify(status_text: str) -> str:
+    low = status_text.lower()
+    if "✓" in status_text or "connected" in low:
+        return AGENT_MCP_CONNECTED
+    if "auth" in low:  # "Needs authentication"
+        return AGENT_MCP_NEEDS_AUTH
+    if "✗" in status_text or "fail" in low or "error" in low or "disconnected" in low:
+        return AGENT_MCP_FAILED
+    return AGENT_MCP_UNKNOWN
+
+
+def parse_claude_mcp_list(output: str) -> dict[str, str]:
+    """Parse ``claude mcp list`` stdout into ``{server_name: agent_status}``.
+
+    Each server line looks like ``name: <command-or-url> - ✓ Connected`` (or
+    ``✗ Failed to connect`` / ``Needs authentication``). The verdict is the
+    segment after the final `` - `` on the line; everything before the first
+    ``:`` is the (sanitized) server name. Lines without a `` - `` verdict and the
+    ``Checking MCP server health...`` banner / blank lines are ignored.
+    """
+    result: dict[str, str] = {}
+    for raw in output.splitlines():
+        line = raw.strip()
+        match = _MCP_LIST_LINE.match(line)
+        if not match:
+            continue
+        body = match.group("body")
+        if " - " not in body:
+            continue
+        status_text = body.rsplit(" - ", 1)[1].strip()
+        result[match.group("name")] = _classify(status_text)
+    return result
+
+
+def rollup_statuses(statuses: Iterable[str]) -> str | None:
+    """Collapse many agents' verdicts for one server into a single headline.
+
+    Returns ``None`` when no agent reported on the server (so callers can render
+    "no agent data" distinctly from "all agents unknown").
+    """
+    seen = set(statuses)
+    if not seen:
+        return None
+    for status in _ROLLUP_ORDER:
+        if status in seen:
+            return status
+    return AGENT_MCP_UNKNOWN
+
+
+async def collect_agent_mcp_health(
+    agents: list,
+    exec_list: Callable[[str], Awaitable[str | None]],
+    server_names: Iterable[str],
+    *,
+    per_agent_timeout: float = 25.0,
+) -> dict:
+    """Run the agent-side check across ``agents`` and aggregate per server name.
+
+    ``exec_list(container_id)`` returns the raw ``claude mcp list`` stdout for one
+    agent, or ``None`` if the check could not run (agent unreachable, command
+    failed). Such agents are skipped (fail-soft) — one broken agent never fails
+    the whole report. Results are restricted to ``server_names`` (the registered
+    external servers) so the agent's built-in stdio servers are ignored.
+
+    Each ``agent`` must expose ``id``, ``name`` and ``container_id`` attributes.
+    """
+    wanted = set(server_names)
+    per_server: dict[str, list[dict]] = {name: [] for name in wanted}
+
+    async def _one(agent) -> str | None:
+        try:
+            return await asyncio.wait_for(exec_list(agent.container_id), per_agent_timeout)
+        except (asyncio.TimeoutError, Exception):  # noqa: BLE001 — fail-soft per agent
+            return None
+
+    outputs = await asyncio.gather(*[_one(agent) for agent in agents])
+
+    checked = 0
+    for agent, output in zip(agents, outputs):
+        if not output:
+            continue
+        checked += 1
+        parsed = parse_claude_mcp_list(output)
+        for name in wanted:
+            status = parsed.get(name)
+            if status is None:
+                continue
+            per_server[name].append(
+                {"agent_id": agent.id, "agent_name": agent.name, "status": status}
+            )
+
+    servers: dict[str, dict] = {}
+    for name, entries in per_server.items():
+        statuses = [entry["status"] for entry in entries]
+        servers[name] = {
+            "connected": statuses.count(AGENT_MCP_CONNECTED),
+            "failed": statuses.count(AGENT_MCP_FAILED),
+            "needs_auth": statuses.count(AGENT_MCP_NEEDS_AUTH),
+            "unknown": statuses.count(AGENT_MCP_UNKNOWN),
+            "agent_status": rollup_statuses(statuses),
+            "agents": entries,
+        }
+
+    return {"agents_checked": checked, "servers": servers}

--- a/orchestrator/tests/test_mcp_agent_health.py
+++ b/orchestrator/tests/test_mcp_agent_health.py
@@ -1,0 +1,127 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.mcp_agent_health import (
+    AGENT_MCP_CONNECTED,
+    AGENT_MCP_FAILED,
+    AGENT_MCP_NEEDS_AUTH,
+    AGENT_MCP_UNKNOWN,
+    collect_agent_mcp_health,
+    parse_claude_mcp_list,
+    rollup_statuses,
+)
+
+SAMPLE_OUTPUT = """Checking MCP server health...
+
+memory: node /opt/mcp/memory-server.mjs - ✓ Connected
+orchestrator: node /opt/mcp/orchestrator-server.mjs - ✓ Connected
+composio: https://mcp.composio.dev/xyz (HTTP) - ✗ Failed to connect
+n8n: https://n8n.example.test/mcp (HTTP) - Needs authentication
+"""
+
+
+def test_parse_classifies_each_server_line():
+    parsed = parse_claude_mcp_list(SAMPLE_OUTPUT)
+
+    assert parsed["memory"] == AGENT_MCP_CONNECTED
+    assert parsed["orchestrator"] == AGENT_MCP_CONNECTED
+    assert parsed["composio"] == AGENT_MCP_FAILED
+    assert parsed["n8n"] == AGENT_MCP_NEEDS_AUTH
+
+
+def test_parse_ignores_banner_and_blank_lines():
+    parsed = parse_claude_mcp_list(SAMPLE_OUTPUT)
+    # Only real server lines are kept; the "Checking..." banner is dropped.
+    assert set(parsed) == {"memory", "orchestrator", "composio", "n8n"}
+
+
+def test_parse_ignores_lines_without_a_verdict():
+    # Some CLI versions print just "name: command" with no " - <status>".
+    parsed = parse_claude_mcp_list("foo: node /opt/mcp/foo.mjs\nbar: url - ✓ Connected\n")
+    assert parsed == {"bar": AGENT_MCP_CONNECTED}
+
+
+def test_parse_handles_empty_output():
+    assert parse_claude_mcp_list("") == {}
+
+
+def test_rollup_prefers_failure_over_auth_over_connected():
+    assert rollup_statuses([AGENT_MCP_CONNECTED, AGENT_MCP_FAILED]) == AGENT_MCP_FAILED
+    assert rollup_statuses([AGENT_MCP_CONNECTED, AGENT_MCP_NEEDS_AUTH]) == AGENT_MCP_NEEDS_AUTH
+    assert rollup_statuses([AGENT_MCP_CONNECTED, AGENT_MCP_CONNECTED]) == AGENT_MCP_CONNECTED
+    assert rollup_statuses([AGENT_MCP_UNKNOWN]) == AGENT_MCP_UNKNOWN
+
+
+def test_rollup_none_when_no_agent_reported():
+    assert rollup_statuses([]) is None
+
+
+@pytest.mark.asyncio
+async def test_collect_aggregates_per_server_across_agents():
+    agents = [
+        SimpleNamespace(id="a1", name="Alice", container_id="c1"),
+        SimpleNamespace(id="a2", name="Bob", container_id="c2"),
+    ]
+    outputs = {
+        "c1": "composio: https://x (HTTP) - ✓ Connected\n",
+        "c2": "composio: https://x (HTTP) - ✗ Failed to connect\n",
+    }
+
+    async def exec_list(container_id):
+        return outputs.get(container_id)
+
+    result = await collect_agent_mcp_health(agents, exec_list, ["composio"])
+
+    assert result["agents_checked"] == 2
+    server = result["servers"]["composio"]
+    assert server["connected"] == 1
+    assert server["failed"] == 1
+    # A failure anywhere makes the headline status "failed".
+    assert server["agent_status"] == AGENT_MCP_FAILED
+    assert {a["agent_id"] for a in server["agents"]} == {"a1", "a2"}
+
+
+@pytest.mark.asyncio
+async def test_collect_is_fail_soft_when_an_agent_check_returns_none():
+    agents = [
+        SimpleNamespace(id="a1", name="Alice", container_id="c1"),
+        SimpleNamespace(id="a2", name="Bob", container_id="c2"),
+    ]
+
+    async def exec_list(container_id):
+        if container_id == "c2":
+            return None  # agent unreachable / command failed
+        return "composio: https://x (HTTP) - ✓ Connected\n"
+
+    result = await collect_agent_mcp_health(agents, exec_list, ["composio"])
+
+    assert result["agents_checked"] == 1
+    assert result["servers"]["composio"]["connected"] == 1
+
+
+@pytest.mark.asyncio
+async def test_collect_ignores_servers_not_in_wanted_set():
+    agents = [SimpleNamespace(id="a1", name="Alice", container_id="c1")]
+
+    async def exec_list(container_id):
+        return "memory: node x - ✓ Connected\ncomposio: url - ✗ Failed\n"
+
+    result = await collect_agent_mcp_health(agents, exec_list, ["composio"])
+
+    # Built-in "memory" is not a registered external server → excluded.
+    assert set(result["servers"]) == {"composio"}
+    assert result["servers"]["composio"]["agent_status"] == AGENT_MCP_FAILED
+
+
+@pytest.mark.asyncio
+async def test_collect_reports_none_status_for_server_no_agent_sees():
+    agents = [SimpleNamespace(id="a1", name="Alice", container_id="c1")]
+
+    async def exec_list(container_id):
+        return "composio: url - ✓ Connected\n"
+
+    result = await collect_agent_mcp_health(agents, exec_list, ["composio", "slack"])
+
+    assert result["servers"]["slack"]["agent_status"] is None
+    assert result["servers"]["slack"]["agents"] == []


### PR DESCRIPTION
## Summary
Phase 2 of #425. Phase 1 (#432) persisted the **orchestrator's** MCP discovery check, but a green orchestrator status only proves *the orchestrator* can reach a server. Each agent container registers the same external servers via `claude mcp add` and can see a **different** result — most importantly a per-agent token the server rejects with **401** on a URL the orchestrator reaches anonymously. That is the exact "a server that returns 401 for every agent call looks identical to a working one" case in #425.

This adds a second, independent signal:

- **`orchestrator/app/services/mcp_agent_health.py`** — pure `parse_claude_mcp_list()` (server → `connected`/`failed`/`needs_auth`/`unknown`) and a fail-soft `collect_agent_mcp_health()` collector. The collector takes an injected `exec_list` callable so it is fully unit-testable without Docker. A `rollup_statuses()` precedence (`failed` > `needs_auth` > `connected` > `unknown`) collapses many agents' verdicts into one headline.
- **`GET /mcp-servers/agent-health`** (admin, on-demand) — runs `claude mcp list` in every running agent container (via `DockerService.exec_in_container`, off-loop with `asyncio.to_thread`, per-agent timeout, one broken agent never fails the report) and aggregates per registered server, keyed by server id.
- **Integrations UI** — an "Agent-Sicht prüfen" button, a per-server agent-side status line, and an explicit **discrepancy banner** when the orchestrator sees a server as reachable but agents disagree.

It is on-demand (not on every page load) because each check does live connectivity probes across N agents.

## Test plan
- [x] `pytest tests/test_mcp_agent_health.py` — 10/10 pass (parser, rollup precedence, fail-soft collector, wanted-set filtering, no-agent-data → `None`)
- [x] `python -m py_compile` on `mcp_agent_health.py` + `api/mcp_servers.py`
- [x] `tsc --noEmit` clean on the frontend
- [x] `git diff --check` clean
- [ ] Manual: trigger "Agent-Sicht prüfen" against a server with a bad per-agent token and confirm the discrepancy banner appears (requires the full Docker stack; the orchestrator backend change needs a `docker compose up --build -d` rebuild to take effect after merge)

Fixes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)