### PR TITLE
Fix #462: serialize MCP OAuth refresh with per-server advisory lock

### DIFF
--- a/orchestrator/app/services/mcp_oauth_refresh.py
+++ b/orchestrator/app/services/mcp_oauth_refresh.py
@@ -7,9 +7,11 @@ the agent manager (mint a fresh access token just before an agent starts).
 from __future__ import annotations
 
 import logging
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 
 import httpx
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.encryption import decrypt_token, encrypt_token
@@ -19,6 +21,43 @@ from app.services import mcp_oauth_client as oc
 logger = logging.getLogger(__name__)
 
 _TOKEN_TIMEOUT = 15.0
+
+# Namespace for the per-server advisory lock (#462). PostgreSQL's two-int form
+# ``pg_advisory_xact_lock(classid, objid)`` keys the lock on (namespace, id) so a
+# server id can never collide with another advisory-lock user in the cluster.
+# Arbitrary fixed int4 ("mcp\0"); must stay stable across releases.
+_REFRESH_LOCK_NAMESPACE = 0x6D63_7000
+
+
+def _is_postgres(db: AsyncSession) -> bool:
+    try:
+        return db.bind.dialect.name == "postgresql"
+    except Exception:
+        return False
+
+
+@asynccontextmanager
+async def _refresh_lock(db: AsyncSession, server_id: int):
+    """Serialize concurrent OAuth refreshes for one server across agent sessions.
+
+    On PostgreSQL this takes a *transaction-level* advisory lock keyed on the
+    server id (namespaced). When several agents start at once and share an
+    OAuth-MCP server with rotating refresh tokens, only the first caller performs
+    the token request; the others block here until it commits, then re-read the
+    freshly persisted token instead of replaying an already-rotated (revoked)
+    refresh token (#462). The lock auto-releases when the caller's transaction
+    ends (commit/rollback) — so callers MUST end their transaction after the
+    critical section, which :func:`refresh_if_needed` already does.
+
+    On any other backend (e.g. the SQLite unit tests) it is a no-op: there is no
+    cross-process race to guard.
+    """
+    if _is_postgres(db):
+        await db.execute(
+            text("SELECT pg_advisory_xact_lock(:ns, :oid)"),
+            {"ns": _REFRESH_LOCK_NAMESPACE, "oid": int(server_id)},
+        )
+    yield
 
 
 class OAuthTokenError(Exception):
@@ -104,29 +143,65 @@ async def refresh_if_needed(server: McpServer, db: AsyncSession) -> bool:
     if not server.oauth_refresh_token_encrypted or not server.oauth_token_endpoint:
         return bool(server.auth_token_encrypted)
 
-    try:
-        refresh_token = decrypt_token(server.oauth_refresh_token_encrypted)
-        client_secret = (
-            decrypt_token(server.oauth_client_secret_encrypted)
-            if server.oauth_client_secret_encrypted else None
-        )
-        data = oc.build_refresh_data(
-            refresh_token=refresh_token,
-            client_id=server.oauth_client_id or "",
-            client_secret=client_secret,
-            scope=server.oauth_scope or "",
-            resource=server.oauth_resource or None,
-        )
-        parsed = await perform_token_request(server.oauth_token_endpoint, data)
-    except Exception as exc:  # noqa: BLE001 — see docstring: never break the caller
-        logger.warning("MCP OAuth refresh failed for server %s: %s", server.name, exc)
-        return bool(server.auth_token_encrypted)
+    async with _refresh_lock(db, server.id):
+        # Re-check under the lock (#462): a concurrent caller may have just
+        # refreshed and committed. Reload the row so we observe its committed
+        # token and rotated refresh token instead of firing our own request with
+        # a now-revoked refresh token.
+        try:
+            await db.refresh(server)
+        except Exception:  # noqa: BLE001 — a fresh reload is best-effort
+            pass
+        expires_at = server.oauth_access_expires_at
+        epoch = expires_at.timestamp() if expires_at else None
+        if server.auth_token_encrypted and not oc.is_expired(epoch):
+            # A concurrent winner already refreshed; release the lock promptly.
+            await _release(db)
+            return True
 
