### PR TITLE
AI-account model discovery + connection health (#435)

### DIFF
--- a/frontend/src/app/ai-accounts/view.tsx
+++ b/frontend/src/app/ai-accounts/view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Cpu, Plus, Trash2, Pencil, Check, X, Loader2, Power } from "lucide-react";
+import { Cpu, Plus, Trash2, Pencil, Check, X, Loader2, Power, RefreshCw, Search } from "lucide-react";
 import { Header } from "@/components/layout/header";
 import { cn } from "@/lib/utils";
 import * as api from "@/lib/api";
@@ -52,6 +52,19 @@ const EMPTY_FORM: FormState = {
 
 const EMPTY_MODEL: ModelRow = { name: "", provider_type: "azure-openai", api_endpoint: "" };
 
+// Connection state from the last model-discovery check (#435).
+function accountHealthBadge(a: AIAccount): { label: string; className: string } | null {
+  if (!a.last_status) return null;
+  const map: Record<string, { label: string; className: string }> = {
+    ok: { label: "erreichbar", className: "text-emerald-400" },
+    auth_failed: { label: "Auth fehlgeschlagen", className: "text-amber-400" },
+    unreachable: { label: "nicht erreichbar", className: "text-red-400" },
+    protocol_error: { label: "Protokollfehler", className: "text-red-400" },
+    unsupported: { label: "keine Prüfung möglich", className: "text-muted-foreground/50" },
+  };
+  return map[a.last_status] ?? { label: a.last_status, className: "text-muted-foreground/60" };
+}
+
 function Toast({ type, message, onClose }: { type: "success" | "error"; message: string; onClose: () => void }) {
   useEffect(() => { const t = setTimeout(onClose, 3500); return () => clearTimeout(t); }, [onClose]);
   return (
@@ -77,6 +90,10 @@ export function AIAccountsView({ embedded = false }: { embedded?: boolean }) {
   const [newModel, setNewModel] = useState<ModelRow>(EMPTY_MODEL);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState<number | null>(null);
+  const [discovering, setDiscovering] = useState(false);
+  const [discovered, setDiscovered] = useState<{ id: string; label: string }[] | null>(null);
+  const [discoverMsg, setDiscoverMsg] = useState<{ ok: boolean; text: string } | null>(null);
+  const [recheckId, setRecheckId] = useState<number | null>(null);
 
   const showToast = (type: "success" | "error", message: string) => setToast({ type, message });
 
@@ -92,8 +109,10 @@ export function AIAccountsView({ embedded = false }: { embedded?: boolean }) {
 
   useEffect(() => { load(); }, [load]);
 
-  const openCreate = () => { setForm(EMPTY_FORM); setNewModel(EMPTY_MODEL); setEditingId(null); setShowForm(true); };
+  const resetDiscovery = () => { setDiscovered(null); setDiscoverMsg(null); };
+  const openCreate = () => { setForm(EMPTY_FORM); setNewModel(EMPTY_MODEL); setEditingId(null); resetDiscovery(); setShowForm(true); };
   const openEdit = (a: AIAccount) => {
+    resetDiscovery();
     const extra = a.extra || {};
     setForm({
       name: a.name,
@@ -124,6 +143,61 @@ export function AIAccountsView({ embedded = false }: { embedded?: boolean }) {
   };
   const removeModel = (name: string) =>
     setForm((f) => ({ ...f, models: f.models.filter((m) => m.name !== name) }));
+
+  // #435: ask the provider which models actually exist. The result is the
+  // pick-list, validates typed names, and — via its status — is the connection
+  // state. When editing, the saved key is reused server-side (no re-entry).
+  const runDiscovery = async () => {
+    setDiscovering(true);
+    setDiscoverMsg(null);
+    try {
+      const res = await api.discoverAIAccountModels({
+        provider_type: form.provider_type,
+        api_endpoint: form.api_endpoint.trim() || null,
+        api_key: form.api_key.trim() || null,
+        account_id: editingId ?? undefined,
+      });
+      if (res.status === "ok") {
+        setDiscovered(res.models);
+        setDiscoverMsg({ ok: true, text: `${res.models.length} Modelle gefunden — auswählen zum Übernehmen.` });
+      } else {
+        setDiscovered(null);
+        setDiscoverMsg({ ok: false, text: res.error || res.status });
+      }
+    } catch (e) {
+      setDiscovered(null);
+      setDiscoverMsg({ ok: false, text: e instanceof Error ? e.message : "Abruf fehlgeschlagen" });
+    } finally {
+      setDiscovering(false);
+    }
+  };
+
+  const toggleDiscoveredModel = (id: string) => {
+    setForm((f) => {
+      if (f.models.some((m) => m.name === id)) {
+        return { ...f, models: f.models.filter((m) => m.name !== id) };
+      }
+      return { ...f, models: [...f.models, { name: id, provider_type: f.provider_type, api_endpoint: f.api_endpoint.trim() }] };
+    });
+  };
+
+  const recheck = async (a: AIAccount) => {
+    setRecheckId(a.id);
+    try {
+      const res = await api.discoverAIAccountModels({ account_id: a.id });
+      showToast(
+        res.status === "ok" ? "success" : "error",
+        res.status === "ok"
+          ? `${a.name}: erreichbar (${res.models.length} Modelle)`
+          : `${a.name}: ${res.error || res.status}`,
+      );
+      await load();
+    } catch {
+      showToast("error", "Prüfung fehlgeschlagen");
+    } finally {
+      setRecheckId(null);
+    }
+  };
 
   const save = async () => {
     const isBedrock = form.provider_type === "bedrock";
@@ -268,11 +342,48 @@ export function AIAccountsView({ embedded = false }: { embedded?: boolean }) {
                         {m.provider_type}
                       </span>
                       <span className="text-[10px] text-muted-foreground/50 truncate flex-1">{m.api_endpoint || "— Endpoint fehlt —"}</span>
+                      {discovered && discovered.length > 0 && !discovered.some((d) => d.id === m.name) && (
+                        <span className="shrink-0 rounded-full border border-amber-500/20 bg-amber-500/[0.06] px-2 py-0.5 text-[10px] text-amber-400" title="Nicht in der vom Provider abgerufenen Liste">
+                          nicht in Liste
+                        </span>
+                      )}
                       <button type="button" onClick={() => removeModel(m.name)} className="shrink-0 text-muted-foreground hover:text-red-400">
                         <X className="h-3.5 w-3.5" />
                       </button>
                     </div>
                   ))}
+                </div>
+
+                {/* discovery: fetch the real model list from the provider (#435) */}
+                <div className="mb-2 rounded-lg border border-primary/20 bg-primary/[0.03] p-2.5 space-y-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-[11px] text-muted-foreground/70">
+                      Modelle direkt vom Provider abrufen (prüft zugleich die Verbindung)
+                    </span>
+                    <button type="button" onClick={runDiscovery} disabled={discovering}
+                      className="inline-flex items-center gap-1.5 rounded-lg bg-primary/15 px-3 py-1.5 text-[12px] font-medium text-primary hover:bg-primary/25 disabled:opacity-50 shrink-0">
+                      {discovering ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Search className="h-3.5 w-3.5" />}
+                      Abrufen
+                    </button>
+                  </div>
+                  {discoverMsg && (
+                    <p className={cn("text-[11px]", discoverMsg.ok ? "text-emerald-400" : "text-amber-400")}>
+                      {discoverMsg.text}
+                    </p>
+                  )}
+                  {discovered && discovered.length > 0 && (
+                    <div className="max-h-44 overflow-auto rounded-md border border-foreground/[0.06] bg-background/40 p-1.5 space-y-0.5">
+                      {discovered.map((m) => {
+                        const checked = form.models.some((x) => x.name === m.id);
+                        return (
+                          <label key={m.id} className="flex items-center gap-2 rounded px-2 py-1 text-[12px] hover:bg-foreground/[0.04] cursor-pointer">
+                            <input type="checkbox" checked={checked} onChange={() => toggleDiscoveredModel(m.id)} className="accent-primary" />
+                            <span className="font-mono truncate">{m.label}</span>
+                          </label>
+                        );
+                      })}
+                    </div>
+                  )}
                 </div>
 
                 {/* add-row: name + surface + endpoint */}
@@ -375,11 +486,22 @@ export function AIAccountsView({ embedded = false }: { embedded?: boolean }) {
                     {!a.has_key && a.provider_type !== "ollama" && a.provider_type !== "lm-studio" && (
                       <span className="text-[10px] text-amber-400">kein Key</span>
                     )}
+                    {(() => {
+                      const h = accountHealthBadge(a);
+                      return h ? <span className={cn("text-[10px] font-medium", h.className)}>· {h.label}</span> : null;
+                    })()}
                   </div>
                   <p className="text-[11px] text-muted-foreground/60 mt-0.5 truncate">
                     {(a.models || []).map((m) => m.name).join(", ") || "— keine Modelle —"}
+                    {a.last_status && a.last_status !== "ok" && a.last_error && (
+                      <span className="text-red-400/70"> — {a.last_error}</span>
+                    )}
                   </p>
                 </div>
+                <button onClick={() => recheck(a)} disabled={recheckId === a.id} title="Verbindung prüfen (Modelle abrufen)"
+                  className="rounded-lg p-2 text-muted-foreground hover:text-primary hover:bg-foreground/[0.06]">
+                  {recheckId === a.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                </button>
                 <button onClick={() => toggleActive(a)} title={a.is_active ? "Deaktivieren" : "Aktivieren"}
                   className={cn("rounded-lg p-2 hover:bg-foreground/[0.06]", a.is_active ? "text-emerald-400" : "text-muted-foreground")}>
                   <Power className="h-4 w-4" />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1407,6 +1407,29 @@ export async function deleteAIAccount(id: number): Promise<{ ok: boolean; id: nu
   return fetchJSON(`${getBase()}/ai-accounts/${id}`, { method: "DELETE" });
 }
 
+// Discovered model list + connection state for an AI account (#435). status ∈
+// ok | auth_failed | unreachable | protocol_error | unsupported.
+export interface DiscoveredModels {
+  status: string;
+  models: { id: string; label: string }[];
+  error: string | null;
+}
+
+// Probe a provider's /v1/models (OpenAI-compatible, Anthropic, Google). Pass the
+// typed credentials to check an unsaved account, or an account_id to re-check a
+// saved one with its stored key (which also stamps that account's health state).
+export async function discoverAIAccountModels(payload: {
+  provider_type?: string;
+  api_endpoint?: string | null;
+  api_key?: string | null;
+  account_id?: number;
+}): Promise<DiscoveredModels> {
+  return fetchJSON(`${getBase()}/ai-accounts/discover-models`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
 // ── Second Brains (department-shared knowledge vaults) ──
 export interface SecondBrainPayload {
   name: string;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -57,6 +57,9 @@ export interface AIAccount {
   extra: Record<string, unknown>;
   is_active: boolean;
   has_key: boolean;
+  last_checked_at: string | null;       // last model-discovery check (#435)
+  last_status: string | null;           // ok | auth_failed | unreachable | protocol_error | unsupported
+  last_error: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/orchestrator/app/api/ai_accounts.py
+++ b/orchestrator/app/api/ai_accounts.py
@@ -4,16 +4,18 @@ Admins create/edit/delete accounts; any authenticated user may list them so
 they can attach one to an agent. API keys are Fernet-encrypted and never
 returned in responses.
 """
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Literal
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.encryption import encrypt_token
+from app.core.encryption import decrypt_token, encrypt_token
 from app.db.session import get_db
+from app.services.ai_account_discovery import discover_models
 from app.dependencies import require_auth
 from app.models.ai_account import AIAccount
 from app.models.user import UserRole
@@ -82,6 +84,9 @@ class AIAccountResponse(BaseModel):
     extra: dict
     is_active: bool
     has_key: bool
+    last_checked_at: datetime | None
+    last_status: str | None
+    last_error: str | None
     created_at: datetime
     updated_at: datetime
 
@@ -96,9 +101,43 @@ def _to_response(a: AIAccount) -> AIAccountResponse:
         extra=a.extra or {},
         is_active=a.is_active,
         has_key=bool(a.api_key_encrypted),
+        last_checked_at=a.last_checked_at,
+        last_status=a.last_status,
+        last_error=a.last_error,
         created_at=a.created_at,
         updated_at=a.updated_at,
     )
+
+
+class DiscoverModelsRequest(BaseModel):
+    # Either probe an unsaved account (all three fields), or re-check a saved one
+    # by id (missing fields fall back to the stored values / decrypted key).
+    provider_type: ProviderType | None = None
+    api_endpoint: str | None = None
+    api_key: str | None = None
+    account_id: int | None = None
+
+
+def _short_error(text: str | None) -> str | None:
+    if not text:
+        return None
+    compact = " ".join(str(text).split())
+    return compact[:252] + "..." if len(compact) > 255 else compact
+
+
+async def _fetch_provider_models(url: str, headers: dict, params: dict) -> tuple[int | None, dict | None]:
+    """SSRF-guarded GET used by the discovery service. Raises to signal a blocked
+    host (the service maps any exception to ``unreachable``, so no request leaks)."""
+    from app.api.mcp_servers import _assert_mcp_url_allowed
+
+    await _assert_mcp_url_allowed(url)  # 400 on private/invalid host; caught upstream
+    async with httpx.AsyncClient(timeout=8.0, follow_redirects=False) as client:
+        resp = await client.get(url, headers=headers, params=params)
+    try:
+        body = resp.json()
+    except Exception:
+        body = None
+    return resp.status_code, body
 
 
 @router.get("/", response_model=list[AIAccountResponse])
@@ -185,6 +224,50 @@ async def list_realtime_models(
                 "label": f"{m['label']} · {a.name}",
             })
     return {"models": out}
+
+
+@router.post("/discover-models")
+async def discover_ai_account_models(
+    body: DiscoverModelsRequest,
+    user=Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """Discover the models a provider actually exposes, and record connection health.
+
+    Mirrors ``POST /mcp-servers/probe``: validates a target before anything is
+    committed. Admin only. If ``account_id`` is given the stored key/endpoint are
+    used (no need to re-enter the key) and the account's health columns are
+    stamped with the result, so an unusable account becomes visible in the list.
+    """
+    _require_admin(user)
+
+    provider_type = body.provider_type
+    api_endpoint = body.api_endpoint
+    api_key = body.api_key
+    account: AIAccount | None = None
+
+    if body.account_id is not None:
+        account = await db.get(AIAccount, body.account_id)
+        if not account:
+            raise HTTPException(status_code=404, detail="AI account not found")
+        provider_type = provider_type or account.provider_type
+        if api_endpoint is None:
+            api_endpoint = account.api_endpoint
+        if not api_key and account.api_key_encrypted:
+            api_key = decrypt_token(account.api_key_encrypted)
+
+    if not provider_type:
+        raise HTTPException(status_code=400, detail="provider_type is required")
+
+    result = await discover_models(provider_type, api_endpoint, api_key, _fetch_provider_models)
+
+    if account is not None:
+        account.last_checked_at = datetime.now(timezone.utc)
+        account.last_status = result["status"]
+        account.last_error = _short_error(result.get("error"))
+        await db.commit()
+
+    return result
 
 
 @router.get("/{account_id}", response_model=AIAccountResponse)

--- a/orchestrator/app/main.py
+++ b/orchestrator/app/main.py
@@ -1028,6 +1028,24 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning(f"Could not ensure mcp_servers columns: {e}")
 
+    # AI accounts: model-discovery health columns (#435), mirroring mcp_servers.
+    try:
+        from app.db.session import engine as _eng_ai
+        from sqlalchemy import text as _txt_ai
+        async with _eng_ai.begin() as conn:
+            await conn.execute(_txt_ai(
+                "ALTER TABLE ai_accounts ADD COLUMN IF NOT EXISTS last_checked_at timestamptz"
+            ))
+            await conn.execute(_txt_ai(
+                "ALTER TABLE ai_accounts ADD COLUMN IF NOT EXISTS last_status varchar(32)"
+            ))
+            await conn.execute(_txt_ai(
+                "ALTER TABLE ai_accounts ADD COLUMN IF NOT EXISTS last_error varchar(255)"
+            ))
+        logger.info("ai_accounts health columns ensured")
+    except Exception as e:
+        logger.warning(f"Could not ensure ai_accounts columns: {e}")
+
     # Reflection/"Dreaming": provenance column + run-log table. Ensured on every
     # startup, independent of Alembic (multi-head chain → no new migrations).
     try:

--- a/orchestrator/app/models/ai_account.py
+++ b/orchestrator/app/models/ai_account.py
@@ -29,6 +29,11 @@ class AIAccount(Base):
     # vertex_project, max_tokens, temperature, ...
     extra: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, server_default="true")
+    # Connection health from the last model-discovery check against the provider
+    # (mirrors McpServer). last_status ∈ ok|auth_failed|unreachable|protocol_error|unsupported.
+    last_checked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_status: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    last_error: Mapped[str | None] = mapped_column(String(255), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False
     )

--- a/orchestrator/app/services/ai_account_discovery.py
+++ b/orchestrator/app/services/ai_account_discovery.py
@@ -1,0 +1,172 @@
+"""Model discovery + connection health for AI accounts (#435).
+
+A single request against the provider's model list covers all three gaps the
+issue describes at once: the result *is* the pick-list, a typed model name can be
+validated against it, and whether the request succeeded *is* the connection
+state. ``GET /v1/models`` is the OpenAI-compatible standard (OpenAI, LiteLLM,
+Groq, Together, vLLM, Ollama, LM Studio); Anthropic exposes the same path with a
+different auth header, and Google uses ``/v1beta/models``.
+
+This module is pure and network-free: :func:`discover_models` takes an injected
+``fetch`` coroutine so it is unit-testable without httpx or a live provider. The
+API layer supplies a real, SSRF-guarded fetch.
+"""
+from __future__ import annotations
+
+from typing import Awaitable, Callable, Optional
+
+# Status vocabulary is shared verbatim with the MCP health check so the UI can
+# reuse one renderer. ``unsupported`` is added for providers with no discovery
+# endpoint (e.g. Bedrock), where a manual model list stays the only option.
+AI_ACCOUNT_OK = "ok"
+AI_ACCOUNT_AUTH_FAILED = "auth_failed"
+AI_ACCOUNT_UNREACHABLE = "unreachable"
+AI_ACCOUNT_PROTOCOL_ERROR = "protocol_error"
+AI_ACCOUNT_UNSUPPORTED = "unsupported"
+
+# Providers speaking the OpenAI ``GET {base}/v1/models`` shape with a Bearer key.
+_OPENAI_COMPATIBLE = {"openai", "azure-openai", "ollama", "lm-studio"}
+
+# Fallback base URLs for hosted providers, so discovery works before an operator
+# types a custom endpoint. Self-hosted providers (ollama, lm-studio) have none.
+_DEFAULT_ENDPOINTS = {
+    "openai": "https://api.openai.com",
+    "anthropic": "https://api.anthropic.com",
+    "google": "https://generativelanguage.googleapis.com",
+}
+
+# fetch(url, headers, params) -> (status_code | None, json_body | None)
+# status_code None signals a transport failure (the caller maps it to UNREACHABLE).
+FetchFn = Callable[
+    [str, dict, dict],
+    Awaitable[tuple[Optional[int], Optional[dict]]],
+]
+
+
+def _base_url(provider_type: str, api_endpoint: str | None) -> str:
+    raw = (api_endpoint or _DEFAULT_ENDPOINTS.get(provider_type) or "").strip()
+    return raw.rstrip("/")
+
+
+def build_discovery_request(
+    provider_type: str, api_endpoint: str | None, api_key: str | None
+) -> dict | None:
+    """Build the discovery HTTP request for a provider, or None if unsupported.
+
+    Returns ``{"url", "headers", "params"}``. None means the provider exposes no
+    model-list endpoint we know how to call — the caller reports ``unsupported``
+    and keeps manual model entry.
+    """
+    base = _base_url(provider_type, api_endpoint)
+    if not base:
+        return None
+
+    if provider_type == "anthropic":
+        return {
+            "url": f"{base}/v1/models",
+            "headers": {
+                "x-api-key": api_key or "",
+                "anthropic-version": "2023-06-01",
+            },
+            "params": {},
+        }
+
+    if provider_type == "google":
+        return {
+            "url": f"{base}/v1beta/models",
+            "headers": {},
+            "params": {"key": api_key} if api_key else {},
+        }
+
+    if provider_type in _OPENAI_COMPATIBLE:
+        # If the endpoint already ends in /v1, append only /models (LiteLLM and
+        # some gateways are configured with the /v1 base baked in).
+        path = "/models" if base.endswith("/v1") else "/v1/models"
+        headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+        return {"url": f"{base}{path}", "headers": headers, "params": {}}
+
+    return None
+
+
+def parse_models(payload: dict, provider_type: str) -> list[dict]:
+    """Extract ``[{"id", "label"}]`` from a provider's model-list response.
+
+    Handles the OpenAI ``{"data": [{"id": ...}]}`` shape and Google's
+    ``{"models": [{"name": "models/...", "displayName": ...}]}``. Unknown/empty
+    entries are skipped; ids are de-duplicated preserving order.
+    """
+    out: list[dict] = []
+    seen: set[str] = set()
+
+    if provider_type == "google":
+        items = payload.get("models") or []
+        for m in items:
+            if not isinstance(m, dict):
+                continue
+            raw = (m.get("name") or "").split("/")[-1].strip()
+            if not raw or raw in seen:
+                continue
+            seen.add(raw)
+            out.append({"id": raw, "label": (m.get("displayName") or raw)})
+        return out
+
+    items = payload.get("data") or []
+    for m in items:
+        if not isinstance(m, dict):
+            continue
+        mid = (m.get("id") or "").strip()
+        if not mid or mid in seen:
+            continue
+        seen.add(mid)
+        out.append({"id": mid, "label": mid})
+    return out
+
+
+def classify_http_status(status_code: int) -> str:
+    if status_code == 200:
+        return AI_ACCOUNT_OK
+    if status_code in (401, 403):
+        return AI_ACCOUNT_AUTH_FAILED
+    return AI_ACCOUNT_PROTOCOL_ERROR
+
+
+async def discover_models(
+    provider_type: str,
+    api_endpoint: str | None,
+    api_key: str | None,
+    fetch: FetchFn,
+) -> dict:
+    """Run discovery and return ``{"status", "models", "error"}``.
+
+    Never raises: a transport failure becomes ``unreachable``, an auth rejection
+    ``auth_failed``, any other non-200 ``protocol_error``. The ``fetch`` callable
+    isolates the network so this stays unit-testable.
+    """
+    request = build_discovery_request(provider_type, api_endpoint, api_key)
+    if request is None:
+        return {
+            "status": AI_ACCOUNT_UNSUPPORTED,
+            "models": [],
+            "error": "This provider has no model-discovery endpoint; enter models manually.",
+        }
+
+    try:
+        status_code, body = await fetch(
+            request["url"], request["headers"], request["params"]
+        )
+    except Exception:
+        status_code, body = None, None
+
+    if status_code is None:
+        return {
+            "status": AI_ACCOUNT_UNREACHABLE,
+            "models": [],
+            "error": "Could not reach the provider endpoint.",
+        }
+
+    status = classify_http_status(status_code)
+    if status == AI_ACCOUNT_OK:
+        return {"status": status, "models": parse_models(body or {}, provider_type), "error": None}
+    if status == AI_ACCOUNT_AUTH_FAILED:
+        return {"status": status, "models": [], "error": f"Authentication failed ({status_code})."}
+    return {"status": status, "models": [], "error": f"Provider returned HTTP {status_code}."}

--- a/orchestrator/tests/test_ai_account_discovery.py
+++ b/orchestrator/tests/test_ai_account_discovery.py
@@ -26,7 +26,7 @@ def test_openai_endpoint_already_ending_in_v1_only_gets_models():
 
 def test_openai_default_endpoint_used_when_blank():
     req = build_discovery_request("openai", None, "sk")
-    assert req["url"].startswith("https://api.openai.com")
+    assert req["url"] == "https://api.openai.com/v1/models"
 
 
 def test_selfhosted_without_endpoint_is_unsupported():

--- a/orchestrator/tests/test_ai_account_discovery.py
+++ b/orchestrator/tests/test_ai_account_discovery.py
@@ -1,0 +1,132 @@
+import pytest
+
+from app.services.ai_account_discovery import (
+    AI_ACCOUNT_AUTH_FAILED,
+    AI_ACCOUNT_OK,
+    AI_ACCOUNT_PROTOCOL_ERROR,
+    AI_ACCOUNT_UNREACHABLE,
+    AI_ACCOUNT_UNSUPPORTED,
+    build_discovery_request,
+    classify_http_status,
+    discover_models,
+    parse_models,
+)
+
+
+def test_openai_request_appends_v1_models():
+    req = build_discovery_request("openai", "https://api.openai.com", "sk-x")
+    assert req["url"] == "https://api.openai.com/v1/models"
+    assert req["headers"]["Authorization"] == "Bearer sk-x"
+
+
+def test_openai_endpoint_already_ending_in_v1_only_gets_models():
+    req = build_discovery_request("ollama", "http://litellm.local/v1", "k")
+    assert req["url"] == "http://litellm.local/v1/models"
+
+
+def test_openai_default_endpoint_used_when_blank():
+    req = build_discovery_request("openai", None, "sk")
+    assert req["url"].startswith("https://api.openai.com")
+
+
+def test_selfhosted_without_endpoint_is_unsupported():
+    # ollama/lm-studio have no default host, so a blank endpoint yields no request.
+    assert build_discovery_request("ollama", "", "k") is None
+
+
+def test_anthropic_uses_x_api_key_header():
+    req = build_discovery_request("anthropic", None, "sk-ant")
+    assert req["url"] == "https://api.anthropic.com/v1/models"
+    assert req["headers"]["x-api-key"] == "sk-ant"
+    assert req["headers"]["anthropic-version"]
+
+
+def test_google_uses_key_query_param():
+    req = build_discovery_request("google", None, "AIza")
+    assert req["url"].endswith("/v1beta/models")
+    assert req["params"] == {"key": "AIza"}
+
+
+def test_bedrock_has_no_discovery():
+    assert build_discovery_request("bedrock", "https://x", "k") is None
+
+
+def test_parse_openai_shape_dedupes_and_skips_empty():
+    payload = {"data": [{"id": "gpt-4o"}, {"id": "gpt-4o"}, {"id": ""}, {"nope": 1}]}
+    assert parse_models(payload, "openai") == [{"id": "gpt-4o", "label": "gpt-4o"}]
+
+
+def test_parse_google_strips_models_prefix_and_prefers_display_name():
+    payload = {"models": [{"name": "models/gemini-1.5-pro", "displayName": "Gemini 1.5 Pro"}]}
+    assert parse_models(payload, "google") == [
+        {"id": "gemini-1.5-pro", "label": "Gemini 1.5 Pro"}
+    ]
+
+
+def test_classify_http_status():
+    assert classify_http_status(200) == AI_ACCOUNT_OK
+    assert classify_http_status(401) == AI_ACCOUNT_AUTH_FAILED
+    assert classify_http_status(403) == AI_ACCOUNT_AUTH_FAILED
+    assert classify_http_status(500) == AI_ACCOUNT_PROTOCOL_ERROR
+
+
+@pytest.mark.asyncio
+async def test_discover_ok_returns_models():
+    async def fetch(url, headers, params):
+        return 200, {"data": [{"id": "gpt-4o"}]}
+
+    result = await discover_models("openai", "https://api.openai.com", "sk", fetch)
+    assert result["status"] == AI_ACCOUNT_OK
+    assert result["models"] == [{"id": "gpt-4o", "label": "gpt-4o"}]
+    assert result["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_discover_auth_failed_on_401():
+    async def fetch(url, headers, params):
+        return 401, {"error": {"message": "no key"}}
+
+    result = await discover_models("openai", "https://api.openai.com", "", fetch)
+    assert result["status"] == AI_ACCOUNT_AUTH_FAILED
+    assert result["models"] == []
+
+
+@pytest.mark.asyncio
+async def test_discover_unreachable_when_fetch_signals_none():
+    async def fetch(url, headers, params):
+        return None, None
+
+    result = await discover_models("openai", "https://api.openai.com", "sk", fetch)
+    assert result["status"] == AI_ACCOUNT_UNREACHABLE
+
+
+@pytest.mark.asyncio
+async def test_discover_unreachable_when_fetch_raises():
+    async def fetch(url, headers, params):
+        raise RuntimeError("connection reset")
+
+    result = await discover_models("openai", "https://api.openai.com", "sk", fetch)
+    assert result["status"] == AI_ACCOUNT_UNREACHABLE
+
+
+@pytest.mark.asyncio
+async def test_discover_unsupported_provider_short_circuits():
+    calls = []
+
+    async def fetch(url, headers, params):
+        calls.append(url)
+        return 200, {}
+
+    result = await discover_models("bedrock", "https://x", "k", fetch)
+    assert result["status"] == AI_ACCOUNT_UNSUPPORTED
+    assert result["models"] == []
+    assert calls == []  # no network attempt for an unsupported provider
+
+
+@pytest.mark.asyncio
+async def test_discover_protocol_error_on_500():
+    async def fetch(url, headers, params):
+        return 500, None
+
+    result = await discover_models("openai", "https://api.openai.com", "sk", fetch)
+    assert result["status"] == AI_ACCOUNT_PROTOCOL_ERROR


### PR DESCRIPTION
## Summary
Closes the three-in-one gap #435 describes: an AI account was never verified against its provider, so models were typed by hand, typos were stored silently, and a bad key/endpoint only surfaced later as an agent runtime failure.

- **`POST /ai-accounts/discover-models`** (admin, SSRF-guarded) probes the provider's model list. Mirrors `POST /mcp-servers/probe` — validates a target before anything is saved, and can re-check a saved account by `account_id` using its stored key (no re-entry). Supports:
  - OpenAI-compatible `GET /v1/models` (OpenAI, Azure OpenAI, Ollama, LM Studio, LiteLLM gateways)
  - Anthropic (`x-api-key` + `anthropic-version`)
  - Google (`/v1beta/models?key=`)
  - providers without a list endpoint (Bedrock, Brave) → `unsupported`, manual entry kept
- **Pure, unit-tested service** `app/services/ai_account_discovery.py` (16 tests, no network) builds the request, parses the response, and classifies status as `ok | auth_failed | unreachable | protocol_error | unsupported` — the same vocabulary as the MCP health check (#425/#432), so the result *is* the connection state.
- **Health columns** `last_checked_at / last_status / last_error` on `AIAccount`, copied verbatim from the `McpServer` shape and ensured via `ALTER TABLE … ADD COLUMN IF NOT EXISTS` in `main.py` (the repo's non-Alembic startup pattern, as the issue instructs). Exposed in `GET /ai-accounts`.
- **UI**: a "Modelle abrufen" button turns the free-text model field into a checkbox pick-list from the discovered models; a manually entered model not in the discovered list is *flagged* rather than rejected (a gateway may expose one the list omits). Each account card shows its connection state with a re-check button.

## Why
Same failure mode just fixed for MCP servers: configuration was blind on all three counts (type from memory, no validity feedback, no health), deferring every mistake to an agent run — the worst place to find it.

## Out of scope (per issue)
Pricing/quota info (LiteLLM `/model/info`). This is only *which models exist, whether a chosen one is valid, and whether the account works*.

## Test plan
- [x] `python -m pytest tests/test_ai_account_discovery.py` → 16 passed
- [x] `python -m py_compile` on all touched backend modules
- [x] `npx tsc --noEmit` clean
- [ ] Create an OpenAI/LiteLLM account → "Modelle abrufen" lists real models as checkboxes; select some → saved
- [ ] Wrong key → card shows "Auth fehlgeschlagen"; wrong host → "nicht erreichbar"
- [ ] Bedrock → "keine Prüfung möglich", manual entry still works
- [ ] Re-check button on a saved account stamps `last_status`

Fixes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)