### PR TITLE
fix(computer-use): show authoritative bridge connection URL

### DIFF
--- a/frontend/src/components/agents/computer-use-tab.tsx
+++ b/frontend/src/components/agents/computer-use-tab.tsx
@@ -141,6 +141,52 @@ const RISK_COLORS = {
   high: "text-red-400",
 };
 
+type BridgeUrlSource = "bridge_host" | "configured" | "browser_derived";
+
+function buildBridgeWsUrl(base: string, sessionId: string): string {
+  const normalizedBase = base
+    .trim()
+    .replace(/^http:\/\//i, "ws://")
+    .replace(/^https:\/\//i, "wss://")
+    .replace(/\/$/, "");
+
+  if (normalizedBase.includes("/ws/computer-use/bridge")) {
+    try {
+      const url = new URL(normalizedBase);
+      url.searchParams.set("session_id", sessionId);
+      return url.toString();
+    } catch {
+      // Fall through to the base-URL shape below.
+    }
+  }
+
+  return `${normalizedBase}/ws/computer-use/bridge?session_id=${encodeURIComponent(sessionId)}`;
+}
+
+function bridgeBaseFromHost(host: string | null | undefined, browserWsBase: string): string | null {
+  const trimmed = host?.trim();
+  if (!trimmed || trimmed.includes("/") || trimmed.includes("\\") || /\s/.test(trimmed)) {
+    return null;
+  }
+  const scheme = browserWsBase.toLowerCase().startsWith("wss://") ? "wss" : "ws";
+  return `${scheme}://${trimmed}`;
+}
+
+function resolveBridgeUrl(session: ComputerUseSession, browserWsBase: string): { url: string; source: BridgeUrlSource } {
+  const bridgeHostBase = session.status === "connected"
+    ? bridgeBaseFromHost(session.bridge_host, browserWsBase)
+    : null;
+  if (bridgeHostBase) {
+    return { url: buildBridgeWsUrl(bridgeHostBase, session.session_id), source: "bridge_host" };
+  }
+
+  if (session.bridge_public_url?.trim()) {
+    return { url: buildBridgeWsUrl(session.bridge_public_url, session.session_id), source: "configured" };
+  }
+
+  return { url: buildBridgeWsUrl(browserWsBase, session.session_id), source: "browser_derived" };
+}
+
 // ── Main component ────────────────────────────────────────────────────────────
 
 export function ComputerUseTab({ agentId, browserMode: initialBrowserMode = false }: Props) {
@@ -228,7 +274,7 @@ export function ComputerUseTab({ agentId, browserMode: initialBrowserMode = fals
   };
 
   const baseUrl = getApiUrl().replace(/\/$/, "");
-  const wsBase = baseUrl.replace(/^http/, "ws");
+  const browserWsBase = baseUrl.replace(/^http/, "ws");
 
   return (
     <div className="h-full overflow-y-auto space-y-4 pr-1">
@@ -370,7 +416,7 @@ export function ComputerUseTab({ agentId, browserMode: initialBrowserMode = fals
               <SessionCard
                 key={session.session_id}
                 session={session}
-                wsBase={wsBase}
+                browserWsBase={browserWsBase}
                 expectedBridgeVersion={bridgeVersion}
                 onDelete={handleDelete}
                 onCapabilitiesChange={handleCapabilitiesChange}
@@ -448,20 +494,24 @@ export function ComputerUseTab({ agentId, browserMode: initialBrowserMode = fals
 
 function SessionCard({
   session,
-  wsBase,
+  browserWsBase,
   expectedBridgeVersion,
   onDelete,
   onCapabilitiesChange,
 }: {
   session: ComputerUseSession;
-  wsBase: string;
+  browserWsBase: string;
   expectedBridgeVersion: string | null;
   onDelete: (id: string) => void;
   onCapabilitiesChange: (id: string, caps: string[]) => void;
 }) {
   const bridgeStale = session.bridge_last_seen_at !== null && (Date.now() / 1000 - session.bridge_last_seen_at) > 20;
   const isConnected = session.status === "connected" && !bridgeStale;
-  const wsUrl = `${wsBase}/ws/computer-use/bridge?session_id=${session.session_id}`;
+  const bridgeUrl = resolveBridgeUrl(
+    isConnected ? session : { ...session, status: session.status === "connected" ? "waiting_for_bridge" : session.status },
+    browserWsBase,
+  );
+  const wsUrl = bridgeUrl.url;
   const visibleBridgeVersion = session.bridge_version || expectedBridgeVersion;
 
   const [copiedWs, setCopiedWs] = useState(false);
@@ -683,6 +733,21 @@ function SessionCard({
           <p className="text-[10px] text-muted-foreground/50">
             Bridge-App starten und diese URL einfügen:{" "}
             <code className="text-violet-400/80">python tray_app.py</code>
+          </p>
+        )}
+        {bridgeUrl.source === "browser_derived" && (
+          <p className="text-[10px] text-amber-400/70">
+            Abgeleitet aus der Adresse dieses Browsers. Wenn die Bridge über einen anderen Hostnamen verbindet, verwende diesen Hostnamen.
+          </p>
+        )}
+        {bridgeUrl.source === "bridge_host" && (
+          <p className="text-[10px] text-muted-foreground/50">
+            Hostname von der aktiven Bridge-Verbindung übernommen.
+          </p>
+        )}
+        {bridgeUrl.source === "configured" && (
+          <p className="text-[10px] text-muted-foreground/50">
+            Hostname aus der Server-Konfiguration übernommen.
           </p>
         )}
       </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2694,6 +2694,8 @@ export interface ComputerUseSession {
   action_count: number;
   platform: string;
   bridge_version?: string | null;
+  bridge_host?: string | null;
+  bridge_public_url?: string | null;
   capabilities: string[];
   allowed_capabilities: string[];
   last_disconnected_at: number | null;

--- a/orchestrator/app/api/computer_use.py
+++ b/orchestrator/app/api/computer_use.py
@@ -25,6 +25,7 @@ from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisco
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import settings
 from app.dependencies import get_db, is_agent_principal, require_auth, require_auth_or_agent
 from app.services.redis_service import RedisService
 
@@ -129,6 +130,11 @@ def init_computer_use(redis: RedisService) -> None:
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
+def _public_bridge_base_url() -> str | None:
+    configured = settings.bridge_public_url.strip().rstrip("/")
+    return configured or None
+
+
 async def _resolve_caller_user_id(caller, db: AsyncSession) -> str | None:
     """Return the user_id for a caller (User object or agent SimpleNamespace)."""
     if is_agent_principal(caller):
@@ -153,6 +159,8 @@ def _session_view(sid: str, s: dict) -> dict:
         "last_disconnected_at": s.get("last_disconnected_at"),
         "bridge_last_seen_at": s.get("bridge_last_seen_at"),
         "bridge_version": s.get("bridge_version"),
+        "bridge_host": s.get("bridge_host"),
+        "bridge_public_url": _public_bridge_base_url(),
         "agent_id": s.get("agent_id"),
         "recording": bool(s.get("recording")),
     }
@@ -183,6 +191,7 @@ async def create_session(user=Depends(require_auth)):
         "allowed_capabilities": allowed,
         "last_disconnected_at": None,
         "bridge_last_seen_at": None,
+        "bridge_host": None,
         "agent_id": None,
         # Replay-Modus: while recording, every screen-changing action is
         # captured as a step (action + params + a screenshot taken right
@@ -460,6 +469,8 @@ async def get_session_status(
         "allowed_capabilities": sorted(session.get("allowed_capabilities", DEFAULT_ALLOWED_CAPABILITIES)),
         "platform": session.get("platform"),
         "bridge_version": session.get("bridge_version"),
+        "bridge_host": session.get("bridge_host"),
+        "bridge_public_url": _public_bridge_base_url(),
         "action_count": session["action_count"],
     }
 
@@ -713,6 +724,7 @@ async def bridge_websocket(websocket: WebSocket, session_id: str | None = None):
     session["bridge_connected"] = True
     session["bridge_ws"] = websocket
     session["bridge_last_seen_at"] = time.time()
+    session["bridge_host"] = websocket.headers.get("host")
     logger.info(f"Bridge connected for session {session_id} (user {user_id})")
 
     await websocket.send_text(json.dumps({

--- a/orchestrator/app/config.py
+++ b/orchestrator/app/config.py
@@ -172,6 +172,9 @@ class Settings(BaseSettings):
     # Anthropic OAuth (Claude Code public client — no secret needed)
     oauth_anthropic_client_id: str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
     oauth_redirect_base_url: str = "http://localhost:8000"
+    # Public bridge endpoint base for deployments where the browser-facing app
+    # host differs from the hostname desktop bridges must use.
+    bridge_public_url: str = ""
 
     # Public, externally-reachable base URL of THIS platform (e.g. the Cloudflare
     # tunnel domain "https://agents.future-app.de"). Used to build absolute,


### PR DESCRIPTION
## Summary
- record the Host header from the bridge WebSocket handshake on the computer-use session and return it with session metadata
- add BRIDGE_PUBLIC_URL config plumbing for deployments where the bridge uses a dedicated bypass hostname
- update the Computer-Use UI to prefer the connected bridge host, then configured bridge URL, then clearly labeled browser-derived fallback

## Validation
- npm run build (frontend)
- python -m py_compile orchestrator/app/config.py orchestrator/app/api/computer_use.py
- git diff --check

No live bridge/WebSocket hardware e2e was run in this environment.

Fixes #438