### PR TITLE
Phase 1 of #488: periodically refresh OAuth-MCP tokens

### DIFF
--- a/orchestrator/app/main.py
+++ b/orchestrator/app/main.py
@@ -225,7 +225,7 @@ async def _refresh_mcp_oauth_tokens() -> None:
             async with async_session_factory() as db:
                 await refresh_all_oauth_servers(db)
         except Exception:
-            pass
+            logger.exception("MCP OAuth periodic sweep failed; will retry in 5 min")
         await asyncio.sleep(300)  # Check every 5 minutes
 
 

--- a/orchestrator/app/main.py
+++ b/orchestrator/app/main.py
@@ -209,6 +209,26 @@ async def _refresh_oauth_tokens(redis: RedisService) -> None:
         await asyncio.sleep(300)  # Check every 5 minutes
 
 
+async def _refresh_mcp_oauth_tokens() -> None:
+    """Keep OAuth-protected MCP server tokens fresh on a timer (#488).
+
+    ``refresh_if_needed`` previously ran only while building a new agent container,
+    so a stored MCP access token expired within ~1h and every agent lost the server
+    until recreated. This periodic sweep keeps the persisted token valid; the
+    per-server advisory lock (#462) makes it safe to run alongside agent startup.
+    """
+    while True:
+        try:
+            from app.db.session import async_session_factory
+            from app.services.mcp_oauth_refresh import refresh_all_oauth_servers
+
+            async with async_session_factory() as db:
+                await refresh_all_oauth_servers(db)
+        except Exception:
+            pass
+        await asyncio.sleep(300)  # Check every 5 minutes
+
+
 async def _refresh_claude_token() -> None:
     """Background task that manages the Claude OAuth token lifecycle.
 
@@ -1635,6 +1655,9 @@ clean Markdown; you don't need to commit.
     # Start third-party OAuth token refresh background task
     oauth_refresh_task = asyncio.create_task(_refresh_oauth_tokens(app.state.redis))
 
+    # Start OAuth-protected MCP server token refresh background task (#488)
+    mcp_oauth_refresh_task = asyncio.create_task(_refresh_mcp_oauth_tokens())
+
     # Start Claude Code OAuth token refresh background task
     claude_token_task = asyncio.create_task(_refresh_claude_token())
 
@@ -1721,6 +1744,7 @@ clean Markdown; you don't need to commit.
     chat_persist_task.cancel()
     step_persist_task.cancel()
     oauth_refresh_task.cancel()
+    mcp_oauth_refresh_task.cancel()
     claude_token_task.cancel()
     scheduler_task.cancel()
     skill_crawler_task.cancel()

--- a/orchestrator/app/services/mcp_oauth_refresh.py
+++ b/orchestrator/app/services/mcp_oauth_refresh.py
@@ -11,7 +11,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 
 import httpx
-from sqlalchemy import text
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.encryption import decrypt_token, encrypt_token
@@ -186,6 +186,36 @@ async def refresh_if_needed(server: McpServer, db: AsyncSession) -> bool:
             logger.warning("Could not persist refreshed MCP token for server %s", server.name)
             return bool(server.auth_token_encrypted)
         return True
+
+
+async def refresh_all_oauth_servers(db: AsyncSession) -> int:
+    """Refresh every OAuth-enabled MCP server whose access token is (near) expired.
+
+    Intended for a periodic background sweep (#488). Before this, ``refresh_if_needed``
+    ran at exactly one moment — while building the environment for a new agent
+    container — so a stored access token expired within roughly an hour and every
+    agent lost the server until its container was recreated. Running this on a timer
+    keeps the persisted token valid so freshly created and restarted agents receive
+    a live token.
+
+    ``refresh_if_needed`` is a no-op for a server whose token is still valid and
+    never raises, so this is cheap to run often. It commits per server (releasing
+    the per-server advisory lock each time), which is safe alongside agent startup.
+    Returns the number of servers holding a usable token after the sweep.
+    """
+    result = await db.execute(select(McpServer).where(McpServer.oauth_enabled.is_(True)))
+    servers = result.scalars().all()
+    usable = 0
+    for server in servers:
+        try:
+            if await refresh_if_needed(server, db):
+                usable += 1
+        except Exception as exc:  # noqa: BLE001 — one bad server must not abort the sweep
+            logger.warning(
+                "MCP OAuth sweep: refresh raised for server %s: %s",
+                getattr(server, "name", "?"), exc,
+            )
+    return usable
 
 
 async def _release(db: AsyncSession) -> None:

--- a/orchestrator/app/services/mcp_oauth_refresh.py
+++ b/orchestrator/app/services/mcp_oauth_refresh.py
@@ -215,6 +215,7 @@ async def refresh_all_oauth_servers(db: AsyncSession) -> int:
                 "MCP OAuth sweep: refresh raised for server %s: %s",
                 getattr(server, "name", "?"), exc,
             )
+            await db.rollback()
     return usable
 
 

--- a/orchestrator/tests/test_mcp_oauth_refresh_sweep.py
+++ b/orchestrator/tests/test_mcp_oauth_refresh_sweep.py
@@ -1,0 +1,80 @@
+"""Tests for issue #488: periodic sweep that refreshes OAuth-MCP tokens on a timer.
+
+Before #488 ``refresh_if_needed`` ran only while building a new agent container, so
+a stored access token expired within ~1h and every agent lost the server until it
+was recreated. ``refresh_all_oauth_servers`` iterates the ``oauth_enabled`` servers
+and refreshes each, so the persisted token stays valid between container creations.
+"""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.models.mcp_server import McpServer
+from app.services import mcp_oauth_refresh as mor
+
+
+def _server(server_id: int, name: str) -> McpServer:
+    s = McpServer()
+    s.id = server_id
+    s.name = name
+    s.oauth_enabled = True
+    return s
+
+
+def _session_returning(servers) -> AsyncMock:
+    """An AsyncMock session whose execute(...).scalars().all() yields ``servers``."""
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = servers
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+class RefreshAllOAuthServersTests(unittest.IsolatedAsyncioTestCase):
+    async def test_calls_refresh_if_needed_for_every_server_and_counts_usable(self):
+        servers = [_server(1, "a"), _server(2, "b"), _server(3, "c")]
+        db = _session_returning(servers)
+
+        # b fails to refresh (returns False), a and c succeed.
+        results = {1: True, 2: False, 3: True}
+
+        async def _fake_refresh(server, session):
+            assert session is db
+            return results[server.id]
+
+        with patch.object(mor, "refresh_if_needed", side_effect=_fake_refresh) as rin:
+            usable = await mor.refresh_all_oauth_servers(db)
+
+        assert usable == 2
+        assert rin.await_count == 3
+        called_ids = sorted(c.args[0].id for c in rin.await_args_list)
+        assert called_ids == [1, 2, 3]
+
+    async def test_only_selects_oauth_enabled_servers(self):
+        db = _session_returning([])
+        with patch.object(mor, "refresh_if_needed", new=AsyncMock()):
+            await mor.refresh_all_oauth_servers(db)
+        db.execute.assert_awaited_once()
+        # The WHERE clause must filter on oauth_enabled so non-OAuth servers are skipped.
+        sql = str(db.execute.await_args.args[0]).lower()
+        assert "oauth_enabled" in sql
+
+    async def test_one_failing_server_does_not_abort_the_sweep(self):
+        servers = [_server(1, "a"), _server(2, "boom"), _server(3, "c")]
+        db = _session_returning(servers)
+
+        async def _fake_refresh(server, session):
+            if server.id == 2:
+                raise RuntimeError("unexpected explosion")
+            return True
+
+        with patch.object(mor, "refresh_if_needed", side_effect=_fake_refresh) as rin:
+            usable = await mor.refresh_all_oauth_servers(db)
+
+        # server 2 raised, but 1 and 3 were still refreshed and counted.
+        assert usable == 2
+        assert rin.await_count == 3
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem (#488)
`refresh_if_needed` had exactly one caller — `_get_custom_mcp_env` at agent-container creation. So a stored OAuth-MCP access token (lifetime ~1–2h) expired within the hour and every agent lost the server until its container was recreated, even though a valid refresh token was present. Nobody ever asked for the refresh.

## This PR (Phase 1: keep the stored token valid on a timer)
- **`refresh_all_oauth_servers(db)`** in `mcp_oauth_refresh.py` — selects all `oauth_enabled` MCP servers and calls the existing `refresh_if_needed` on each. It's a no-op for still-valid tokens and never aborts the sweep on a single bad server.
- **`_refresh_mcp_oauth_tokens()`** background task in `main.py` — 5-minute cadence, mirrors the existing `_refresh_oauth_tokens` third-party sweep. Registered and cancelled alongside the other lifespan tasks.
- The per-server advisory lock from #462 makes this safe to run concurrently with agent startup.

## Not in this PR (Phase 2 — stays open in #488)
A running agent still holds `CUSTOM_MCP_AUTH` as an env var captured at container creation, which cannot change in a live container. Giving running agents the rotated token (re-fetch + `claude mcp add --header`, or an orchestrator-side header-injecting proxy) is a larger change and remains tracked in #488.

## Tests
`tests/test_mcp_oauth_refresh_sweep.py` (3 new): every server refreshed + usable count; WHERE filters on `oauth_enabled`; one failing server doesn't abort the sweep. All 10 tests in the two refresh suites pass.

Refs #488