### PR TITLE
fix(agent): expose desktop bridge to codex tools

### DIFF
--- a/agent/app/codex_runner.py
+++ b/agent/app/codex_runner.py
@@ -433,6 +433,7 @@ def _ensure_codex_mcp_config(codex_home: str, env: dict) -> None:
         "memory": "/opt/mcp/memory-server.mjs",
         "notification": "/opt/mcp/notification-server.mjs",
         "orchestrator": "/opt/mcp/orchestrator-server.mjs",
+        "desktop": "/opt/mcp/computer-use-server.mjs",
         "read_logs": "/opt/mcp/read-logs-server.mjs",
     }
 

--- a/agent/app/llm_chat_handler.py
+++ b/agent/app/llm_chat_handler.py
@@ -38,6 +38,7 @@ CORE_TOOL_NAMES = {
     "bash", "read_file", "write_file", "edit_file", "multi_edit",
     "list_files", "grep", "glob", "git_status", "git_diff",
     "web_search", "web_fetch",
+    "computer_use",
     "request_approval", "notify_user", "send_message_and_wait",
     "memory_save", "memory_search", "brain_search", "secondbrain_search",
     "list_todos", "complete_todo", "update_todos",

--- a/agent/app/runner_hooks.py
+++ b/agent/app/runner_hooks.py
@@ -54,6 +54,15 @@ Kalender / Teams / OneDrive / Planner, ein Integrations- oder weiteres Skill-Too
 werden dann im nächsten Schritt aufrufbar. Behaupte NIE, ein Tool sei „nicht verfügbar", ohne
 vorher `search_tools` probiert zu haben.
 
+🖥️ COMPUTER-USE-BRIDGE VS. SERVERSEITIGER BROWSER:
+Wenn der Nutzer von seinem Bildschirm, seinem Browser, einer internen URL, Navigation im Browser,
+Klicken/Tippen auf seinem Rechner oder einem Screenshot dessen spricht, was er gerade sieht, nutze
+die Computer-Use-Bridge (`computer_*` bzw. `computer_use`) auf dem Rechner des Nutzers. Nutze dafuer
+nicht `bash`, `curl`, `web_search` oder einen agent-browser-/Playwright-Skill im Agent-Container.
+Wenn die Bridge nicht verbunden ist oder eine Capability fehlt, melde genau diesen Fehler und wechsle
+nicht still auf einen serverseitigen Browser. Beschreibe niemals einen Bildschirm, wenn der Bridge-
+Screenshot fehlgeschlagen ist.
+
 🔐 AUTONOMY WHITELIST (NON-NEGOTIABLE):
 Your autonomy level defines what you may do freely. ANYTHING outside your whitelist requires
 calling `request_approval` BEFORE acting. The whitelist is injected below under

--- a/agent/app/tools/api_client.py
+++ b/agent/app/tools/api_client.py
@@ -5,12 +5,14 @@ with direct API calls for custom_llm agents.
 """
 
 import asyncio
+import json
 import logging
 import time
 from typing import Any
 
 import httpx
 
+from app import multimodal
 from app.config import settings
 
 logger = logging.getLogger(__name__)
@@ -93,6 +95,72 @@ class OrchestratorAPIClient:
             status = a.get("state") or a.get("status", "unknown")
             lines.append(f"- {a.get('name', '?')} (id: {a.get('id')}, role: {a.get('role', 'none')}, status: {status})")
         return "\n".join(lines)
+
+    async def computer_use(self, params: dict) -> str:
+        """Control the user's desktop through the Computer-Use Bridge.
+
+        This mirrors the Claude-Code `desktop` MCP capability for custom-LLM/Codex
+        agents, using the same orchestrator endpoints and server-side authz.
+        """
+        action = str(params.get("action") or "").strip()
+        if not action:
+            return "Error: action is required"
+
+        if action == "list_sessions":
+            result = await self._request("GET", "/computer-use/sessions")
+            if isinstance(result, str):
+                return result
+            sessions = result.get("sessions", [])
+            if not sessions:
+                return (
+                    "No active bridge sessions. Ask the user to open the AI-Employee "
+                    "Computer-Use tab and start the Desktop Bridge app."
+                )
+            lines = [f"Found {len(sessions)} bridge session(s):"]
+            for s in sessions:
+                status = s.get("status") or "unknown"
+                caps = ", ".join(s.get("allowed_capabilities") or [])
+                assigned = s.get("agent_id") or "any"
+                lines.append(
+                    f"  session_id={s.get('session_id')} status={status} "
+                    f"platform={s.get('platform', 'unknown')} assigned_agent={assigned}"
+                )
+                if caps:
+                    lines.append(f"    capabilities: {caps}")
+            return "\n".join(lines)
+
+        session_id = str(params.get("session_id") or "").strip()
+        if not session_id:
+            return "Error: session_id is required. Call computer_use(action='list_sessions') first."
+
+        timeout = params.get("timeout", 15)
+        try:
+            timeout_value = max(1.0, min(float(timeout), 60.0))
+        except (TypeError, ValueError):
+            timeout_value = 15.0
+
+        result = await self._request(
+            "POST",
+            f"/computer-use/sessions/{session_id}/command",
+            json={
+                "action": action,
+                "params": params.get("params") or {},
+                "timeout": timeout_value,
+            },
+        )
+        if isinstance(result, str):
+            return result
+
+        payload = result.get("result", result)
+        if action == "screenshot" and isinstance(payload, dict):
+            if payload.get("screenshot_b64"):
+                return multimodal.IMAGE_SENTINEL + json.dumps({
+                    "media_type": "image/png",
+                    "data": payload["screenshot_b64"],
+                    "note": "Screenshot captured from the user's desktop.",
+                })
+            return "Error: screenshot did not return image data"
+        return json.dumps(payload, ensure_ascii=False)
 
     async def list_agent_messages(self, params: dict) -> str:
         """List recent inter-agent messages involving this agent."""

--- a/agent/app/tools/definitions.py
+++ b/agent/app/tools/definitions.py
@@ -407,6 +407,54 @@ LOCAL_TOOLS.extend(get_skill_tool_definitions())
 # ── Orchestrator API Tools (replicate MCP server functionality) ──
 
 ORCHESTRATOR_TOOLS: list[dict] = [
+    # ── Computer-Use Desktop Bridge ──
+    {
+        "type": "function",
+        "function": {
+            "name": "computer_use",
+            "description": (
+                "Control the user's real desktop through the AI-Employee Desktop Bridge. "
+                "Use this when the user asks to open a URL or app on their computer, "
+                "navigate in their browser, click/type on their screen, or take a screenshot "
+                "of what they are seeing. Do not use bash, curl, web_search, or an agent-browser "
+                "skill for the user's own screen or internal/company URLs. First call "
+                "action='list_sessions'; then use the connected session_id for actions. If the "
+                "bridge or a capability is unavailable, report that error instead of switching "
+                "to a server-side browser."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "description": (
+                            "Action to perform. Special: 'list_sessions'. Desktop actions: "
+                            "'screenshot', 'mouse_click', 'mouse_move', 'mouse_scroll', "
+                            "'type', 'key', 'hotkey', 'open_app', 'close_app', "
+                            "'clipboard_read', 'clipboard_write', 'shell_run', 'ax_tree'."
+                        ),
+                    },
+                    "session_id": {
+                        "type": "string",
+                        "description": "Bridge session ID returned by action='list_sessions'. Required for all desktop actions.",
+                    },
+                    "params": {
+                        "type": "object",
+                        "description": (
+                            "Action parameters. Examples: screenshot {scale: 0.5}; "
+                            "mouse_click {x: 100, y: 200, button: 'left'}; type {text: 'https://example.com'}; "
+                            "key {key: 'enter'}; hotkey {keys: ['ctrl', 'l']}; open_app {name: 'Edge'}."
+                        ),
+                    },
+                    "timeout": {
+                        "type": "number",
+                        "description": "Timeout in seconds for bridge actions (default 15, max enforced by server/client).",
+                    },
+                },
+                "required": ["action"],
+            },
+        },
+    },
     # ── Task Management (orchestrator-server.mjs) ──
     {
         "type": "function",

--- a/agent/mcp/computer-use-server.mjs
+++ b/agent/mcp/computer-use-server.mjs
@@ -320,7 +320,10 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
             ],
           };
         }
-        break;
+        return {
+          content: [{ type: "text", text: `Error: screenshot did not return image data: ${JSON.stringify(result)}` }],
+          isError: true,
+        };
 
       case "computer_ax_tree":
         result = await sendCommand("ax_tree", {

--- a/agent/tests/test_computer_use_tool.py
+++ b/agent/tests/test_computer_use_tool.py
@@ -1,0 +1,141 @@
+"""Regression tests for issue #475: custom-LLM/Codex agents must see and execute
+the Desktop Bridge tool instead of being forced toward server-side browser/bash
+fallbacks."""
+
+import json
+
+import pytest
+
+from app import codex_runner
+from app import multimodal
+from app.llm_chat_handler import CORE_TOOL_NAMES
+from app.tools.api_client import OrchestratorAPIClient
+from app.tools.definitions import ORCHESTRATOR_TOOL_NAMES, TOOL_DEFINITIONS
+
+
+def _tool(name: str) -> dict:
+    return next(t for t in TOOL_DEFINITIONS if t["function"]["name"] == name)
+
+
+def test_computer_use_is_core_orchestrator_tool():
+    assert "computer_use" in ORCHESTRATOR_TOOL_NAMES
+    assert "computer_use" in CORE_TOOL_NAMES
+
+    description = _tool("computer_use")["function"]["description"]
+    assert "user's real desktop" in description
+    assert "server-side browser" in description
+    assert "internal/company URLs" in description
+
+
+@pytest.mark.asyncio
+async def test_computer_use_lists_sessions(monkeypatch):
+    client = OrchestratorAPIClient()
+    calls = []
+
+    async def fake_request(method, path, json=None, params=None):
+        calls.append((method, path, json, params))
+        return {
+            "sessions": [{
+                "session_id": "s1",
+                "status": "connected",
+                "platform": "windows",
+                "agent_id": None,
+                "allowed_capabilities": ["screenshots", "mouse"],
+            }]
+        }
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = await client.computer_use({"action": "list_sessions"})
+
+    assert calls == [("GET", "/computer-use/sessions", None, None)]
+    assert "session_id=s1" in result
+    assert "status=connected" in result
+    assert "screenshots, mouse" in result
+
+
+@pytest.mark.asyncio
+async def test_computer_use_requires_session_for_actions():
+    client = OrchestratorAPIClient()
+
+    result = await client.computer_use({"action": "screenshot"})
+
+    assert result == "Error: session_id is required. Call computer_use(action='list_sessions') first."
+
+
+@pytest.mark.asyncio
+async def test_computer_use_sends_command(monkeypatch):
+    client = OrchestratorAPIClient()
+    calls = []
+
+    async def fake_request(method, path, json=None, params=None):
+        calls.append((method, path, json, params))
+        return {"result": {"ok": True}}
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = await client.computer_use({
+        "action": "mouse_click",
+        "session_id": "s1",
+        "params": {"x": 10, "y": 20},
+        "timeout": 3,
+    })
+
+    assert calls == [(
+        "POST",
+        "/computer-use/sessions/s1/command",
+        {"action": "mouse_click", "params": {"x": 10, "y": 20}, "timeout": 3.0},
+        None,
+    )]
+    assert json.loads(result) == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_computer_use_screenshot_returns_presentable_image(monkeypatch):
+    client = OrchestratorAPIClient()
+
+    async def fake_request(method, path, json=None, params=None):
+        return {"result": {"screenshot_b64": "abc123"}}
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = await client.computer_use({"action": "screenshot", "session_id": "s1"})
+
+    assert result.startswith(multimodal.IMAGE_SENTINEL)
+    payload = multimodal.parse_image_result(result)
+    assert payload == {
+        "media_type": "image/png",
+        "data": "abc123",
+        "note": "Screenshot captured from the user's desktop.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_computer_use_screenshot_without_image_is_error(monkeypatch):
+    client = OrchestratorAPIClient()
+
+    async def fake_request(method, path, json=None, params=None):
+        return {"result": {"ok": False, "error": "screenshots disabled"}}
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = await client.computer_use({"action": "screenshot", "session_id": "s1"})
+
+    assert result == "Error: screenshot did not return image data"
+    assert not result.startswith(multimodal.IMAGE_SENTINEL)
+
+
+def test_codex_config_includes_desktop_mcp(tmp_path, monkeypatch):
+    monkeypatch.setattr(codex_runner.os.path, "exists", lambda path: True)
+    env = {
+        "ORCHESTRATOR_URL": "http://orchestrator:8000",
+        "AGENT_ID": "agent-1",
+        "AGENT_TOKEN": "token",
+    }
+
+    codex_runner._ensure_codex_mcp_config(str(tmp_path), env)
+
+    config = (tmp_path / "config.toml").read_text()
+    assert "[mcp_servers.desktop]" in config
+    assert 'args = ["/opt/mcp/computer-use-server.mjs"]' in config
+    assert 'AGENT_ID = "agent-1"' in config

--- a/orchestrator/app/api/mcp_agent.py
+++ b/orchestrator/app/api/mcp_agent.py
@@ -487,6 +487,8 @@ async def _call_tool(name: str, args: dict, agent: Agent, db: AsyncSession, redi
             result = await _asyncio.wait_for(result_future, timeout=args.get("timeout", 15.0))
             if action == "screenshot":
                 b64 = result.get("screenshot_b64", "")
+                if not b64:
+                    return _tool_result("Error: screenshot did not return image data", is_error=True)
                 return {"content": [{"type": "image", "data": b64, "mimeType": "image/png"}]}
             return _tool_result(json.dumps(result, ensure_ascii=False))
         except _asyncio.TimeoutError:


### PR DESCRIPTION
## Summary
- expose a first-class `computer_use` tool to custom-LLM/Codex agents and keep it in the core tool set
- route that tool through the existing `/computer-use` session and command APIs, preserving server-side ownership, agent assignment, and capability checks
- add Bridge-vs-server-browser guidance to task prompts and Codex desktop MCP registration
- make screenshot failures explicit when no image data is returned

## Investigation
- Claude-Code already registers the `desktop` MCP server and exposes `computer_*` tools.
- `agent-browser` marketplace wording strongly matches customer phrases like opening a website and taking screenshots, so guidance was needed.
- Voice/realtime voice delegates to the container agent, where custom-LLM/Codex uses `TOOL_DEFINITIONS`; that catalog had no Computer-Use bridge tool, so affected agents could only fall back to bash/server-side browser behavior.

Fixes #475

## Validation
- `python -m py_compile agent/app/codex_runner.py agent/app/llm_chat_handler.py agent/app/runner_hooks.py agent/app/tools/api_client.py agent/app/tools/definitions.py agent/tests/test_computer_use_tool.py orchestrator/app/api/mcp_agent.py`
- `node --check agent/mcp/computer-use-server.mjs`
- `PYTHONPATH=/workspace/AI-Employee-issue475/agent /tmp/ai-employee-issue475-venv/bin/python -m pytest agent/tests/test_computer_use_tool.py agent/tests/test_openai_responses_tool_args.py -q` -> 10 passed