-    apply_token_to_server(server, parsed)
+        try:
+            refresh_token = decrypt_token(server.oauth_refresh_token_encrypted)
+            client_secret = (
+                decrypt_token(server.oauth_client_secret_encrypted)
+                if server.oauth_client_secret_encrypted else None
+            )
+            data = oc.build_refresh_data(
+                refresh_token=refresh_token,
+                client_id=server.oauth_client_id or "",
+                client_secret=client_secret,
+                scope=server.oauth_scope or "",
+                resource=server.oauth_resource or None,
+            )
+            parsed = await perform_token_request(server.oauth_token_endpoint, data)
+        except Exception as exc:  # noqa: BLE001 — see docstring: never break the caller
+            logger.warning("MCP OAuth refresh failed for server %s: %s", server.name, exc)
+            await _release(db)
+            return bool(server.auth_token_encrypted)
+
+        apply_token_to_server(server, parsed)
+        try:
+            await db.commit()  # persists the token AND releases the advisory lock
+        except Exception:
+            await db.rollback()
+            logger.warning("Could not persist refreshed MCP token for server %s", server.name)
+            return bool(server.auth_token_encrypted)
+        return True
+
+
+async def _release(db: AsyncSession) -> None:
+    """End the current transaction to release a held advisory lock, best-effort.
+
+    Uses ``commit`` (not ``rollback``) to end the transaction: the session runs
+    with ``expire_on_commit=False``, so committing releases the advisory lock
+    without expiring the loaded ORM instances — the caller (``agent_manager``)
+    reads ``server.auth_token_encrypted`` right after in a non-async context, and
+    a rollback would expire it and trigger an illegal async lazy-load. No writes
+    are pending on the release paths, so the commit flushes nothing meaningful.
+    """
     try:
         await db.commit()
-    except Exception:
-        await db.rollback()
-        logger.warning("Could not persist refreshed MCP token for server %s", server.name)
-        return bool(server.auth_token_encrypted)
-    return True
+    except Exception:  # noqa: BLE001
+        try:
+            await db.rollback()
+        except Exception:  # noqa: BLE001
+            pass

--- a/orchestrator/tests/test_mcp_oauth_refresh_lock.py
+++ b/orchestrator/tests/test_mcp_oauth_refresh_lock.py
@@ -1,0 +1,162 @@
+"""Regression tests for issue #462: MCP OAuth refresh race under parallel starts.
+
+When several agents start at once and share an OAuth-MCP server with rotating
+refresh tokens, parallel ``refresh_if_needed`` calls must NOT each fire a token
+request — the first rotates the refresh token, revoking it for the rest. The fix
+serializes the refresh with a per-server PostgreSQL advisory lock and re-checks
+the (reloaded) token under the lock, so late callers read the freshly persisted
+token instead of replaying a now-revoked refresh token.
+"""
+
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.models.mcp_server import McpServer
+from app.services import mcp_oauth_refresh as mor
+
+
+def _make_server(*, expires_in: int | None) -> McpServer:
+    s = McpServer()
+    s.id = 7
+    s.name = "shared-oauth-mcp"
+    s.oauth_enabled = True
+    s.oauth_token_endpoint = "https://idp.example/token"
+    s.oauth_client_id = "client-abc"
+    s.oauth_client_secret_encrypted = None
+    s.oauth_scope = "read"
+    s.oauth_resource = None
+    s.oauth_refresh_token_encrypted = "enc:rt-old"
+    s.auth_token_encrypted = "enc:at-old"
+    if expires_in is None:
+        s.oauth_access_expires_at = None
+    else:
+        s.oauth_access_expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+    return s
+
+
+def _pg_session() -> AsyncMock:
+    """An AsyncMock session that looks like PostgreSQL to ``_is_postgres``."""
+    db = AsyncMock()
+    db.bind = MagicMock()
+    db.bind.dialect.name = "postgresql"
+    db.execute = AsyncMock()
+    db.refresh = AsyncMock()
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+    return db
+
+
+def _sqlite_session() -> AsyncMock:
+    db = AsyncMock()
+    db.bind = MagicMock()
+    db.bind.dialect.name = "sqlite"
+    db.execute = AsyncMock()
+    db.refresh = AsyncMock()
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+    return db
+
+
+def _enc(token):
+    return f"enc:{token}"
+
+
+def _dec(token):
+    return token.split(":", 1)[1] if ":" in token else token
+
+
+class RefreshLockDialectTests(unittest.IsolatedAsyncioTestCase):
+    async def test_lock_acquires_advisory_lock_on_postgres(self):
+        db = _pg_session()
+        async with mor._refresh_lock(db, 7):
+            pass
+        db.execute.assert_awaited_once()
+        sql = str(db.execute.await_args.args[0])
+        params = db.execute.await_args.args[1]
+        assert "pg_advisory_xact_lock" in sql
+        assert params == {"ns": mor._REFRESH_LOCK_NAMESPACE, "oid": 7}
+
+    async def test_lock_is_noop_off_postgres(self):
+        db = _sqlite_session()
+        async with mor._refresh_lock(db, 7):
+            pass
+        db.execute.assert_not_awaited()
+
+    async def test_is_postgres_false_when_bind_missing(self):
+        db = AsyncMock()
+        db.bind = None
+        assert mor._is_postgres(db) is False
+
+
+class RefreshIfNeededRaceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_late_caller_skips_token_request_after_winner_refreshed(self):
+        """#462 core: if the reload under the lock shows a fresh token, no request."""
+        server = _make_server(expires_in=-10)  # currently expired → needs refresh
+
+        db = _pg_session()
+
+        # Simulate the winner having committed a fresh token: db.refresh() reloads
+        # the row with a valid access token and a rotated refresh token.
+        async def _reload(obj):
+            obj.auth_token_encrypted = "enc:at-fresh"
+            obj.oauth_refresh_token_encrypted = "enc:rt-rotated"
+            obj.oauth_access_expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+
+        db.refresh.side_effect = _reload
+
+        with patch.object(mor, "perform_token_request", new=AsyncMock()) as ptr:
+            ok = await mor.refresh_if_needed(server, db)
+
+        assert ok is True
+        ptr.assert_not_awaited()          # did NOT replay the rotated refresh token
+        db.commit.assert_awaited()        # committed to release the lock (no writes pending)
+
+    async def test_winner_performs_refresh_and_commits(self):
+        """Still-expired after reload → this caller performs the refresh."""
+        server = _make_server(expires_in=-10)
+        db = _pg_session()
+        db.refresh.side_effect = None  # reload leaves it expired (still needs refresh)
+
+        parsed = {
+            "access_token": "at-new",
+            "refresh_token": "rt-new",
+            "expires_at": (datetime.now(timezone.utc) + timedelta(hours=1)).timestamp(),
+            "scope": "read",
+        }
+        with patch.object(mor, "perform_token_request", new=AsyncMock(return_value=parsed)) as ptr, \
+                patch.object(mor, "decrypt_token", side_effect=_dec), \
+                patch.object(mor, "encrypt_token", side_effect=_enc):
+            ok = await mor.refresh_if_needed(server, db)
+
+        assert ok is True
+        ptr.assert_awaited_once()
+        db.commit.assert_awaited_once()   # commit persists AND releases the lock
+        assert server.auth_token_encrypted == "enc:at-new"
+        assert server.oauth_refresh_token_encrypted == "enc:rt-new"
+
+    async def test_valid_token_returns_without_taking_lock(self):
+        """Fast path: a still-valid token must not touch the DB/lock at all."""
+        server = _make_server(expires_in=3600)  # valid for another hour
+        db = _pg_session()
+        with patch.object(mor, "perform_token_request", new=AsyncMock()) as ptr:
+            ok = await mor.refresh_if_needed(server, db)
+        assert ok is True
+        ptr.assert_not_awaited()
+        db.execute.assert_not_awaited()   # no advisory lock acquired
+
+    async def test_refresh_failure_releases_lock_and_keeps_stale_token(self):
+        """A failed token request must release the lock and never raise."""
+        server = _make_server(expires_in=-10)
+        db = _pg_session()
+        db.refresh.side_effect = None
+        with patch.object(mor, "perform_token_request",
+                          new=AsyncMock(side_effect=mor.OAuthTokenError("boom"))), \
+                patch.object(mor, "decrypt_token", side_effect=_dec):
+            ok = await mor.refresh_if_needed(server, db)
+        assert ok is True                 # stale token still present → usable
+        db.commit.assert_awaited()        # committed to release the lock
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #462

