### PR TITLE
feat: client-side OAuth for OAuth-protected MCP servers

### DIFF
--- a/frontend/src/app/integrations/page.tsx
+++ b/frontend/src/app/integrations/page.tsx
@@ -6,6 +6,7 @@ import {
   AlertCircle, Loader2, Unplug, ExternalLink, RefreshCw,
   Plus, Trash2, ChevronRight, Wrench, Globe, Power,
   Eye, EyeOff, Save, Users, Copy, Info, Pencil, KeyRound, PlugZap,
+  ShieldCheck, LogIn,
 } from "lucide-react";
 import { Github } from "@/components/icons/github";
 import { Header } from "@/components/layout/header";
@@ -463,6 +464,7 @@ function McpServersSection({ onToast }: { onToast: (t: { type: "success" | "erro
   const [deleting, setDeleting] = useState<number | null>(null);
   const [agentHealth, setAgentHealth] = useState<McpAgentHealth | null>(null);
   const [checkingAgents, setCheckingAgents] = useState(false);
+  const [oauthBusy, setOauthBusy] = useState<number | null>(null);
 
   const editingServer = editingId != null ? servers.find((s) => s.id === editingId) ?? null : null;
 
@@ -480,6 +482,51 @@ function McpServersSection({ onToast }: { onToast: (t: { type: "success" | "erro
   useEffect(() => {
     loadServers();
   }, []);
+
+  // Surface the result of the OAuth browser round-trip (#426): the callback
+  // redirects back to /integrations?mcp_oauth=connected|error, then we clean the URL.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const result = params.get("mcp_oauth");
+    if (!result) return;
+    const name = params.get("server");
+    if (result === "connected") {
+      onToast({ type: "success", message: `OAuth verbunden${name ? `: ${name}` : ""}` });
+      loadServers();
+    } else {
+      onToast({ type: "error", message: `OAuth fehlgeschlagen: ${params.get("detail") || "unbekannt"}` });
+    }
+    const url = new URL(window.location.href);
+    ["mcp_oauth", "server", "detail"].forEach((k) => url.searchParams.delete(k));
+    window.history.replaceState({}, "", url.toString());
+  }, []);  // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Discover OAuth config (once) then start the authorization_code flow, sending
+  // the browser to the authorization server. Returns via the callback → /integrations.
+  const handleOAuthConnect = async (server: McpServerInfo) => {
+    setOauthBusy(server.id);
+    try {
+      if (!server.oauth_enabled || !server.oauth_client_id) {
+        const disc = await api.discoverMcpOAuth(server.id);
+        if (disc.needs_client_id) {
+          const clientId = window.prompt(
+            "Dieser Authorization-Server bietet keine dynamische Registrierung. " +
+            "Bitte die vorab registrierte client_id eingeben:",
+          );
+          if (!clientId?.trim()) {
+            setOauthBusy(null);
+            return;
+          }
+          await api.discoverMcpOAuth(server.id, clientId.trim());
+        }
+      }
+      const { authorization_url } = await api.connectMcpOAuth(server.id);
+      window.location.href = authorization_url;
+    } catch (e) {
+      onToast({ type: "error", message: e instanceof Error ? e.message : "OAuth-Start fehlgeschlagen" });
+      setOauthBusy(null);
+    }
+  };
 
   const parseHeaderLines = (text: string): Record<string, string> => {
     const out: Record<string, string> = {};
@@ -868,6 +915,22 @@ function McpServersSection({ onToast }: { onToast: (t: { type: "success" | "erro
                           Token
                         </span>
                       )}
+                      {server.oauth_enabled && (
+                        <span
+                          title={server.oauth_connected
+                            ? "OAuth verbunden — Access-Token wird serverseitig automatisch erneuert"
+                            : "OAuth konfiguriert, aber noch nicht verbunden — auf „Verbinden“ klicken"}
+                          className={cn(
+                            "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium",
+                            server.oauth_connected
+                              ? "bg-emerald-500/10 text-emerald-400"
+                              : "bg-amber-500/10 text-amber-400"
+                          )}
+                        >
+                          <ShieldCheck className="h-2.5 w-2.5" />
+                          {server.oauth_connected ? "OAuth" : "OAuth offen"}
+                        </span>
+                      )}
                       <span className="inline-flex items-center gap-1 rounded-full bg-violet-500/10 px-2 py-0.5 text-[10px] font-medium text-violet-400">
                         <Wrench className="h-2.5 w-2.5" />
                         {toolCount} Tool{toolCount !== 1 && "s"} entdeckt
@@ -911,6 +974,25 @@ function McpServersSection({ onToast }: { onToast: (t: { type: "success" | "erro
                       title={server.enabled ? "Deaktivieren" : "Aktivieren"}
                     >
                       <Power className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      onClick={() => handleOAuthConnect(server)}
+                      disabled={oauthBusy === server.id}
+                      className={cn(
+                        "flex h-7 w-7 items-center justify-center rounded-lg transition-colors",
+                        server.oauth_connected
+                          ? "text-emerald-400 hover:bg-emerald-500/15"
+                          : "text-muted-foreground/40 hover:text-foreground hover:bg-foreground/[0.06]"
+                      )}
+                      title={server.oauth_connected
+                        ? "OAuth erneut verbinden (neuer Login)"
+                        : "Mit OAuth verbinden (Login im Browser)"}
+                    >
+                      {oauthBusy === server.id ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <LogIn className="h-3.5 w-3.5" />
+                      )}
                     </button>
                     <button
                       onClick={() => openEdit(server)}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1171,6 +1171,12 @@ export interface McpServerInfo {
   last_checked_at: string | null;
   last_status: "ok" | "auth_failed" | "unreachable" | "protocol_error" | null;
   last_error: string | null;
+  // Client-side OAuth (#426)
+  oauth_enabled?: boolean;
+  oauth_client_id?: string | null;
+  oauth_connected?: boolean;  // a refresh token is stored → the flow completed
+  oauth_scope?: string | null;
+  oauth_expires_at?: string | null;
 }
 
 export interface McpTool {
@@ -1278,6 +1284,34 @@ export async function callMcpTool(
     method: "POST",
     body: JSON.stringify({ name, arguments: args }),
   });
+}
+
+// Client-side OAuth for OAuth-protected MCP servers (#426).
+export interface McpOAuthDiscovery {
+  oauth_enabled: boolean;
+  authorization_endpoint: string | null;
+  token_endpoint: string | null;
+  registration_endpoint: string | null;
+  scope: string | null;
+  resource: string | null;
+  client_id: string | null;
+  dynamically_registered: boolean;
+  needs_client_id: boolean;
+  redirect_uri: string;
+}
+
+// Admin: discover a server's OAuth config (RFC 9728 → RFC 8414) and register a
+// client via DCR when available. Pass a client_id for servers without DCR.
+export async function discoverMcpOAuth(id: number, clientId?: string): Promise<McpOAuthDiscovery> {
+  return fetchJSON(`${getBase()}/mcp-servers/${id}/oauth/discover`, {
+    method: "POST",
+    body: JSON.stringify(clientId ? { client_id: clientId } : {}),
+  });
+}
+
+// Admin: start authorization_code + PKCE — returns the URL to open in the browser.
+export async function connectMcpOAuth(id: number): Promise<{ authorization_url: string }> {
+  return fetchJSON(`${getBase()}/mcp-servers/${id}/oauth/connect`);
 }
 
 // Admin: User Management

--- a/orchestrator/app/api/mcp_servers.py
+++ b/orchestrator/app/api/mcp_servers.py
@@ -4,22 +4,25 @@ import asyncio
 import json as json_mod
 import os
 import re
+import secrets
 import socket
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from ipaddress import ip_address
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import quote, urlparse, urlunparse
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import RedirectResponse
 from pydantic import BaseModel, field_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_db
-from app.dependencies import require_admin, require_auth
+from app.dependencies import get_redis_service, require_admin, require_auth
 from app.models.audit_log import AuditEventType, AuditLog
 from app.models.mcp_server import McpServer
+from app.services.redis_service import RedisService
 
 router = APIRouter(prefix="/mcp-servers", tags=["mcp-servers"])
 
@@ -240,6 +243,14 @@ def _serialize_mcp_server(server: McpServer) -> dict:
         "last_checked_at": server.last_checked_at.isoformat() if server.last_checked_at else None,
         "last_status": server.last_status,
         "last_error": server.last_error,
+        "oauth_enabled": bool(getattr(server, "oauth_enabled", False)),
+        "oauth_client_id": getattr(server, "oauth_client_id", None),
+        "oauth_connected": bool(getattr(server, "oauth_refresh_token_encrypted", None)),
+        "oauth_scope": getattr(server, "oauth_scope", None),
+        "oauth_expires_at": (
+            server.oauth_access_expires_at.isoformat()
+            if getattr(server, "oauth_access_expires_at", None) else None
+        ),
     }
 
 
@@ -759,3 +770,265 @@ async def call_mcp_tool(
                        {"server_id": server.id, "tool": body.name})
 
     return {"server_id": server.id, "tool": body.name, "result": rpc, "is_error": is_error}
+
+
+# ===========================================================================
+# Client-side OAuth for OAuth-protected MCP servers (#426)
+# ===========================================================================
+#
+# The orchestrator drives authorization_code + PKCE against the MCP server's own
+# authorization server, stores the refresh token, and keeps a fresh access token
+# in `auth_token_encrypted` (which already flows to agents). The flow runs in the
+# operator's browser against the orchestrator's public URL — never inside an agent
+# container, whose localhost callback would never arrive.
+
+_STATE_PREFIX = "mcp_oauth_client:state:"
+_STATE_TTL_SECONDS = 600  # 10 min to complete the browser round-trip
+
+
+def _callback_redirect_uri() -> str:
+    """Public redirect URI the authorization server sends the browser back to."""
+    from app.core import mcp_oauth as oas
+    return f"{oas.issuer()}/api/v1/mcp-servers/oauth/callback"
+
+
+def _integrations_redirect(status: str, **params) -> RedirectResponse:
+    """Bounce the browser back to the integrations page with a result marker."""
+    from app.core import mcp_oauth as oas
+    query = "&".join([f"mcp_oauth={quote(status)}"] + [f"{k}={quote(str(v))}" for k, v in params.items()])
+    return RedirectResponse(f"{oas.issuer()}/integrations?{query}", status_code=302)
+
+
+async def _oauth_fetch_json(url: str) -> dict:
+    """SSRF-guarded GET of an OAuth discovery document (PRM / AS metadata)."""
+    await _assert_mcp_url_allowed(url)
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.get(url, headers={"Accept": "application/json"}, follow_redirects=True)
+    if resp.status_code != 200:
+        raise HTTPException(status_code=400, detail=f"Discovery document {url} returned {resp.status_code}")
+    try:
+        data = resp.json()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"Discovery document {url} was not JSON") from exc
+    if not isinstance(data, dict):
+        raise HTTPException(status_code=400, detail=f"Discovery document {url} was not a JSON object")
+    return data
+
+
+async def _oauth_probe_challenge(url: str) -> str | None:
+    """Send an unauthenticated MCP initialize and return the WWW-Authenticate header.
+
+    An OAuth-protected server answers with 401 + a Bearer challenge carrying the
+    RFC 9728 ``resource_metadata`` pointer. Returns None when the server does not
+    challenge (i.e. it is not OAuth-protected on this path).
+    """
+    safe_url = _validate_mcp_url(url)
+    await _assert_discovery_host_allowed(safe_url)
+    headers = _build_headers(None, None)
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        try:
+            resp = await client.post(safe_url, headers=headers, json={  # codeql[py/full-ssrf]: URL validated by _validate_mcp_url.
+                "jsonrpc": "2.0", "id": 1, "method": "initialize",
+                "params": {"protocolVersion": "2024-11-05", "capabilities": {},
+                           "clientInfo": {"name": "ai-employee-orchestrator", "version": "1.0.0"}},
+            })
+        except httpx.RequestError as exc:
+            raise HTTPException(status_code=400, detail=f"Could not reach MCP server: {_short_error(str(exc))}") from exc
+    return resp.headers.get("www-authenticate")
+
+
+async def _register_oauth_client(registration_endpoint: str, redirect_uri: str) -> dict:
+    """RFC 7591 Dynamic Client Registration against the MCP authorization server."""
+    from app.services import mcp_oauth_client as oc
+    await _assert_mcp_url_allowed(registration_endpoint)
+    body = oc.build_registration_request(redirect_uri=redirect_uri, client_name="AI-Employee")
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.post(registration_endpoint, json=body,
+                                 headers={"Accept": "application/json"}, follow_redirects=False)
+    if resp.status_code not in (200, 201):
+        raise HTTPException(status_code=400,
+                            detail=f"Dynamic client registration failed ({resp.status_code})")
+    try:
+        data = resp.json()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Registration response was not JSON") from exc
+    if not data.get("client_id"):
+        raise HTTPException(status_code=400, detail="Registration response had no client_id")
+    return data
+
+
+class OAuthDiscoverRequest(BaseModel):
+    # Optional manual client_id for authorization servers that do not offer DCR.
+    client_id: str | None = None
+
+
+@router.post("/{server_id}/oauth/discover")
+async def oauth_discover(
+    server_id: int, body: OAuthDiscoverRequest | None = None,
+    user=Depends(require_admin), db: AsyncSession = Depends(get_db),
+):
+    """Discover a server's OAuth configuration (RFC 9728 → RFC 8414) and store it.
+
+    Registers the orchestrator as an OAuth client via DCR when the AS offers it;
+    otherwise a ``client_id`` must be supplied (some Entra/Okta setups pre-register
+    the client). Does not obtain any token — that happens in the Connect flow.
+    """
+    from app.services import mcp_oauth_client as oc
+    from app.core.encryption import encrypt_token
+
+    server = await db.get(McpServer, server_id)
+    if not server:
+        raise HTTPException(status_code=404, detail="MCP server not found")
+
+    www_auth = await _oauth_probe_challenge(server.url)
+    prm_url = oc.resource_metadata_url(www_auth, server.url)
+    if not prm_url:
+        raise HTTPException(status_code=400,
+                            detail="Server did not advertise OAuth (no WWW-Authenticate resource_metadata)")
+
+    prm = await _oauth_fetch_json(prm_url)
+    issuer = oc.pick_authorization_server(prm)
+    if not issuer:
+        raise HTTPException(status_code=400, detail="Protected-resource metadata lists no authorization server")
+
+    as_meta = None
+    for candidate in oc.as_metadata_urls(issuer):
+        try:
+            as_meta = await _oauth_fetch_json(candidate)
+            break
+        except HTTPException:
+            continue
+    if not as_meta:
+        raise HTTPException(status_code=400, detail="Could not fetch authorization-server metadata")
+
+    endpoints = oc.select_endpoints(as_meta)
+    if not endpoints["authorization_endpoint"] or not endpoints["token_endpoint"]:
+        raise HTTPException(status_code=400, detail="Authorization server metadata is missing endpoints")
+
+    server.oauth_enabled = True
+    server.oauth_authorization_endpoint = endpoints["authorization_endpoint"]
+    server.oauth_token_endpoint = endpoints["token_endpoint"]
+    server.oauth_registration_endpoint = endpoints["registration_endpoint"]
+    server.oauth_scope = oc.default_scope(prm, as_meta) or server.oauth_scope
+    server.oauth_resource = prm.get("resource") or server.oauth_resource
+
+    registered = False
+    if body and body.client_id:
+        server.oauth_client_id = body.client_id.strip()
+        server.oauth_client_secret_encrypted = None
+    elif not server.oauth_client_id and endpoints["registration_endpoint"]:
+        reg = await _register_oauth_client(endpoints["registration_endpoint"], _callback_redirect_uri())
+        server.oauth_client_id = reg["client_id"]
+        secret = reg.get("client_secret")
+        server.oauth_client_secret_encrypted = encrypt_token(secret) if secret else None
+        registered = True
+
+    await db.commit()
+    await db.refresh(server)
+    return {
+        "oauth_enabled": True,
+        "authorization_endpoint": server.oauth_authorization_endpoint,
+        "token_endpoint": server.oauth_token_endpoint,
+        "registration_endpoint": server.oauth_registration_endpoint,
+        "scope": server.oauth_scope,
+        "resource": server.oauth_resource,
+        "client_id": server.oauth_client_id,
+        "dynamically_registered": registered,
+        "needs_client_id": not server.oauth_client_id,
+        "redirect_uri": _callback_redirect_uri(),
+    }
+
+
+@router.get("/{server_id}/oauth/connect")
+async def oauth_connect(
+    server_id: int, user=Depends(require_admin),
+    db: AsyncSession = Depends(get_db), redis: RedisService = Depends(get_redis_service),
+):
+    """Begin authorization_code + PKCE: return the URL to open in the browser."""
+    from app.services import mcp_oauth_client as oc
+
+    server = await db.get(McpServer, server_id)
+    if not server:
+        raise HTTPException(status_code=404, detail="MCP server not found")
+    if not server.oauth_enabled or not server.oauth_authorization_endpoint:
+        raise HTTPException(status_code=400, detail="Run OAuth discovery for this server first")
+    if not server.oauth_client_id:
+        raise HTTPException(status_code=400, detail="No client_id — provide one or use a server that supports DCR")
+
+    verifier, challenge = oc.gen_pkce()
+    state = secrets.token_urlsafe(32)
+    await redis.client.setex(_STATE_PREFIX + state, _STATE_TTL_SECONDS, json_mod.dumps({
+        "server_id": server.id, "code_verifier": verifier, "user_id": str(user.id),
+    }))
+    auth_url = oc.build_authorization_url(
+        authorization_endpoint=server.oauth_authorization_endpoint,
+        client_id=server.oauth_client_id,
+        redirect_uri=_callback_redirect_uri(),
+        state=state,
+        code_challenge=challenge,
+        scope=server.oauth_scope or "",
+        resource=server.oauth_resource or None,
+    )
+    return {"authorization_url": auth_url}
+
+
+@router.get("/oauth/callback")
+async def oauth_callback(
+    request: Request, db: AsyncSession = Depends(get_db),
+    redis: RedisService = Depends(get_redis_service),
+):
+    """Authorization-server redirect target: exchange the code for tokens.
+
+    Public route (the browser arrives here after the IdP redirect); the CSRF and
+    server binding come from the single-use ``state`` stored in Redis by
+    :func:`oauth_connect`, not from an auth dependency.
+    """
+    from app.services import mcp_oauth_client as oc
+    from app.services.mcp_oauth_refresh import (
+        OAuthTokenError, apply_token_to_server, perform_token_request,
+    )
+    from app.core.encryption import decrypt_token
+
+    q = request.query_params
+    if q.get("error"):
+        return _integrations_redirect("error", detail=q.get("error", "authorization_failed"))
+
+    code = q.get("code", "")
+    state = q.get("state", "")
+    if not code or not state:
+        return _integrations_redirect("error", detail="missing code or state")
+
+    key = _STATE_PREFIX + state
+    raw = await redis.client.get(key)
+    if raw is None:
+        return _integrations_redirect("error", detail="invalid or expired state")
+    await redis.client.delete(key)  # single-use
+    st = json_mod.loads(raw)
+
+    server = await db.get(McpServer, st["server_id"])
+    if not server or not server.oauth_token_endpoint or not server.oauth_client_id:
+        return _integrations_redirect("error", detail="server not found or not configured")
+
+    client_secret = (
+        decrypt_token(server.oauth_client_secret_encrypted)
+        if server.oauth_client_secret_encrypted else None
+    )
+    data = oc.build_token_exchange_data(
+        code=code,
+        code_verifier=st["code_verifier"],
+        client_id=server.oauth_client_id,
+        redirect_uri=_callback_redirect_uri(),
+        client_secret=client_secret,
+        resource=server.oauth_resource or None,
+    )
+    try:
+        parsed = await perform_token_request(server.oauth_token_endpoint, data)
+    except OAuthTokenError as exc:
+        _mark_health(server, MCP_HEALTH_AUTH_FAILED, str(exc))
+        await db.commit()
+        return _integrations_redirect("error", server=server.name, detail=_short_error(str(exc)) or "token exchange failed")
+
+    apply_token_to_server(server, parsed)
+    _mark_health(server, MCP_HEALTH_OK)
+    await db.commit()
+    return _integrations_redirect("connected", server=server.name)

--- a/orchestrator/app/core/agent_manager.py
+++ b/orchestrator/app/core/agent_manager.py
@@ -805,6 +805,18 @@ class AgentManager:
             except Exception as e:
                 logger.warning(f"MCP role filter failed for agent {agent_id}: {e}")
 
+        # OAuth-protected servers (#426): mint/refresh a fresh access token before
+        # handing it to the agent, so a short-lived token never arrives already
+        # expired. Best-effort — a refresh failure leaves the (possibly stale)
+        # token in place rather than blocking agent startup.
+        try:
+            from app.services.mcp_oauth_refresh import refresh_if_needed
+            for s in servers:
+                if getattr(s, "oauth_enabled", False):
+                    await refresh_if_needed(s, self.db)
+        except Exception as e:
+            logger.warning(f"MCP OAuth token refresh pass failed: {e}")
+
         mcp_map = {s.name: s.url for s in servers}
         # Bearer tokens passed alongside so the agent can authenticate per server.
         auth_map = {

--- a/orchestrator/app/main.py
+++ b/orchestrator/app/main.py
@@ -1024,7 +1024,38 @@ async def lifespan(app: FastAPI):
             await conn.execute(_txt_mh(
                 "ALTER TABLE mcp_servers ADD COLUMN IF NOT EXISTS last_error varchar(255)"
             ))
-        logger.info("mcp_servers auth/header + health columns ensured")
+            # Client-side OAuth columns (#426).
+            await conn.execute(_txt_mh(
+                "ALTER TABLE mcp_servers ADD COLUMN IF NOT EXISTS oauth_enabled boolean DEFAULT false"
+            ))
+            await conn.execute(_txt_mh(
+                "ALTER TABLE mcp_servers ADD COLUMN IF NOT EXISTS oauth_authorization_endpoint text"
+            ))
+            await conn.execute(_txt_mh(
+                "ALTER TABLE mcp_servers ADD COLUMN IF NOT EXISTS oauth_token_endpoint text"
+            ))
+            await conn.execute(_txt_mh(
+                "ALTER TABLE mcp_servers ADD COLUMN IF NOT EXISTS oauth_registration_endpoint text"
+            ))
+            await conn.execute(_txt_mh(
+                "ALTER TABLE mcp_servers ADD COLUMN IF NOT EXISTS oauth_scope text"
+            ))
+            await conn.execute(_txt_mh(
+                "ALTER TABLE mcp_servers ADD COLUMN IF NOT EXISTS oauth_resource text"
+            ))
+            await conn.execute(_txt_mh(
+                "ALTER TABLE mcp_servers ADD COLUMN IF NOT EXISTS oauth_client_id varchar"
+            ))
+            await conn.execute(_txt_mh(
+                "ALTER TABLE mcp_servers ADD COLUMN IF NOT EXISTS oauth_client_secret_encrypted text"
+            ))
+            await conn.execute(_txt_mh(
+                "ALTER TABLE mcp_servers ADD COLUMN IF NOT EXISTS oauth_refresh_token_encrypted text"
+            ))
+            await conn.execute(_txt_mh(
+                "ALTER TABLE mcp_servers ADD COLUMN IF NOT EXISTS oauth_access_expires_at timestamptz"
+            ))
+        logger.info("mcp_servers auth/header + health + oauth columns ensured")
     except Exception as e:
         logger.warning(f"Could not ensure mcp_servers columns: {e}")
 

--- a/orchestrator/app/models/mcp_server.py
+++ b/orchestrator/app/models/mcp_server.py
@@ -26,3 +26,22 @@ class McpServer(Base, TimestampMixin):
     last_checked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     last_status: Mapped[str | None] = mapped_column(String(32), nullable=True)
     last_error: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    # --- Client-side OAuth (#426) -------------------------------------------
+    # Set once the server is discovered to be OAuth-protected (RFC 9728 → 8414).
+    # The live access token lives in `auth_token_encrypted` above so it flows to
+    # agents unchanged; these columns hold what's needed to keep it fresh.
+    oauth_enabled: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
+    oauth_authorization_endpoint: Mapped[str | None] = mapped_column(Text, nullable=True)
+    oauth_token_endpoint: Mapped[str | None] = mapped_column(Text, nullable=True)
+    oauth_registration_endpoint: Mapped[str | None] = mapped_column(Text, nullable=True)
+    oauth_scope: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # RFC 8707 resource indicator — the protected resource id from the PRM doc.
+    oauth_resource: Mapped[str | None] = mapped_column(Text, nullable=True)
+    oauth_client_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    # Fernet-encrypted; only set for confidential (non-PKCE-public) DCR clients.
+    oauth_client_secret_encrypted: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Fernet-encrypted refresh token (rotated on use).
+    oauth_refresh_token_encrypted: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Absolute expiry of the access token currently in auth_token_encrypted.
+    oauth_access_expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/orchestrator/app/services/mcp_oauth_client.py
+++ b/orchestrator/app/services/mcp_oauth_client.py
@@ -1,0 +1,277 @@
+"""Client-side OAuth for external MCP servers (#426) — pure, I/O-free helpers.
+
+The orchestrator is the OAuth *client* here: it drives ``authorization_code`` +
+PKCE (RFC 7636) against an external MCP server's authorization server, stores the
+refresh token, and mints fresh access tokens server-side. This module holds only
+the pure request/response shaping so it is trivially unit-testable; all network,
+DB and crypto live in :mod:`app.services.mcp_oauth_refresh` and the API layer.
+
+Standards followed: OAuth 2.1 (authorization_code + PKCE S256, refresh_token),
+RFC 6750 / RFC 9728 (``WWW-Authenticate`` → Protected Resource Metadata),
+RFC 8414 (Authorization Server Metadata), RFC 7591 (Dynamic Client Registration),
+RFC 8707 (resource indicators).
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import re
+import secrets
+import time
+from urllib.parse import urlencode, urljoin, urlparse
+
+# Refresh a little before the real expiry so an agent never starts a run with a
+# token that dies mid-request.
+EXPIRY_SKEW_SECONDS = 60
+
+
+# ---------------------------------------------------------------------------
+# PKCE (RFC 7636, S256)
+# ---------------------------------------------------------------------------
+
+def gen_pkce() -> tuple[str, str]:
+    """Return ``(code_verifier, code_challenge)`` for PKCE S256.
+
+    ``token_urlsafe(64)`` yields ~86 chars, safely inside RFC 7636's 43-128 range.
+    """
+    verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+# ---------------------------------------------------------------------------
+# WWW-Authenticate parsing (RFC 6750 / RFC 9728)
+# ---------------------------------------------------------------------------
+
+_PARAM_RE = re.compile(r'(\w+)\s*=\s*"([^"]*)"')
+
+
+def parse_www_authenticate(header: str | None) -> dict[str, str]:
+    """Parse a ``Bearer`` challenge into its ``key="value"`` parameters.
+
+    Returns e.g. ``{"error": "invalid_token", "resource_metadata": "https://…"}``.
+    Only ``Bearer`` challenges are considered; anything else yields ``{}``.
+    """
+    if not header:
+        return {}
+    # A single header may carry multiple challenges; we only care about Bearer.
+    if "bearer" not in header.lower():
+        return {}
+    return {k.lower(): v for k, v in _PARAM_RE.findall(header)}
+
+
+def resource_metadata_url(header: str | None, resource_url: str | None = None) -> str | None:
+    """Best-effort Protected Resource Metadata URL.
+
+    Prefer the explicit ``resource_metadata`` from the challenge; otherwise fall
+    back to the RFC 9728 well-known path derived from the resource URL.
+    """
+    params = parse_www_authenticate(header)
+    if params.get("resource_metadata"):
+        return params["resource_metadata"]
+    if resource_url:
+        p = urlparse(resource_url)
+        if p.scheme in ("http", "https") and p.netloc:
+            base = f"{p.scheme}://{p.netloc}"
+            path = p.path.rstrip("/")
+            # RFC 9728: metadata path prefixes the resource path under well-known.
+            return f"{base}/.well-known/oauth-protected-resource{path}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Metadata selection (RFC 9728 PRM + RFC 8414 AS metadata)
+# ---------------------------------------------------------------------------
+
+def pick_authorization_server(prm: dict | None) -> str | None:
+    """First authorization server issuer advertised by a PRM document."""
+    if not isinstance(prm, dict):
+        return None
+    servers = prm.get("authorization_servers")
+    if isinstance(servers, list) and servers:
+        first = servers[0]
+        return first if isinstance(first, str) else None
+    return None
+
+
+def as_metadata_urls(issuer: str) -> list[str]:
+    """Candidate RFC 8414 metadata URLs for an issuer.
+
+    RFC 8414 inserts the well-known segment *between* host and path; many servers
+    (and the OpenID variant) also expose it appended at the end. Try both plus the
+    OpenID configuration so discovery works against real-world deployments.
+    """
+    p = urlparse(issuer)
+    if p.scheme not in ("http", "https") or not p.netloc:
+        return []
+    base = f"{p.scheme}://{p.netloc}"
+    path = p.path.rstrip("/")
+    out = [
+        f"{base}/.well-known/oauth-authorization-server{path}",
+        f"{issuer.rstrip('/')}/.well-known/oauth-authorization-server",
+        f"{base}/.well-known/openid-configuration{path}",
+        f"{issuer.rstrip('/')}/.well-known/openid-configuration",
+    ]
+    # De-dup while preserving order.
+    seen: set[str] = set()
+    return [u for u in out if not (u in seen or seen.add(u))]
+
+
+def select_endpoints(as_meta: dict | None) -> dict:
+    """Extract the endpoints/capabilities we need from AS metadata."""
+    m = as_meta if isinstance(as_meta, dict) else {}
+    scopes = m.get("scopes_supported")
+    return {
+        "issuer": m.get("issuer"),
+        "authorization_endpoint": m.get("authorization_endpoint"),
+        "token_endpoint": m.get("token_endpoint"),
+        "registration_endpoint": m.get("registration_endpoint"),
+        "grant_types_supported": m.get("grant_types_supported") or [],
+        "scopes_supported": scopes if isinstance(scopes, list) else [],
+    }
+
+
+def default_scope(prm: dict | None, as_meta: dict | None) -> str:
+    """Pick a scope string, preferring the resource's PRM scopes over the AS's."""
+    for src in (prm, as_meta):
+        if isinstance(src, dict):
+            sc = src.get("scopes_supported")
+            if isinstance(sc, list) and sc:
+                return " ".join(str(s) for s in sc)
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Request builders
+# ---------------------------------------------------------------------------
+
+def build_registration_request(*, redirect_uri: str, client_name: str) -> dict:
+    """RFC 7591 Dynamic Client Registration body for a public PKCE client."""
+    return {
+        "client_name": client_name,
+        "redirect_uris": [redirect_uri],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+    }
+
+
+def build_authorization_url(
+    *,
+    authorization_endpoint: str,
+    client_id: str,
+    redirect_uri: str,
+    state: str,
+    code_challenge: str,
+    scope: str = "",
+    resource: str | None = None,
+) -> str:
+    """Build the browser-facing ``authorization_code`` + PKCE authorization URL."""
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "state": state,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+    if scope:
+        params["scope"] = scope
+    if resource:
+        params["resource"] = resource
+    sep = "&" if "?" in authorization_endpoint else "?"
+    return f"{authorization_endpoint}{sep}{urlencode(params)}"
+
+
+def build_token_exchange_data(
+    *,
+    code: str,
+    code_verifier: str,
+    client_id: str,
+    redirect_uri: str,
+    client_secret: str | None = None,
+    resource: str | None = None,
+) -> dict:
+    """Form body for the ``authorization_code`` → token exchange."""
+    data = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "client_id": client_id,
+        "code_verifier": code_verifier,
+    }
+    if client_secret:
+        data["client_secret"] = client_secret
+    if resource:
+        data["resource"] = resource
+    return data
+
+
+def build_refresh_data(
+    *,
+    refresh_token: str,
+    client_id: str,
+    client_secret: str | None = None,
+    scope: str = "",
+    resource: str | None = None,
+) -> dict:
+    """Form body for a ``refresh_token`` grant."""
+    data = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": client_id,
+    }
+    if client_secret:
+        data["client_secret"] = client_secret
+    if scope:
+        data["scope"] = scope
+    if resource:
+        data["resource"] = resource
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Token response
+# ---------------------------------------------------------------------------
+
+def parse_token_response(payload: dict | None) -> dict:
+    """Normalize a token endpoint response.
+
+    Returns ``{"access_token", "refresh_token", "expires_at", "scope"}``.
+    ``expires_at`` is an absolute epoch second (``None`` if the server gave no
+    ``expires_in``). ``refresh_token`` is ``None`` when the server did not rotate
+    it — callers keep the previous one in that case.
+    """
+    p = payload if isinstance(payload, dict) else {}
+    access = p.get("access_token")
+    if not isinstance(access, str) or not access:
+        raise ValueError("token response missing access_token")
+    expires_at = None
+    exp = p.get("expires_in")
+    if isinstance(exp, (int, float)) and exp > 0:
+        expires_at = int(time.time()) + int(exp)
+    refresh = p.get("refresh_token")
+    scope = p.get("scope")
+    return {
+        "access_token": access,
+        "refresh_token": refresh if isinstance(refresh, str) and refresh else None,
+        "expires_at": expires_at,
+        "scope": scope if isinstance(scope, str) else "",
+    }
+
+
+def is_expired(expires_at: int | float | None, *, skew_seconds: int = EXPIRY_SKEW_SECONDS) -> bool:
+    """Whether an access token should be refreshed now.
+
+    A ``None`` expiry is treated as expired: we cannot prove it is still valid, so
+    we refresh rather than hand an agent a possibly-dead token.
+    """
+    if expires_at is None:
+        return True
+    return time.time() >= float(expires_at) - skew_seconds
+
+
+def absolute_metadata_url(base_url: str, ref: str) -> str:
+    """Resolve a possibly-relative metadata reference against a base URL."""
+    return urljoin(base_url, ref)

--- a/orchestrator/app/services/mcp_oauth_refresh.py
+++ b/orchestrator/app/services/mcp_oauth_refresh.py
@@ -1,0 +1,132 @@
+"""Execution half of client-side MCP OAuth (#426): token requests + server-side refresh.
+
+Keeps the network/DB/crypto out of the pure :mod:`app.services.mcp_oauth_client`
+helpers. Used by the MCP-servers API (code exchange on the OAuth callback) and by
+the agent manager (mint a fresh access token just before an agent starts).
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.encryption import decrypt_token, encrypt_token
+from app.models.mcp_server import McpServer
+from app.services import mcp_oauth_client as oc
+
+logger = logging.getLogger(__name__)
+
+_TOKEN_TIMEOUT = 15.0
+
+
+class OAuthTokenError(Exception):
+    """A token endpoint call failed (network, non-2xx, or malformed response)."""
+
+
+async def perform_token_request(token_endpoint: str, data: dict) -> dict:
+    """POST a form to an OAuth token endpoint and return a parsed token response.
+
+    SSRF-guarded (same DNS-resolving guard the manual tools/call path uses) and
+    fail-closed. Returns the dict from :func:`mcp_oauth_client.parse_token_response`.
+    """
+    # Lazy import avoids a circular dependency (the API module imports this one).
+    from app.api.mcp_servers import _assert_mcp_url_allowed
+
+    await _assert_mcp_url_allowed(token_endpoint)
+    try:
+        async with httpx.AsyncClient(timeout=_TOKEN_TIMEOUT) as client:
+            resp = await client.post(
+                token_endpoint,
+                data=data,
+                headers={"Accept": "application/json"},
+                follow_redirects=False,
+            )
+    except httpx.RequestError as exc:
+        raise OAuthTokenError(f"token endpoint unreachable: {exc}") from exc
+
+    if resp.status_code >= 400:
+        # Surface the OAuth error code when present, without leaking the body.
+        detail = ""
+        try:
+            body = resp.json()
+            detail = body.get("error") or body.get("error_description") or ""
+        except Exception:
+            pass
+        raise OAuthTokenError(f"token endpoint returned {resp.status_code}"
+                              + (f" ({detail})" if detail else ""))
+    try:
+        payload = resp.json()
+    except Exception as exc:
+        raise OAuthTokenError("token endpoint returned non-JSON") from exc
+    try:
+        return oc.parse_token_response(payload)
+    except ValueError as exc:
+        raise OAuthTokenError(str(exc)) from exc
+
+
+def apply_token_to_server(server: McpServer, parsed: dict) -> None:
+    """Store a parsed token response on the server row (in-memory; caller commits).
+
+    The access token goes into ``auth_token_encrypted`` so it reaches agents
+    unchanged. A rotated refresh token replaces the old one; if the server did not
+    return one, the previous refresh token is kept.
+    """
+    server.auth_token_encrypted = encrypt_token(parsed["access_token"])
+    if parsed.get("refresh_token"):
+        server.oauth_refresh_token_encrypted = encrypt_token(parsed["refresh_token"])
+    expires_at = parsed.get("expires_at")
+    server.oauth_access_expires_at = (
+        datetime.fromtimestamp(expires_at, tz=timezone.utc) if expires_at else None
+    )
+    if parsed.get("scope"):
+        server.oauth_scope = parsed["scope"]
+
+
+async def refresh_if_needed(server: McpServer, db: AsyncSession) -> bool:
+    """Ensure ``server`` has a non-expired access token, refreshing if necessary.
+
+    Returns True if the server now holds a usable (fresh or still-valid) access
+    token, False if it could not be refreshed (no refresh token, or the grant
+    failed). Never raises — a refresh failure must not break agent startup or a
+    listing; the stale token simply stays and the server's own health check will
+    flag the eventual 401.
+    """
+    if not getattr(server, "oauth_enabled", False):
+        return bool(server.auth_token_encrypted)
+
+    expires_at = server.oauth_access_expires_at
+    epoch = expires_at.timestamp() if expires_at else None
+    if server.auth_token_encrypted and not oc.is_expired(epoch):
+        return True
+
+    if not server.oauth_refresh_token_encrypted or not server.oauth_token_endpoint:
+        return bool(server.auth_token_encrypted)
+
+    try:
+        refresh_token = decrypt_token(server.oauth_refresh_token_encrypted)
+        client_secret = (
+            decrypt_token(server.oauth_client_secret_encrypted)
+            if server.oauth_client_secret_encrypted else None
+        )
+        data = oc.build_refresh_data(
+            refresh_token=refresh_token,
+            client_id=server.oauth_client_id or "",
+            client_secret=client_secret,
+            scope=server.oauth_scope or "",
+            resource=server.oauth_resource or None,
+        )
+        parsed = await perform_token_request(server.oauth_token_endpoint, data)
+    except Exception as exc:  # noqa: BLE001 — see docstring: never break the caller
+        logger.warning("MCP OAuth refresh failed for server %s: %s", server.name, exc)
+        return bool(server.auth_token_encrypted)
+
+    apply_token_to_server(server, parsed)
+    try:
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        logger.warning("Could not persist refreshed MCP token for server %s", server.name)
+        return bool(server.auth_token_encrypted)
+    return True

--- a/orchestrator/tests/test_mcp_oauth_client.py
+++ b/orchestrator/tests/test_mcp_oauth_client.py
@@ -1,0 +1,236 @@
+"""Unit tests for the pure MCP OAuth client helpers (#426)."""
+import base64
+import hashlib
+import time
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from app.services import mcp_oauth_client as oc
+
+
+# --- PKCE -----------------------------------------------------------------
+
+def test_gen_pkce_verifier_length_in_rfc_range():
+    verifier, challenge = oc.gen_pkce()
+    assert 43 <= len(verifier) <= 128
+    assert challenge  # non-empty
+
+
+def test_gen_pkce_challenge_is_s256_of_verifier():
+    verifier, challenge = oc.gen_pkce()
+    expected = base64.urlsafe_b64encode(
+        hashlib.sha256(verifier.encode("ascii")).digest()
+    ).rstrip(b"=").decode("ascii")
+    assert challenge == expected
+
+
+def test_gen_pkce_is_random():
+    assert oc.gen_pkce()[0] != oc.gen_pkce()[0]
+
+
+# --- WWW-Authenticate parsing ---------------------------------------------
+
+def test_parse_www_authenticate_extracts_params():
+    hdr = 'Bearer error="invalid_token", resource_metadata="https://h/.well-known/oauth-protected-resource/srv"'
+    params = oc.parse_www_authenticate(hdr)
+    assert params["error"] == "invalid_token"
+    assert params["resource_metadata"] == "https://h/.well-known/oauth-protected-resource/srv"
+
+
+def test_parse_www_authenticate_non_bearer_returns_empty():
+    assert oc.parse_www_authenticate('Basic realm="x"') == {}
+
+
+def test_parse_www_authenticate_none():
+    assert oc.parse_www_authenticate(None) == {}
+
+
+def test_resource_metadata_url_prefers_challenge():
+    hdr = 'Bearer resource_metadata="https://h/.well-known/oauth-protected-resource/s"'
+    assert oc.resource_metadata_url(hdr) == "https://h/.well-known/oauth-protected-resource/s"
+
+
+def test_resource_metadata_url_falls_back_to_well_known():
+    url = oc.resource_metadata_url(None, "https://host.example/api/v1/mcp/srv")
+    assert url == "https://host.example/.well-known/oauth-protected-resource/api/v1/mcp/srv"
+
+
+def test_resource_metadata_url_none_when_no_hint():
+    assert oc.resource_metadata_url(None, None) is None
+
+
+# --- Metadata selection ---------------------------------------------------
+
+def test_pick_authorization_server_first():
+    assert oc.pick_authorization_server({"authorization_servers": ["https://as1", "https://as2"]}) == "https://as1"
+
+
+def test_pick_authorization_server_missing():
+    assert oc.pick_authorization_server({}) is None
+    assert oc.pick_authorization_server(None) is None
+
+
+def test_as_metadata_urls_covers_rfc8414_and_openid():
+    urls = oc.as_metadata_urls("https://as.example/tenant")
+    assert "https://as.example/.well-known/oauth-authorization-server/tenant" in urls
+    assert "https://as.example/tenant/.well-known/oauth-authorization-server" in urls
+    assert any("openid-configuration" in u for u in urls)
+    assert len(urls) == len(set(urls))  # de-duped
+
+
+def test_as_metadata_urls_invalid_issuer():
+    assert oc.as_metadata_urls("not-a-url") == []
+
+
+def test_select_endpoints():
+    meta = {
+        "issuer": "https://as",
+        "authorization_endpoint": "https://as/authorize",
+        "token_endpoint": "https://as/token",
+        "registration_endpoint": "https://as/register",
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "scopes_supported": ["MCP.Access"],
+    }
+    got = oc.select_endpoints(meta)
+    assert got["token_endpoint"] == "https://as/token"
+    assert got["registration_endpoint"] == "https://as/register"
+    assert got["scopes_supported"] == ["MCP.Access"]
+
+
+def test_select_endpoints_empty():
+    got = oc.select_endpoints(None)
+    assert got["token_endpoint"] is None
+    assert got["grant_types_supported"] == []
+
+
+def test_default_scope_prefers_prm():
+    assert oc.default_scope({"scopes_supported": ["A", "B"]}, {"scopes_supported": ["C"]}) == "A B"
+
+
+def test_default_scope_falls_back_to_as():
+    assert oc.default_scope({}, {"scopes_supported": ["C"]}) == "C"
+
+
+def test_default_scope_empty():
+    assert oc.default_scope({}, {}) == ""
+
+
+# --- Request builders -----------------------------------------------------
+
+def test_build_registration_request_public_pkce():
+    body = oc.build_registration_request(redirect_uri="https://o/cb", client_name="AI-Employee")
+    assert body["redirect_uris"] == ["https://o/cb"]
+    assert body["token_endpoint_auth_method"] == "none"
+    assert "refresh_token" in body["grant_types"]
+
+
+def test_build_authorization_url_has_pkce_and_state():
+    url = oc.build_authorization_url(
+        authorization_endpoint="https://as/authorize",
+        client_id="cid",
+        redirect_uri="https://o/cb",
+        state="st8",
+        code_challenge="chal",
+        scope="MCP.Access",
+        resource="https://h/api/v1/mcp/srv",
+    )
+    q = parse_qs(urlparse(url).query)
+    assert q["response_type"] == ["code"]
+    assert q["code_challenge_method"] == ["S256"]
+    assert q["code_challenge"] == ["chal"]
+    assert q["state"] == ["st8"]
+    assert q["scope"] == ["MCP.Access"]
+    assert q["resource"] == ["https://h/api/v1/mcp/srv"]
+    assert q["client_id"] == ["cid"]
+
+
+def test_build_authorization_url_appends_when_query_present():
+    url = oc.build_authorization_url(
+        authorization_endpoint="https://as/authorize?foo=bar",
+        client_id="cid", redirect_uri="https://o/cb", state="s", code_challenge="c",
+    )
+    assert "?foo=bar&" in url
+
+
+def test_build_authorization_url_omits_empty_scope_and_resource():
+    url = oc.build_authorization_url(
+        authorization_endpoint="https://as/a", client_id="c", redirect_uri="https://o/cb",
+        state="s", code_challenge="c",
+    )
+    q = parse_qs(urlparse(url).query)
+    assert "scope" not in q
+    assert "resource" not in q
+
+
+def test_build_token_exchange_data():
+    data = oc.build_token_exchange_data(
+        code="AC", code_verifier="V", client_id="cid", redirect_uri="https://o/cb",
+        resource="https://h/mcp",
+    )
+    assert data["grant_type"] == "authorization_code"
+    assert data["code_verifier"] == "V"
+    assert data["resource"] == "https://h/mcp"
+    assert "client_secret" not in data
+
+
+def test_build_token_exchange_data_confidential():
+    data = oc.build_token_exchange_data(
+        code="AC", code_verifier="V", client_id="cid", redirect_uri="https://o/cb",
+        client_secret="sek",
+    )
+    assert data["client_secret"] == "sek"
+
+
+def test_build_refresh_data():
+    data = oc.build_refresh_data(refresh_token="RT", client_id="cid", scope="s", resource="https://h/mcp")
+    assert data["grant_type"] == "refresh_token"
+    assert data["refresh_token"] == "RT"
+    assert data["scope"] == "s"
+    assert data["resource"] == "https://h/mcp"
+
+
+# --- Token response -------------------------------------------------------
+
+def test_parse_token_response_full():
+    out = oc.parse_token_response({
+        "access_token": "AT", "refresh_token": "RT", "expires_in": 900, "scope": "s",
+    })
+    assert out["access_token"] == "AT"
+    assert out["refresh_token"] == "RT"
+    assert out["scope"] == "s"
+    assert out["expires_at"] is not None
+    assert out["expires_at"] > time.time()
+
+
+def test_parse_token_response_no_rotation():
+    out = oc.parse_token_response({"access_token": "AT", "expires_in": 60})
+    assert out["refresh_token"] is None
+
+
+def test_parse_token_response_no_expiry():
+    out = oc.parse_token_response({"access_token": "AT"})
+    assert out["expires_at"] is None
+
+
+def test_parse_token_response_missing_access_raises():
+    with pytest.raises(ValueError):
+        oc.parse_token_response({"token_type": "Bearer"})
+
+
+# --- Expiry ---------------------------------------------------------------
+
+def test_is_expired_none_is_true():
+    assert oc.is_expired(None) is True
+
+
+def test_is_expired_future_false():
+    assert oc.is_expired(time.time() + 3600) is False
+
+
+def test_is_expired_within_skew_true():
+    assert oc.is_expired(time.time() + 10, skew_seconds=60) is True
+
+
+def test_is_expired_past_true():
+    assert oc.is_expired(time.time() - 5) is True


### PR DESCRIPTION
## Summary
Implements the **client half** of MCP OAuth so admins can connect MCP servers that sit behind an OAuth 2.1 authorization server. The orchestrator discovers the AS, runs an authorization-code + PKCE flow, and keeps the access token fresh so agents receive a valid bearer token.

- **`mcp_oauth_client`** (new, pure/testable): PKCE S256, `WWW-Authenticate` parsing, RFC 9728 protected-resource-metadata + RFC 8414 AS-metadata discovery, RFC 7591 DCR request building, token/refresh request building, token-response parsing, expiry checks. **33 unit tests, all pass.**
- **`mcp_oauth_refresh`** (new): SSRF-guarded token endpoint requests, apply/rotate tokens onto the server row, and a fail-closed `refresh_if_needed` (never raises — stale token stays, health check flags the eventual 401).
- **API**: `POST /mcp-servers/{id}/oauth/discover`, `GET /mcp-servers/{id}/oauth/connect`, and an unauthenticated `GET /mcp-servers/oauth/callback` (CSRF-bound via single-use Redis state, TTL 600s) implementing the authorization-code exchange.
- **Model + startup migration**: `oauth_*` columns on `mcp_servers` (via `ADD COLUMN IF NOT EXISTS`, consistent with the existing non-Alembic pattern).
- **Agent manager**: refreshes the OAuth token before injecting `CUSTOM_MCP_AUTH`.
- **Frontend**: Connect button, OAuth status badge, callback result toast, and discovery/connect API helpers + types on the integrations page.

## Note on the token-forwarding dependency
The refreshed access token lands in `auth_token_encrypted`, which the orchestrator already decrypts into `CUSTOM_MCP_AUTH` and the agent passes via `--header` to `claude mcp add`. So the "token reaches the agent" dependency is already satisfied — this PR only adds the minting/refresh half.

## Test plan
- [x] `python -m pytest orchestrator/tests/test_mcp_oauth_client.py` — 33 pass
- [x] `python -m py_compile` on all changed orchestrator modules
- [x] `npx tsc --noEmit` — clean
- [x] `git diff --check` — no whitespace errors
- [ ] Live browser round-trip against a real OAuth-protected MCP server (needs a deployed environment)

Fixes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)