### PR TITLE
fix(computer-use): clear stale bridge host on disconnect

### DIFF
--- a/orchestrator/app/api/computer_use.py
+++ b/orchestrator/app/api/computer_use.py
@@ -795,6 +795,7 @@ async def bridge_websocket(websocket: WebSocket, session_id: str | None = None):
         ping_task.cancel()
         session["bridge_connected"] = False
         session["bridge_ws"] = None
+        session["bridge_host"] = None
         session["last_disconnected_at"] = time.time()
         for future in session["pending_results"].values():
             if not future.done():


### PR DESCRIPTION
Follow-up to #454.

Clears `bridge_host` in the WebSocket disconnect `finally` block so waiting sessions do not expose the hostname from a previous bridge connection.

Validation:
- `python -m py_compile orchestrator/app/api/computer_use.py`
- `git diff --check`