## Problem
When several agents start at once and share an OAuth-MCP server with **rotating refresh tokens**, parallel `refresh_if_needed` calls each fire a token request. The first caller rotates the refresh token, revoking it for the others → **silent auth failures** and an unnecessary re-auth flow.

## Fix
`orchestrator/app/services/mcp_oauth_refresh.py`:
- New `_refresh_lock(db, server_id)` async context manager takes a **transaction-level PostgreSQL advisory lock** (`pg_advisory_xact_lock(namespace, server.id)`). The namespace int4 prevents collisions with any other advisory-lock user in the cluster.
- `refresh_if_needed` now acquires the lock, then **re-reads the row** (`db.refresh`) and re-checks expiry under the lock. A late caller that finds a freshly-committed token returns immediately **without** replaying the now-rotated refresh token — the core race fix.
- The winner persists + releases via `db.commit()`. Loser / refresh-failure paths release via `_release()` which **commits** (not rolls back) so the lock is freed without expiring loaded ORM instances (session runs `expire_on_commit=False`; the caller reads `server.auth_token_encrypted` right after in a non-async context).
- **No-op on non-Postgres** backends (e.g. SQLite unit tests) — no cross-process race to guard.

Fast path (token still valid) is unchanged and never touches the DB/lock.

## Tests
New `tests/test_mcp_oauth_refresh_lock.py` (7 tests):
- advisory lock acquired on Postgres with correct namespaced params; no-op off Postgres; `_is_postgres` false when bind missing
- **#462 core:** late caller whose reload shows a fresh token does **not** call `perform_token_request`
- winner still performs the refresh + commits + rotates the stored tokens
- valid token returns via fast path without acquiring the lock
- failed token request releases the lock and keeps the stale (still-usable) token, never raises

`pytest -k "oauth or mcp or asgi or middleware"` → **100 passed**.

## Test plan
- [ ] CI green (orchestrator pytest, CodeQL, secret scan)
- [ ] Deploy gate: orchestrator image rebuild (host `docker compose up -d --build`)
- [ ] Post-deploy: start ≥2 agents sharing a rotating-RT OAuth-MCP server simultaneously → exactly one token request in logs, all agents authenticate