### PR TITLE
fix(docker-compose): wire BRIDGE_PUBLIC_URL env passthrough

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,6 +139,9 @@ services:
       OAUTH_REDIRECT_BASE_URL: ${OAUTH_REDIRECT_BASE_URL:-http://localhost:8000}
       # Public base URL (Cloudflare tunnel domain) → absolute, shareable app links.
       PUBLIC_APP_URL: ${PUBLIC_APP_URL:-}
+      # Bridge-facing base URL, when it differs from PUBLIC_APP_URL (e.g. an
+      # identity-aware-proxy bypass hostname dedicated to desktop bridges).
+      BRIDGE_PUBLIC_URL: ${BRIDGE_PUBLIC_URL:-}
       API_SECRET_KEY: ${API_SECRET_KEY:-change-me-in-production}
       CORS_ALLOW_ORIGIN: ${CORS_ALLOW_ORIGIN:-}
       AGENT_IMAGE: ai-employee-agent:latest


### PR DESCRIPTION
## Summary
- #454 introduced `bridge_public_url` in `orchestrator/app/config.py` but never wired it into `docker-compose.yml`'s `environment:` block for the orchestrator service, so the setting was unreachable at runtime in the deployed stack.
- Adds `BRIDGE_PUBLIC_URL: ${BRIDGE_PUBLIC_URL:-}` alongside the existing `PUBLIC_APP_URL` line, matching the established pattern for this repo's env passthrough (same gap class previously fixed for `OAUTH_*_SCOPES` in #422).

Refs #438

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('docker-compose.yml'))"` — valid YAML
- [ ] CI: `docker compose config` check green