### PR TITLE
Fix #468: inject skill context into chat sessions

### DIFF
--- a/agent/app/chat_consumer.py
+++ b/agent/app/chat_consumer.py
@@ -512,9 +512,18 @@ class ChatConsumer:
         from app.runner_hooks import get_approval_rules_prefix
         rules_prefix = get_approval_rules_prefix()
         is_new = self._is_new_session(handler)
+        # custom_llm builds its own skills/marketplace context into the system
+        # prompt on the first message (see LLMChatHandler). The CLI-based chat
+        # handlers (claude_code / codex_cli) had NO such injection at all — the
+        # agent only saw a soft "use skill_search" hint and regularly skipped it
+        # (#468). Inject the same context CLI tasks already get, once per session.
+        skills_prefix = ""
+        if is_new and settings.agent_mode != "custom_llm":
+            from app.runner_hooks import get_marketplace_skill_suggestions, get_skills_context
+            skills_prefix = get_skills_context() + get_marketplace_skill_suggestions(text[:200])
         if telegram_ctx:
-            return rules_prefix + _build_telegram_prompt(text, telegram_ctx, is_new_session=is_new)
-        return rules_prefix + _build_channel_prompt(text, source, is_new)
+            return rules_prefix + skills_prefix + _build_telegram_prompt(text, telegram_ctx, is_new_session=is_new)
+        return rules_prefix + skills_prefix + _build_channel_prompt(text, source, is_new)
 
     def _save_images(self, message_id: str, images: list[dict]) -> list[str]:
         """Decode base64 images to workspace files (for the CLI handler).

--- a/agent/tests/test_chat_skill_injection.py
+++ b/agent/tests/test_chat_skill_injection.py
@@ -1,0 +1,105 @@
+"""Chat (claude_code/codex_cli) had NO skill/marketplace context injection at all —
+only a soft "use skill_search" hint the agent regularly ignored (#468). custom_llm
+chat already builds this into its own system prompt on the first message, so it
+must stay untouched to avoid a duplicated block.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class PrepareTextSkillInjectionTests(unittest.TestCase):
+    def _consumer(self):
+        from app.chat_consumer import ChatConsumer
+
+        return ChatConsumer(agent_id="agent-1")
+
+    def _new_session_handler(self):
+        handler = MagicMock()
+        handler.session_id = None
+        return handler
+
+    def _resumed_session_handler(self):
+        handler = MagicMock()
+        handler.session_id = "sess-123"
+        return handler
+
+    @patch("app.runner_hooks.get_marketplace_skill_suggestions", return_value="MARKETPLACE_BLOCK")
+    @patch("app.runner_hooks.get_skills_context", return_value="SKILLS_BLOCK")
+    @patch("app.runner_hooks.get_approval_rules_prefix", return_value="")
+    @patch("app.chat_consumer.settings")
+    def test_claude_code_new_session_gets_skill_context(
+        self, mock_settings, _rules, mock_skills_ctx, mock_marketplace
+    ):
+        mock_settings.agent_mode = "claude_code"
+        consumer = self._consumer()
+        result = consumer._prepare_text(
+            "Bau mir eine Webapp im Wizard-Style", None, "webapp", self._new_session_handler()
+        )
+        self.assertIn("SKILLS_BLOCK", result)
+        self.assertIn("MARKETPLACE_BLOCK", result)
+        mock_marketplace.assert_called_once_with("Bau mir eine Webapp im Wizard-Style"[:200])
+
+    @patch("app.runner_hooks.get_marketplace_skill_suggestions", return_value="MARKETPLACE_BLOCK")
+    @patch("app.runner_hooks.get_skills_context", return_value="SKILLS_BLOCK")
+    @patch("app.runner_hooks.get_approval_rules_prefix", return_value="")
+    @patch("app.chat_consumer.settings")
+    def test_codex_cli_new_session_gets_skill_context(
+        self, mock_settings, _rules, mock_skills_ctx, mock_marketplace
+    ):
+        mock_settings.agent_mode = "codex_cli"
+        consumer = self._consumer()
+        result = consumer._prepare_text("hi", None, "webapp", self._new_session_handler())
+        self.assertIn("SKILLS_BLOCK", result)
+        self.assertIn("MARKETPLACE_BLOCK", result)
+
+    @patch("app.runner_hooks.get_marketplace_skill_suggestions", return_value="MARKETPLACE_BLOCK")
+    @patch("app.runner_hooks.get_skills_context", return_value="SKILLS_BLOCK")
+    @patch("app.runner_hooks.get_approval_rules_prefix", return_value="")
+    @patch("app.chat_consumer.settings")
+    def test_custom_llm_not_double_injected(
+        self, mock_settings, _rules, mock_skills_ctx, mock_marketplace
+    ):
+        """LLMChatHandler already injects this into its own system prompt."""
+        mock_settings.agent_mode = "custom_llm"
+        consumer = self._consumer()
+        result = consumer._prepare_text("hi", None, "webapp", self._new_session_handler())
+        self.assertNotIn("SKILLS_BLOCK", result)
+        self.assertNotIn("MARKETPLACE_BLOCK", result)
+        mock_marketplace.assert_not_called()
+
+    @patch("app.runner_hooks.get_marketplace_skill_suggestions", return_value="MARKETPLACE_BLOCK")
+    @patch("app.runner_hooks.get_skills_context", return_value="SKILLS_BLOCK")
+    @patch("app.runner_hooks.get_approval_rules_prefix", return_value="")
+    @patch("app.chat_consumer.settings")
+    def test_resumed_session_not_reinjected(
+        self, mock_settings, _rules, mock_skills_ctx, mock_marketplace
+    ):
+        """Only inject once per session (on the first turn), not on every follow-up."""
+        mock_settings.agent_mode = "claude_code"
+        consumer = self._consumer()
+        result = consumer._prepare_text(
+            "follow-up message", None, "webapp", self._resumed_session_handler()
+        )
+        self.assertNotIn("SKILLS_BLOCK", result)
+        self.assertNotIn("MARKETPLACE_BLOCK", result)
+        mock_marketplace.assert_not_called()
+
+    @patch("app.runner_hooks.get_marketplace_skill_suggestions", return_value="MARKETPLACE_BLOCK")
+    @patch("app.runner_hooks.get_skills_context", return_value="SKILLS_BLOCK")
+    @patch("app.runner_hooks.get_approval_rules_prefix", return_value="")
+    @patch("app.chat_consumer.settings")
+    def test_telegram_new_session_also_gets_skill_context(
+        self, mock_settings, _rules, mock_skills_ctx, mock_marketplace
+    ):
+        mock_settings.agent_mode = "claude_code"
+        consumer = self._consumer()
+        result = consumer._prepare_text(
+            "hi", {"chat_id": 123}, "telegram", self._new_session_handler()
+        )
+        self.assertIn("SKILLS_BLOCK", result)
+        self.assertIn("MARKETPLACE_BLOCK", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orchestrator/app/api/ws.py
+++ b/orchestrator/app/api/ws.py
@@ -705,6 +705,18 @@ async def ws_agent_chat(websocket: WebSocket, agent_id: str, token: str | None =
                 _session["id"] = uuid.uuid4().hex[:12]
                 is_new_session = True
 
+            # Auto-inject skills for chat too — previously only the task path
+            # (task_router.py) did this, so a chat-only agent never picked up
+            # path/role-matched skill assignments (#468). Once per session,
+            # mirroring task_router.py's own best-effort try/except.
+            if is_new_session and text:
+                try:
+                    from app.services.skill_auto_injector import auto_inject_skills
+                    async with async_session_factory() as skill_db:
+                        await auto_inject_skills(skill_db, agent_id, text)
+                except Exception as e:
+                    logger.warning(f"Skill auto-injection failed for chat session {_session['id']}: {e}")
+
             # Generate message ID and push to agent's chat queue
             message_id = uuid.uuid4().hex[:12]
             _pending_message_ids.add(message_id)


### PR DESCRIPTION
## Summary
Chat sessions (`claude_code` / `codex_cli` modes) never received the skills/marketplace context injection that task execution already gets via `compose_prompt_bundle()` (see `agent_runner.py`, `codex_runner.py`). The agent only saw a soft "use skill_search" hint in chat and regularly ignored it, so chat responses looked worse than task responses.

- `agent/app/chat_consumer.py`: `_prepare_text` now injects `get_skills_context()` + `get_marketplace_skill_suggestions(text[:200])` once per new session, for `claude_code`/`codex_cli` chat modes. `custom_llm` is explicitly excluded since `LLMChatHandler` already builds this into its own system prompt on the first message — avoids a duplicated block.
- `orchestrator/app/api/ws.py`: calls `auto_inject_skills()` once per new websocket chat session (webapp/iOS), mirroring the existing call site in `task_router.py`, so chat-only agents also pick up DB-based path/role skill assignments.
- Added `agent/tests/test_chat_skill_injection.py` covering: claude_code new session, codex_cli new session, custom_llm not double-injected, resumed session not re-injected, and Telegram channel also gets context.

Scope: Telegram entry points for `auto_inject_skills` (orchestrator side) were intentionally left untouched in this PR to keep the change focused on the webapp/iOS path called out in the issue; the agent-side `chat_consumer.py` fix already covers Telegram chat uniformly since all channels share that code path.

Fixes #468

## Test plan
- [x] `python3 -m unittest tests.test_chat_skill_injection -v` — 5/5 pass
- [x] `python3 -m unittest discover -s tests -p "test_*.py"` in `agent/` — no regressions (pre-existing pytest-only tests unaffected, unrelated to this change)
- [x] `python3 -m py_compile agent/app/chat_consumer.py orchestrator/app/api/ws.py` — compiles cleanly
- [ ] Requires agent-image rebuild to take effect in running containers (`docker build ... ./agent && docker compose up --build -d`)