### PR TITLE
Fix #472: test ws.py chat auto_inject_skills guard

### DIFF
--- a/orchestrator/app/api/ws.py
+++ b/orchestrator/app/api/ws.py
@@ -119,6 +119,23 @@ async def ws_agent_logs(websocket: WebSocket, agent_id: str, token: str | None =
         pass
 
 
+async def _auto_inject_skills_for_chat(agent_id: str, text: str, is_new_session: bool, session_id: str) -> None:
+    """Best-effort skill auto-injection for a new chat session.
+
+    Mirrors the task path (task_router.py): only fires once per new session and
+    never lets an injection failure break the chat turn (#468, PR #471). The
+    auto_inject_skills import stays local to avoid a circular import at module load.
+    """
+    if not (is_new_session and text):
+        return
+    try:
+        from app.services.skill_auto_injector import auto_inject_skills
+        async with async_session_factory() as skill_db:
+            await auto_inject_skills(skill_db, agent_id, text)
+    except Exception as e:
+        logger.warning(f"Skill auto-injection failed for chat session {session_id}: {e}")
+
+
 @router.websocket("/agents/{agent_id}/chat")
 async def ws_agent_chat(websocket: WebSocket, agent_id: str, token: str | None = Query(None), ticket: str | None = Query(None), client_id: str | None = Query(None)):
     """Bidirectional WebSocket for chatting with an agent.
@@ -709,13 +726,7 @@ async def ws_agent_chat(websocket: WebSocket, agent_id: str, token: str | None =
             # (task_router.py) did this, so a chat-only agent never picked up
             # path/role-matched skill assignments (#468). Once per session,
             # mirroring task_router.py's own best-effort try/except.
-            if is_new_session and text:
-                try:
-                    from app.services.skill_auto_injector import auto_inject_skills
-                    async with async_session_factory() as skill_db:
-                        await auto_inject_skills(skill_db, agent_id, text)
-                except Exception as e:
-                    logger.warning(f"Skill auto-injection failed for chat session {_session['id']}: {e}")
+            await _auto_inject_skills_for_chat(agent_id, text, is_new_session, _session["id"])
 
             # Generate message ID and push to agent's chat queue
             message_id = uuid.uuid4().hex[:12]

--- a/orchestrator/tests/test_ws_chat_skill_injection.py
+++ b/orchestrator/tests/test_ws_chat_skill_injection.py
@@ -1,0 +1,65 @@
+"""Tests for the chat-websocket skill auto-injection guard (issue #472, PR #471 W1).
+
+Covers ``_auto_inject_skills_for_chat`` in app/api/ws.py — the seam that mirrors
+the task path (task_router.py) so a chat-only agent also picks up path/role-matched
+skills (#468). It must inject exactly once per NEW session and never let an
+injection failure break the chat turn.
+"""
+import unittest
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.api import ws
+
+
+def _patch_session_factory():
+    """Patch async_session_factory so ``async with ... as skill_db`` yields a mock."""
+    skill_db = AsyncMock()
+
+    @asynccontextmanager
+    async def _factory():
+        yield skill_db
+
+    return patch.object(ws, "async_session_factory", _factory), skill_db
+
+
+class AutoInjectSkillsForChatTests(unittest.IsolatedAsyncioTestCase):
+    async def test_new_session_injects_once(self):
+        inject = AsyncMock(return_value=[{"skill_id": 1, "skill_name": "x", "assigned_by": "auto:path"}])
+        sess_patch, _ = _patch_session_factory()
+        with patch("app.services.skill_auto_injector.auto_inject_skills", inject), sess_patch:
+            await ws._auto_inject_skills_for_chat("agent-1", "Fix /app/models/user.py", True, "sess123")
+        inject.assert_awaited_once()
+        # agent_id and prompt text are forwarded to the injector
+        args = inject.await_args.args
+        self.assertEqual(args[1], "agent-1")
+        self.assertEqual(args[2], "Fix /app/models/user.py")
+
+    async def test_resumed_session_does_not_reinject(self):
+        inject = AsyncMock()
+        sess_patch, _ = _patch_session_factory()
+        with patch("app.services.skill_auto_injector.auto_inject_skills", inject), sess_patch:
+            await ws._auto_inject_skills_for_chat("agent-1", "hello again", False, "sess123")
+        inject.assert_not_awaited()
+
+    async def test_empty_text_does_not_inject(self):
+        inject = AsyncMock()
+        sess_patch, _ = _patch_session_factory()
+        with patch("app.services.skill_auto_injector.auto_inject_skills", inject), sess_patch:
+            await ws._auto_inject_skills_for_chat("agent-1", "", True, "sess123")
+        inject.assert_not_awaited()
+
+    async def test_injection_exception_is_swallowed_and_logged(self):
+        inject = AsyncMock(side_effect=RuntimeError("db down"))
+        sess_patch, _ = _patch_session_factory()
+        with patch("app.services.skill_auto_injector.auto_inject_skills", inject), sess_patch, \
+                patch.object(ws.logger, "warning") as warn:
+            # Must NOT raise — a failed injection may never break the chat turn.
+            await ws._auto_inject_skills_for_chat("agent-1", "Fix /app/x.py", True, "sess123")
+        inject.assert_awaited_once()
+        warn.assert_called_once()
+        self.assertIn("sess123", warn.call_args.args[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #472 (W1 follow-up from PR #471 / #468).

## Problem
The chat-websocket skill auto-injection block in `ws_agent_chat` (added in PR #471 so a chat-only agent also picks up path/role-matched skills, #468) had **no tests** — CodeReview flagged this as non-blocking W1.

## Change
- **Refactor (behavior-preserving):** extract the inline `if is_new_session and text: try/except` block into a module-level `_auto_inject_skills_for_chat(agent_id, text, is_new_session, session_id)` helper in `orchestrator/app/api/ws.py`. The `auto_inject_skills` import stays local to the helper to avoid the circular import (CodeReview W2 note).
- **Tests:** `orchestrator/tests/test_ws_chat_skill_injection.py` (4 cases, `IsolatedAsyncioTestCase`):
  - new session + text → `auto_inject_skills` awaited once, agent_id + prompt forwarded
  - resumed session (`is_new_session=False`) → not called
  - empty text → not called
  - injector raises → exception swallowed, `logger.warning` called with the session id (chat turn never breaks)

## Verification
Ran the new file + existing `test_skill_auto_injector.py` in a venv: **16 passed**. `app.api.ws` imports cleanly.

No runtime behavior change — self-mergeable test/refactor, not touching the live chat data path semantics.