### PR TITLE
Fix #465: create OAuth-protected MCP server in needs_oauth state instead of aborting on 401

### DIFF
--- a/frontend/src/app/integrations/page.tsx
+++ b/frontend/src/app/integrations/page.tsx
@@ -70,6 +70,15 @@ function formatMcpHealth(server: McpServerInfo): { ok: boolean; label: string; c
     };
   }
 
+  if (server.last_status === "needs_oauth") {
+    return {
+      ok: false,
+      label: `OAuth erforderlich — auf „Verbinden“ klicken · ${checked}`,
+      className: "text-amber-400",
+      title: "Der Server ist OAuth-geschützt und wurde angelegt, aber noch nicht verbunden. Auf „Verbinden“ klicken, um die Autorisierung zu starten.",
+    };
+  }
+
   const fallback = {
     auth_failed: "Authentifizierung fehlgeschlagen",
     unreachable: "nicht erreichbar",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1169,7 +1169,7 @@ export interface McpServerInfo {
   has_headers?: boolean;
   created_at: string | null;
   last_checked_at: string | null;
-  last_status: "ok" | "auth_failed" | "unreachable" | "protocol_error" | null;
+  last_status: "ok" | "auth_failed" | "unreachable" | "protocol_error" | "needs_oauth" | null;
   last_error: string | null;
   // Client-side OAuth (#426)
   oauth_enabled?: boolean;

--- a/orchestrator/app/api/mcp_servers.py
+++ b/orchestrator/app/api/mcp_servers.py
@@ -12,7 +12,7 @@ from ipaddress import ip_address
 from urllib.parse import quote, urlparse, urlunparse
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel, field_validator
 from sqlalchemy import select
@@ -559,7 +559,7 @@ async def _advertises_oauth(url: str) -> bool:
     return bool(www_auth and oc.resource_metadata_url(www_auth))
 
 
-@router.post("")
+@router.post("", status_code=status.HTTP_201_CREATED)
 async def add_mcp_server(body: McpServerCreate, user=Depends(require_admin), db: AsyncSession = Depends(get_db)):
     """Register a new MCP server and discover its tools."""
     # Check for duplicate name
@@ -603,6 +603,7 @@ async def add_mcp_server(body: McpServerCreate, user=Depends(require_admin), db:
 
     server = McpServer(
         name=body.name, url=body.url, tools=tools, enabled=True,
+        oauth_enabled=False,
         auth_token_encrypted=encrypt_token(body.bearer_token) if body.bearer_token else None,
         headers_encrypted=encrypt_token(json_mod.dumps(body.headers)) if body.headers else None,
     )

--- a/orchestrator/app/api/mcp_servers.py
+++ b/orchestrator/app/api/mcp_servers.py
@@ -30,11 +30,16 @@ MCP_HEALTH_OK = "ok"
 MCP_HEALTH_AUTH_FAILED = "auth_failed"
 MCP_HEALTH_UNREACHABLE = "unreachable"
 MCP_HEALTH_PROTOCOL_ERROR = "protocol_error"
+# The server answered 401 with an RFC 9728 OAuth challenge: not an error, it just
+# still needs the Connect flow. Distinguished from auth_failed (a rejected static
+# token) so the UI can steer the operator to "Verbinden" instead of showing red.
+MCP_HEALTH_NEEDS_OAUTH = "needs_oauth"
 MCP_HEALTH_STATUSES = {
     MCP_HEALTH_OK,
     MCP_HEALTH_AUTH_FAILED,
     MCP_HEALTH_UNREACHABLE,
     MCP_HEALTH_PROTOCOL_ERROR,
+    MCP_HEALTH_NEEDS_OAUTH,
 }
 
 
@@ -534,6 +539,26 @@ async def list_mcp_servers(user=Depends(require_auth), db: AsyncSession = Depend
     }
 
 
+async def _advertises_oauth(url: str) -> bool:
+    """True when the server answers the initialize probe with an RFC 9728 OAuth
+    challenge (``WWW-Authenticate: Bearer resource_metadata="…"``).
+
+    Used to tell an OAuth-protected server (which SHOULD be created so the Connect
+    flow becomes reachable) apart from a genuinely rejected static token. Best
+    effort: any probe failure returns False so we fall back to the normal abort.
+    """
+    from app.services import mcp_oauth_client as oc
+    try:
+        www_auth = await _oauth_probe_challenge(url)
+    except HTTPException:
+        return False
+    # Only the challenge's own ``resource_metadata`` pointer counts. Passing the
+    # server URL as a fallback would derive a well-known path for ANY https host,
+    # so a plain rejected static token (401 with no OAuth challenge) would be
+    # misread as OAuth. RFC 9728 requires the pointer to be advertised explicitly.
+    return bool(www_auth and oc.resource_metadata_url(www_auth))
+
+
 @router.post("")
 async def add_mcp_server(body: McpServerCreate, user=Depends(require_admin), db: AsyncSession = Depends(get_db)):
     """Register a new MCP server and discover its tools."""
@@ -542,10 +567,30 @@ async def add_mcp_server(body: McpServerCreate, user=Depends(require_admin), db:
     if existing.scalar_one_or_none():
         raise HTTPException(status_code=409, detail=f"MCP server '{body.name}' already exists")
 
+    from app.core.encryption import encrypt_token
+
     # Discover tools
     try:
         tools = await _discover_tools(body.url, body.bearer_token, body.headers)
     except McpDiscoveryError as e:
+        # A 401 that carries an OAuth challenge is not a failure: the server is
+        # OAuth-protected and simply needs the Connect flow, which can only be
+        # started against a server that already exists (issue #465). Create the
+        # row in a needs_oauth state instead of aborting, so the "OAuth offen"
+        # badge and "Verbinden" button become reachable. Any static creds the
+        # caller supplied are irrelevant to OAuth, so they are not stored.
+        if e.status == MCP_HEALTH_AUTH_FAILED and await _advertises_oauth(body.url):
+            server = McpServer(
+                name=body.name, url=body.url, tools=[], enabled=True,
+                oauth_enabled=True,
+            )
+            _mark_health(server, MCP_HEALTH_NEEDS_OAUTH,
+                         "OAuth erforderlich — auf 'Verbinden' klicken, um die Autorisierung zu starten")
+            db.add(server)
+            await db.commit()
+            await db.refresh(server)
+            return {**_serialize_mcp_server(server), "needs_oauth": True}
+
         _audit_discovery_failure(db, f"add:{body.name}", str(user.id),
                                   {"url": body.url, "detail": e.message})
         await db.commit()
@@ -556,7 +601,6 @@ async def add_mcp_server(body: McpServerCreate, user=Depends(require_admin), db:
         await db.commit()
         raise HTTPException(status_code=400, detail=f"Could not connect to MCP server: {_short_error(str(e))}")
 
-    from app.core.encryption import encrypt_token
     server = McpServer(
         name=body.name, url=body.url, tools=tools, enabled=True,
         auth_token_encrypted=encrypt_token(body.bearer_token) if body.bearer_token else None,

--- a/orchestrator/tests/test_mcp_add_oauth_needs_connect.py
+++ b/orchestrator/tests/test_mcp_add_oauth_needs_connect.py
@@ -121,6 +121,63 @@ async def test_add_unreachable_does_not_probe_oauth(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_add_protocol_error_still_aborts(monkeypatch):
+    async def fake_discover(_url, _token, _headers):
+        raise mcp_servers.McpDiscoveryError("protocol_error", "HTTP 500 during initialize")
+
+    probed = {"called": False}
+
+    async def fake_advertises(_url):
+        probed["called"] = True
+        return True
+
+    monkeypatch.setattr(mcp_servers, "_discover_tools", fake_discover)
+    monkeypatch.setattr(mcp_servers, "_advertises_oauth", fake_advertises)
+
+    db = _FakeAddSession()
+    with pytest.raises(HTTPException) as exc:
+        await mcp_servers.add_mcp_server(_body(), user=SimpleNamespace(id="admin"), db=db)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "HTTP 500 during initialize"
+    assert probed["called"] is False
+    assert _created_servers(db) == []
+
+
+@pytest.mark.asyncio
+async def test_add_successful_discovery_still_creates_enabled_server(monkeypatch):
+    tools = [{"name": "search", "description": "Search docs"}]
+
+    async def fake_discover(_url, _token, _headers):
+        return tools
+
+    monkeypatch.setattr(mcp_servers, "_discover_tools", fake_discover)
+
+    db = _FakeAddSession()
+    payload = await mcp_servers.add_mcp_server(_body(), user=SimpleNamespace(id="admin"), db=db)
+
+    assert payload["tools"] == tools
+    assert payload["enabled"] is True
+    assert payload["oauth_enabled"] is False
+    assert payload["last_status"] == "ok"
+    assert "needs_oauth" not in payload
+    assert len(db.added) == 1
+    assert db.commits == 1
+    created = db.added[0]
+    assert created.tools == tools
+    assert created.oauth_enabled is False
+    assert created.last_status == "ok"
+
+
+def test_add_mcp_server_route_returns_201_created():
+    route = next(
+        route for route in mcp_servers.router.routes
+        if getattr(route, "endpoint", None) is mcp_servers.add_mcp_server
+    )
+    assert route.status_code == 201
+
+
+@pytest.mark.asyncio
 async def test_advertises_oauth_detects_resource_metadata_challenge(monkeypatch):
     async def fake_probe(_url):
         return 'Bearer resource_metadata="https://mcp.example.test/.well-known/oauth-protected-resource"'

--- a/orchestrator/tests/test_mcp_add_oauth_needs_connect.py
+++ b/orchestrator/tests/test_mcp_add_oauth_needs_connect.py
@@ -1,0 +1,152 @@
+"""Issue #465: adding a fresh OAuth-protected MCP server must succeed in a
+needs_oauth state instead of aborting on the 401 that OAuth is meant to solve.
+"""
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.api import mcp_servers
+from app.models.mcp_server import McpServer
+
+
+def _created_servers(db):
+    return [o for o in db.added if isinstance(o, McpServer)]
+
+
+class _NoDuplicateResult:
+    def scalar_one_or_none(self):
+        return None
+
+
+class _FakeAddSession:
+    """Session whose duplicate-name lookup finds nothing, so creation proceeds."""
+
+    def __init__(self):
+        self.commits = 0
+        self.added = []
+
+    async def execute(self, _stmt):
+        return _NoDuplicateResult()
+
+    async def commit(self):
+        self.commits += 1
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def refresh(self, _obj):
+        return None
+
+
+def _body(**kw):
+    defaults = dict(name="proxy-mcp", url="https://mcp.example.test/mcp",
+                    bearer_token=None, headers=None)
+    defaults.update(kw)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_add_oauth_protected_server_is_created_in_needs_oauth_state(monkeypatch):
+    async def fake_discover(_url, _token, _headers):
+        raise mcp_servers.McpDiscoveryError("auth_failed", "401 Unauthorized on initialize")
+
+    async def fake_advertises(_url):
+        return True
+
+    monkeypatch.setattr(mcp_servers, "_discover_tools", fake_discover)
+    monkeypatch.setattr(mcp_servers, "_advertises_oauth", fake_advertises)
+
+    db = _FakeAddSession()
+    payload = await mcp_servers.add_mcp_server(_body(), user=SimpleNamespace(id="admin"), db=db)
+
+    assert payload["needs_oauth"] is True
+    assert payload["oauth_enabled"] is True
+    assert payload["last_status"] == "needs_oauth"
+    assert payload["tools"] == []
+    # The server row was actually persisted so the Connect flow can reach it.
+    assert len(db.added) == 1
+    assert db.commits == 1
+    created = db.added[0]
+    assert created.oauth_enabled is True
+    # OAuth is the auth mechanism here — no irrelevant static creds get stored.
+    assert created.auth_token_encrypted is None
+    assert created.headers_encrypted is None
+
+
+@pytest.mark.asyncio
+async def test_add_rejected_static_token_without_oauth_still_aborts(monkeypatch):
+    """A 401 with NO OAuth challenge is a real auth failure and must not create a row."""
+    async def fake_discover(_url, _token, _headers):
+        raise mcp_servers.McpDiscoveryError("auth_failed", "401 Unauthorized on initialize")
+
+    async def fake_advertises(_url):
+        return False
+
+    monkeypatch.setattr(mcp_servers, "_discover_tools", fake_discover)
+    monkeypatch.setattr(mcp_servers, "_advertises_oauth", fake_advertises)
+
+    db = _FakeAddSession()
+    with pytest.raises(HTTPException) as exc:
+        await mcp_servers.add_mcp_server(_body(bearer_token="wrong"),
+                                         user=SimpleNamespace(id="admin"), db=db)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "401 Unauthorized on initialize"
+    assert _created_servers(db) == []
+
+
+@pytest.mark.asyncio
+async def test_add_unreachable_does_not_probe_oauth(monkeypatch):
+    """Only a 401/auth_failed triggers the OAuth probe; other failures abort as before."""
+    async def fake_discover(_url, _token, _headers):
+        raise mcp_servers.McpDiscoveryError("unreachable", "Connection failed during initialize")
+
+    probed = {"called": False}
+
+    async def fake_advertises(_url):
+        probed["called"] = True
+        return True
+
+    monkeypatch.setattr(mcp_servers, "_discover_tools", fake_discover)
+    monkeypatch.setattr(mcp_servers, "_advertises_oauth", fake_advertises)
+
+    db = _FakeAddSession()
+    with pytest.raises(HTTPException) as exc:
+        await mcp_servers.add_mcp_server(_body(), user=SimpleNamespace(id="admin"), db=db)
+
+    assert exc.value.status_code == 400
+    assert probed["called"] is False
+    assert _created_servers(db) == []
+
+
+@pytest.mark.asyncio
+async def test_advertises_oauth_detects_resource_metadata_challenge(monkeypatch):
+    async def fake_probe(_url):
+        return 'Bearer resource_metadata="https://mcp.example.test/.well-known/oauth-protected-resource"'
+
+    monkeypatch.setattr(mcp_servers, "_oauth_probe_challenge", fake_probe)
+    assert await mcp_servers._advertises_oauth("https://mcp.example.test/mcp") is True
+
+
+@pytest.mark.asyncio
+async def test_advertises_oauth_false_when_no_challenge(monkeypatch):
+    async def fake_probe(_url):
+        return None
+
+    monkeypatch.setattr(mcp_servers, "_oauth_probe_challenge", fake_probe)
+    assert await mcp_servers._advertises_oauth("https://mcp.example.test/mcp") is False
+
+
+@pytest.mark.asyncio
+async def test_advertises_oauth_false_on_probe_error(monkeypatch):
+    async def fake_probe(_url):
+        raise HTTPException(status_code=400, detail="unreachable")
+
+    monkeypatch.setattr(mcp_servers, "_oauth_probe_challenge", fake_probe)
+    assert await mcp_servers._advertises_oauth("https://mcp.example.test/mcp") is False
+
+
+def test_needs_oauth_is_a_recognised_health_status():
+    assert mcp_servers.MCP_HEALTH_NEEDS_OAUTH == "needs_oauth"
+    assert mcp_servers.MCP_HEALTH_NEEDS_OAUTH in mcp_servers.MCP_HEALTH_STATUSES


### PR DESCRIPTION
Fixes #465

## Problem
A fresh OAuth-protected MCP server could never be added. `add_mcp_server` insisted on a successful tool discovery, but discovery against an OAuth-protected server necessarily returns `401` — exactly what OAuth is meant to resolve. Since `POST /oauth/discover` and `GET /oauth/connect` both key off a `server_id`, the OAuth flow could only start for a server that already existed. Chicken-and-egg: the server that needs the feature can never reach a state where the feature is reachable.

## Fix
- **Backend** (`orchestrator/app/api/mcp_servers.py`): when `_discover_tools` fails with a `401` **and** an unauthenticated probe shows the server advertises an RFC 9728 `WWW-Authenticate: Bearer resource_metadata="…"` challenge, create the row with an empty tool list, `oauth_enabled=true` and a new `needs_oauth` health status — instead of aborting. The existing lazy `handleOAuthConnect` flow then runs discovery + DCR on "Verbinden".
- **Detection is strict**: gated on the challenge's own `resource_metadata` pointer (no URL fallback), so a plain rejected static token (401 with no OAuth challenge) still aborts exactly as before. Only `auth_failed`/401 triggers the probe; `unreachable`/`protocol_error` abort without probing.
- **No creds leak**: OAuth is the auth mechanism on this path, so any static bearer/headers the caller supplied are intentionally not stored. SSRF guards are reused via the existing `_oauth_probe_challenge` (`_validate_mcp_url` + host allowlist).
- **Frontend**: `needs_oauth` renders as an amber "OAuth erforderlich — auf „Verbinden" klicken" state (not a red error); the existing "OAuth offen" badge already lights up from `oauth_enabled`. `McpServerInfo.last_status` union extended.

## Verification
- New `orchestrator/tests/test_mcp_add_oauth_needs_connect.py` (8 tests): needs_oauth creation, no-static-creds-stored, plain-401 still aborts, unreachable does not probe, and the `_advertises_oauth` discriminator (explicit challenge true / no challenge false / probe error false).
- Full orchestrator suite: **647 passed**.
- Frontend `tsc --noEmit`: clean.

## Deploy note
Orchestrator image rebuild required (`docker compose up -d --build`). No DB migration needed — `needs_oauth` is just a value in the existing `last_status varchar(32)` column.