### PR TITLE
Show OAuth scopes on integration cards (Phase 2 of #419)

### DIFF
--- a/frontend/src/app/integrations/page.tsx
+++ b/frontend/src/app/integrations/page.tsx
@@ -319,6 +319,32 @@ export default function IntegrationsPage() {
                               Not configured — set OAUTH_{integration.provider.toUpperCase()}_CLIENT_ID in settings
                             </p>
                           )}
+                          {integration.auth_type === "oauth" && integration.scopes?.trim() && (() => {
+                            const scopeList = integration.scopes.split(/\s+/).filter(Boolean);
+                            return (
+                              <details className="mt-1.5 group">
+                                <summary className="cursor-pointer list-none text-[10px] text-muted-foreground/60 hover:text-muted-foreground/90 select-none">
+                                  {integration.connected ? "Erteilte" : "Angeforderte"} Berechtigungen ({scopeList.length})
+                                  <span className="ml-1 text-muted-foreground/40 group-open:hidden">· anzeigen</span>
+                                </summary>
+                                <div className="mt-1.5 flex flex-wrap gap-1">
+                                  {scopeList.map((s) => (
+                                    <span
+                                      key={s}
+                                      className="inline-block rounded bg-foreground/[0.05] border border-foreground/[0.06] px-1.5 py-0.5 text-[10px] font-mono text-muted-foreground/70"
+                                    >
+                                      {s}
+                                    </span>
+                                  ))}
+                                </div>
+                                {!integration.connected && (
+                                  <p className="mt-1 text-[10px] text-muted-foreground/40">
+                                    Anpassbar via OAUTH_{integration.provider.toUpperCase()}_SCOPES.
+                                  </p>
+                                )}
+                              </details>
+                            );
+                          })()}
                         </div>
                       </div>
                       <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- Each OAuth integration card now shows a collapsible scope list.
- Before connecting: **"Angeforderte Berechtigungen (N)"** with a hint that the set is overridable via `OAUTH_<PROVIDER>_SCOPES`.
- Once connected: **"Erteilte Berechtigungen (N)"** — the scopes actually granted (already recorded per integration).

## Why
Phase 1 (#422) made scopes configurable via env and the backend already returns the effective/granted scopes per provider (`GET /integrations`). But an operator still could not *see* what a Connect would grant without reading source — the exact gap #419 point 2 calls out. `Mail.Send` vs `Mail.Read` is a categorically different ask; surfacing it before consent closes the loop.

## Notes
- Read-only display; no backend change needed (the `scopes` field already ships on the integrations payload and the `Integration` type).
- Points 1 (env override) and 3 (record granted scopes) already landed; this completes the ticket.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Open Integrations → an OAuth provider card shows "Angeforderte Berechtigungen (N)"; expanding lists the scope chips
- [ ] Set `OAUTH_MICROSOFT_SCOPES="Mail.Read"` → card reflects the narrowed set
- [ ] Connect a provider → label switches to "Erteilte Berechtigungen" with the granted scopes

Fixes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)