### PR TITLE
feat: warn when frontend bundle is stale vs backend version (#406)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -252,6 +252,7 @@ services:
       args:
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8000}
         NEXT_PUBLIC_WS_URL: ${NEXT_PUBLIC_WS_URL:-ws://localhost:8000}
+        APP_VERSION: ${APP_VERSION:-dev}
     container_name: ai-employee-frontend
     ports:
       # Bind to loopback only — external access goes via reverse proxy.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -24,6 +24,10 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # Leaving them empty lets the runtime config (config.ts) dynamically
 # resolve the API URL from window.location.hostname, so the app
 # works from localhost, LAN IP, VPN, etc. without rebuilding.
+# The build-time app version is baked in so the running UI can detect
+# when the backend has been updated but the frontend bundle is stale.
+ARG APP_VERSION=dev
+ENV NEXT_PUBLIC_APP_VERSION=$APP_VERSION
 RUN npm run build
 
 # ---- Production ----

--- a/frontend/src/components/layout/update-banner.tsx
+++ b/frontend/src/components/layout/update-banner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { ArrowUpCircle, X, GitCommit, Clock, Loader2, ChevronRight } from "lucide-react";
+import { ArrowUpCircle, X, GitCommit, Clock, Loader2, ChevronRight, AlertTriangle } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import * as Dialog from "@radix-ui/react-dialog";
 import { getBase } from "@/lib/config";
@@ -21,9 +21,17 @@ interface Commit {
 
 const CHECK_INTERVAL = 30 * 60 * 1000; // 30 minutes
 
+// The frontend bundle version is baked in at build time (see Dockerfile
+// ARG APP_VERSION). Comparing it to the backend's live version lets us warn
+// when the served bundle is stale — e.g. update.sh rebuilt the backend but the
+// browser is still holding an old cached bundle, or the frontend image lagged.
+const BUNDLE_VERSION = process.env.NEXT_PUBLIC_APP_VERSION || "";
+const SEMVER = /^\d+\.\d+\.\d+/;
+
 export function UpdateBanner() {
   const [version, setVersion] = useState<VersionInfo | null>(null);
   const [dismissed, setDismissed] = useState(false);
+  const [mismatchDismissed, setMismatchDismissed] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [commits, setCommits] = useState<Commit[]>([]);
   const [changelogMd, setChangelogMd] = useState<string | null>(null);
@@ -77,6 +85,15 @@ export function UpdateBanner() {
   };
 
   const show = version?.update_available && !dismissed;
+
+  // Only warn when BOTH sides report real semvers that actually differ — never
+  // on "dev"/unset, so local builds don't nag.
+  const backendVersion = version?.current ?? "";
+  const versionMismatch =
+    SEMVER.test(BUNDLE_VERSION) &&
+    SEMVER.test(backendVersion) &&
+    BUNDLE_VERSION !== backendVersion;
+  const showMismatch = versionMismatch && !mismatchDismissed;
 
   function formatDate(dateStr: string) {
     if (!dateStr) return "";
@@ -134,6 +151,37 @@ export function UpdateBanner() {
                 setDismissed(true);
               }}
               className="shrink-0 rounded-lg p-1 text-blue-400/50 hover:text-blue-300 hover:bg-blue-500/10 transition-colors"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {showMismatch && (
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 10 }}
+            className="mx-3 mb-2 flex items-center gap-2 rounded-xl border border-amber-500/20 bg-amber-500/10 px-3 py-2 cursor-pointer hover:bg-amber-500/15 transition-colors"
+            onClick={() => window.location.reload()}
+          >
+            <AlertTriangle className="h-4 w-4 shrink-0 text-amber-400" />
+            <div className="flex-1 min-w-0">
+              <p className="text-[11px] font-medium text-amber-300">
+                Veraltete Oberfläche — neu laden
+              </p>
+              <p className="text-[10px] text-amber-400/70 truncate">
+                Frontend {BUNDLE_VERSION} · Backend {backendVersion}
+              </p>
+            </div>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setMismatchDismissed(true);
+              }}
+              className="shrink-0 rounded-lg p-1 text-amber-400/50 hover:text-amber-300 hover:bg-amber-500/10 transition-colors"
             >
               <X className="h-3 w-3" />
             </button>

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -52,6 +52,9 @@ fi
 
 # ── 4. Rebuild + restart the compose services (orchestrator, frontend, ...) ────
 info "Rebuilding and restarting the stack..."
+# Bake the current VERSION into the frontend bundle so the running UI can warn
+# when the served bundle is older than the backend (see update-banner.tsx).
+export APP_VERSION="$(cat VERSION 2>/dev/null || echo dev)"
 docker compose up -d --build
 ok "Stack restarted"
 


### PR DESCRIPTION
## Summary
Completes the final open point of #406 — a frontend↔backend version handshake so the running UI can tell the user when its bundle has fallen behind the backend.

- **Bundle version baked at build:** `frontend/Dockerfile` builder stage adds `ARG APP_VERSION=dev` + `ENV NEXT_PUBLIC_APP_VERSION=$APP_VERSION` before `npm run build`.
- **Wired through compose + updater:** `docker-compose.yml` frontend `args` gains `APP_VERSION: ${APP_VERSION:-dev}`; `scripts/update.sh` exports `APP_VERSION` from the repo `VERSION` file before the compose build.
- **Amber "reload" banner:** `update-banner.tsx` compares `NEXT_PUBLIC_APP_VERSION` (baked bundle) to the backend's live `version.current`. When both are real semvers and differ, it shows a dismissible amber banner that reloads on click. Guarded against `dev`/unset so local builds never nag.

Points 1 (banner → update.sh) and 2 (`/version/` check) were already shipped; this adds point 3.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `git diff --check` clean
- [ ] After deploy: rebuild with an older `VERSION` baked than the backend → amber banner appears; matching versions → no banner; `dev`/unset → no banner

Fixes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)