### PR TITLE
fix(workflows): validate imports and bridge tool surface

### DIFF
--- a/agent/app/codex_runner.py
+++ b/agent/app/codex_runner.py
@@ -14,6 +14,7 @@ from typing import AsyncIterator
 
 from app.config import settings
 from app.log_publisher import LogPublisher
+from app.llm_chat_handler import DESKTOP_MCP_ACTIVE_ENV
 from app.runner_hooks import (
     SELF_IMPROVEMENT_SUFFIX,
     compose_prompt_bundle,
@@ -385,7 +386,9 @@ class CodexChatHandler:
 def _codex_env() -> dict[str, str]:
     env = os.environ.copy()
     codex_home = env.setdefault("CODEX_HOME", "/home/agent/.codex")
-    _ensure_codex_mcp_config(codex_home, env)
+    desktop_mcp_active = _ensure_codex_mcp_config(codex_home, env)
+    env[DESKTOP_MCP_ACTIVE_ENV] = "1" if desktop_mcp_active else "0"
+    os.environ[DESKTOP_MCP_ACTIVE_ENV] = env[DESKTOP_MCP_ACTIVE_ENV]
     return env
 
 
@@ -406,7 +409,7 @@ def _valid_http_url(url: str) -> bool:
         return False
 
 
-def _ensure_codex_mcp_config(codex_home: str, env: dict) -> None:
+def _ensure_codex_mcp_config(codex_home: str, env: dict) -> bool:
     """Write ~/.codex/config.toml with built-in + custom MCP servers.
 
     Called once per Codex invocation. Idempotent — overwrites the server
@@ -443,10 +446,14 @@ def _ensure_codex_mcp_config(codex_home: str, env: dict) -> None:
         "",
     ]
 
+    desktop_mcp_active = False
+
     # Stdio built-in servers
     for name, script in builtin_servers.items():
         if not os.path.exists(script):
             continue
+        if name == "desktop":
+            desktop_mcp_active = True
         # Codex only exposes the env vars declared in this [env] block to the
         # MCP server — it does NOT inherit the agent container's environment.
         # The built-in servers authenticate to the orchestrator with the agent
@@ -507,6 +514,7 @@ def _ensure_codex_mcp_config(codex_home: str, env: dict) -> None:
     finally:
         os.close(fd)
     logger.debug("Written Codex MCP config to %s (%d built-in servers)", config_path, len(builtin_servers))
+    return desktop_mcp_active
 
 
 async def _publish(

--- a/agent/app/llm_chat_handler.py
+++ b/agent/app/llm_chat_handler.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import os
 import time
 
 from app import context_compressor, model_registry, multimodal
@@ -48,6 +49,14 @@ CORE_TOOL_NAMES = {
     "skill_search", "skill_install", "skill_rate", "skill_propose", "rate_task",
 }
 MAX_ACTIVATED_TOOLS = 60  # core (~27) + search_tools + activated stays well under 128
+DESKTOP_MCP_ACTIVE_ENV = "AI_EMPLOYEE_DESKTOP_MCP_ACTIVE"
+
+
+def _core_tool_names() -> set[str]:
+    names = set(CORE_TOOL_NAMES)
+    if os.environ.get(DESKTOP_MCP_ACTIVE_ENV) == "1":
+        names.discard("computer_use")
+    return names
 
 # Integration tools that must ALWAYS be sent to the LLM — never hidden behind
 # search_tools and never evicted by the LRU. These are the most common M365 asks
@@ -269,10 +278,11 @@ class LLMChatHandler:
         # instead of searching (the "mal da / mal nicht" flakiness). Capped to
         # leave headroom for on-demand search_tools activations under the 128 limit.
         if not self._activated:
+            core_names = _core_tool_names()
             mcp_names = [
                 t["function"]["name"] for t in catalog
                 if str(t.get("function", {}).get("name", "")).startswith("mcp_")
-                and t["function"]["name"] not in CORE_TOOL_NAMES
+                and t["function"]["name"] not in core_names
             ]
             if mcp_names:
                 self._activated = mcp_names[: max(1, MAX_ACTIVATED_TOOLS - 15)]
@@ -287,13 +297,14 @@ class LLMChatHandler:
             return None
         catalog = await self._get_catalog()
         active = set(self._activated)
-        sent = [t for t in catalog if t["function"]["name"] in CORE_TOOL_NAMES]
+        core_names = _core_tool_names()
+        sent = [t for t in catalog if t["function"]["name"] in core_names]
         sent.append(SEARCH_TOOLS_DEF)
         sent_names = {t["function"]["name"] for t in sent}
         # Always-pinned integration tools (people/mail/search) — no discovery needed.
         for t in catalog:
             n = t["function"]["name"]
-            if n not in sent_names and n not in CORE_TOOL_NAMES and _is_pinned(n):
+            if n not in sent_names and n not in core_names and _is_pinned(n):
                 sent.append(t)
                 sent_names.add(n)
         # Everything the model activated via search_tools (minus what's already sent).
@@ -303,7 +314,7 @@ class LLMChatHandler:
 
     def _handle_search_tools(self, query: str) -> str:
         """Search the catalog and activate the best matches for the next turn."""
-        matches = _search_catalog(self._all_tools or [], query, CORE_TOOL_NAMES | {"search_tools"})
+        matches = _search_catalog(self._all_tools or [], query, _core_tool_names() | {"search_tools"})
         if not matches:
             return f"Keine passenden Tools für '{query}' gefunden. Versuch andere Stichwörter."
         lines = []

--- a/agent/app/llm_runner.py
+++ b/agent/app/llm_runner.py
@@ -29,7 +29,7 @@ from app.tools.mcp_client import MCPHTTPClient
 # Lazy tool loading (shared with the chat handler) — keeps the per-request tool
 # array under the 128-tool cap that OpenAI/Azure enforce.
 from app.llm_chat_handler import (
-    CORE_TOOL_NAMES, SEARCH_TOOLS_DEF, MAX_ACTIVATED_TOOLS, _search_catalog,
+    SEARCH_TOOLS_DEF, MAX_ACTIVATED_TOOLS, _core_tool_names, _search_catalog,
 )
 
 logger = logging.getLogger(__name__)
@@ -121,10 +121,11 @@ class LLMRunner:
         # always callable instead of only via search_tools — same reliability fix as
         # the chat handler. Capped to leave headroom under the 128-tool limit.
         if not self._activated:
+            core_names = _core_tool_names()
             mcp_names = [
                 t["function"]["name"] for t in self._all_tools
                 if str(t.get("function", {}).get("name", "")).startswith("mcp_")
-                and t["function"]["name"] not in CORE_TOOL_NAMES
+                and t["function"]["name"] not in core_names
             ]
             if mcp_names:
                 self._activated = mcp_names[: max(1, MAX_ACTIVATED_TOOLS - 15)]
@@ -140,15 +141,16 @@ class LLMRunner:
             return None
         catalog = await self._get_catalog()
         active = set(self._activated)
-        sent = [t for t in catalog if t["function"]["name"] in CORE_TOOL_NAMES]
+        core_names = _core_tool_names()
+        sent = [t for t in catalog if t["function"]["name"] in core_names]
         sent.append(SEARCH_TOOLS_DEF)
         sent += [t for t in catalog
-                 if t["function"]["name"] in active and t["function"]["name"] not in CORE_TOOL_NAMES]
+                 if t["function"]["name"] in active and t["function"]["name"] not in core_names]
         return sent
 
     def _handle_search_tools(self, query: str) -> str:
         """Search the catalog and activate the best matches for the next turn."""
-        matches = _search_catalog(self._all_tools or [], query, CORE_TOOL_NAMES | {"search_tools"})
+        matches = _search_catalog(self._all_tools or [], query, _core_tool_names() | {"search_tools"})
         if not matches:
             return f"Keine passenden Tools für '{query}' gefunden. Versuch andere Stichwörter."
         lines = []

--- a/agent/tests/test_computer_use_tool.py
+++ b/agent/tests/test_computer_use_tool.py
@@ -8,7 +8,8 @@ import pytest
 
 from app import codex_runner
 from app import multimodal
-from app.llm_chat_handler import CORE_TOOL_NAMES
+from app.llm_chat_handler import CORE_TOOL_NAMES, DESKTOP_MCP_ACTIVE_ENV, _core_tool_names
+from app.runner_hooks import TASK_STARTUP_PREFIX
 from app.tools.api_client import OrchestratorAPIClient
 from app.tools.definitions import ORCHESTRATOR_TOOL_NAMES, TOOL_DEFINITIONS
 
@@ -20,11 +21,29 @@ def _tool(name: str) -> dict:
 def test_computer_use_is_core_orchestrator_tool():
     assert "computer_use" in ORCHESTRATOR_TOOL_NAMES
     assert "computer_use" in CORE_TOOL_NAMES
+    assert "computer_use" in _core_tool_names()
 
     description = _tool("computer_use")["function"]["description"]
     assert "user's real desktop" in description
     assert "server-side browser" in description
     assert "internal/company URLs" in description
+
+
+def test_task_startup_prefix_contains_computer_use():
+    assert "computer_use" in TASK_STARTUP_PREFIX
+
+
+def test_computer_use_filtered_from_core_when_desktop_mcp_active(monkeypatch):
+    monkeypatch.setenv(DESKTOP_MCP_ACTIVE_ENV, "1")
+
+    assert "computer_use" not in _core_tool_names()
+    assert "computer_use" in CORE_TOOL_NAMES
+
+
+def test_computer_use_remains_core_without_desktop_mcp(monkeypatch):
+    monkeypatch.delenv(DESKTOP_MCP_ACTIVE_ENV, raising=False)
+
+    assert "computer_use" in _core_tool_names()
 
 
 @pytest.mark.asyncio
@@ -133,9 +152,22 @@ def test_codex_config_includes_desktop_mcp(tmp_path, monkeypatch):
         "AGENT_TOKEN": "token",
     }
 
-    codex_runner._ensure_codex_mcp_config(str(tmp_path), env)
+    desktop_mcp_active = codex_runner._ensure_codex_mcp_config(str(tmp_path), env)
 
     config = (tmp_path / "config.toml").read_text()
+    assert desktop_mcp_active is True
     assert "[mcp_servers.desktop]" in config
     assert 'args = ["/opt/mcp/computer-use-server.mjs"]' in config
     assert 'AGENT_ID = "agent-1"' in config
+
+
+def test_codex_env_marks_desktop_mcp_active(monkeypatch, tmp_path):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    monkeypatch.setenv("ORCHESTRATOR_URL", "http://orchestrator:8000")
+    monkeypatch.setenv("AGENT_ID", "agent-1")
+    monkeypatch.setenv("AGENT_TOKEN", "token")
+    monkeypatch.setattr(codex_runner.os.path, "exists", lambda path: path.endswith("computer-use-server.mjs"))
+
+    env = codex_runner._codex_env()
+
+    assert env[DESKTOP_MCP_ACTIVE_ENV] == "1"

--- a/orchestrator/app/api/workflows.py
+++ b/orchestrator/app/api/workflows.py
@@ -41,6 +41,10 @@ WORKFLOW_EXPORT_FORMAT = "ai-employee-workflow"
 WORKFLOW_EXPORT_VERSION = 1
 
 
+def _cron_shape_valid(expr: str) -> bool:
+    return len(expr.split()) == 5
+
+
 def _validate_definition(defn: dict) -> None:
     if not isinstance(defn, dict):
         raise HTTPException(status_code=400, detail="definition must be an object")
@@ -62,6 +66,29 @@ def _validate_definition(defn: dict) -> None:
         for r in refs:
             if r is not None and r not in ids:
                 raise HTTPException(status_code=400, detail=f"step '{sid}' references unknown step '{r}'")
+
+
+def _validate_trigger(trigger: dict | None) -> None:
+    """Validate workflow trigger config before create/import persists it."""
+    if trigger is None:
+        return
+    if not isinstance(trigger, dict):
+        raise HTTPException(status_code=422, detail="trigger must be an object")
+    cron = trigger.get("cron")
+    if cron is None:
+        return
+    if not isinstance(cron, str) or not cron.strip():
+        raise HTTPException(status_code=422, detail="trigger.cron must be a non-empty string")
+    try:
+        from croniter import croniter
+        if not croniter.is_valid(cron):
+            raise ValueError
+    except ImportError:
+        if _cron_shape_valid(cron):
+            return
+        raise HTTPException(status_code=422, detail="trigger.cron must be a valid cron expression")
+    except Exception:
+        raise HTTPException(status_code=422, detail="trigger.cron must be a valid cron expression")
 
 
 def _is_admin(user) -> bool:
@@ -207,6 +234,7 @@ async def list_workflows(user=Depends(require_auth), db: AsyncSession = Depends(
 @router.post("", status_code=201)
 async def create_workflow(body: WorkflowUpsert, user=Depends(require_auth), db: AsyncSession = Depends(get_db)):
     _validate_definition(body.definition)
+    _validate_trigger(body.trigger)
     await _assert_owns_folder(body.folder_id, user, db)
     wf = Workflow(
         id=f"wf_{uuid.uuid4().hex[:12]}", name=body.name, user_id=str(user.id),
@@ -243,6 +271,7 @@ async def import_workflow(body: WorkflowImport, user=Depends(require_auth), db: 
     if body.version is not None and body.version > WORKFLOW_EXPORT_VERSION:
         raise HTTPException(status_code=400, detail=f"Format-Version {body.version} wird nicht unterstützt")
     _validate_definition(body.definition)
+    _validate_trigger(body.trigger)
     await _assert_owns_folder(body.folder_id, user, db)
     name = (body.name or "").strip() or "Importierter Workflow"
     wf = Workflow(
@@ -392,6 +421,7 @@ async def export_workflow(workflow_id: str, user=Depends(require_auth), db: Asyn
 @router.put("/{workflow_id}")
 async def update_workflow(workflow_id: str, body: WorkflowUpsert, user=Depends(require_auth), db: AsyncSession = Depends(get_db)):
     _validate_definition(body.definition)
+    _validate_trigger(body.trigger)
     wf = await _get_wf(workflow_id, user, db, edit=True)
     # Re-parenting into a folder is owner-only and only into a folder you own — an
     # editor must not move a shared workflow (could leak it via a shared folder).

--- a/orchestrator/tests/test_api/test_workflow_import_export.py
+++ b/orchestrator/tests/test_api/test_workflow_import_export.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 from fastapi import HTTPException
 
 from app.api import workflows as wf_api
-from app.models.workflow import Workflow
+from app.models.workflow import Workflow, WorkflowFolder
 
 
 def _wf(name="Mein Workflow"):
@@ -31,6 +31,12 @@ def _db():
     return db
 
 
+def _db_result(value):
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = value
+    return result
+
+
 _VALID_DEF = {"start": "s1", "steps": {"s1": {"type": "agent_task", "title": "A", "prompt": "x", "next": None}}}
 
 
@@ -46,6 +52,23 @@ class ExportTests(unittest.TestCase):
         # Owner/folder/run state must NOT leak into a shared snapshot.
         for leak in ("user_id", "folder_id", "id", "role"):
             self.assertNotIn(leak, d)
+
+
+class ExportAuthzTests(unittest.IsolatedAsyncioTestCase):
+    async def test_export_rejects_workflow_owned_by_another_user(self):
+        workflow = _wf()
+        workflow.user_id = "user-a"
+        workflow.folder_id = None
+        db = _db()
+        db.execute = AsyncMock(side_effect=[
+            _db_result(workflow),  # _get_wf: workflow lookup
+            _db_result(None),      # _access_role: no direct workflow share
+        ])
+
+        with self.assertRaises(HTTPException) as ctx:
+            await wf_api.export_workflow("wf_abc123", user=MagicMock(id="user-b"), db=db)
+
+        self.assertEqual(ctx.exception.status_code, 403)
 
 
 class ImportTests(unittest.IsolatedAsyncioTestCase):
@@ -92,6 +115,39 @@ class ImportTests(unittest.IsolatedAsyncioTestCase):
                 user=MagicMock(id="u"), db=_db(),
             )
         self.assertEqual(ctx.exception.status_code, 400)
+
+    async def test_import_rejects_foreign_folder_id(self):
+        folder = WorkflowFolder(id="wff_foreign", name="A Folder", user_id="user-a")
+        db = _db()
+        db.execute = AsyncMock(return_value=_db_result(folder))
+
+        with self.assertRaises(HTTPException) as ctx:
+            await wf_api.import_workflow(
+                wf_api.WorkflowImport(
+                    definition=_VALID_DEF,
+                    name="Geteilt",
+                    trigger={"cron": "0 7 * * 1"},
+                    folder_id="wff_foreign",
+                ),
+                user=MagicMock(id="user-b"),
+                db=db,
+            )
+
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    async def test_import_rejects_invalid_cron_trigger(self):
+        with self.assertRaises(HTTPException) as ctx:
+            await wf_api.import_workflow(
+                wf_api.WorkflowImport(
+                    definition=_VALID_DEF,
+                    name="Kaputter Trigger",
+                    trigger={"cron": "not a cron"},
+                ),
+                user=MagicMock(id="u"),
+                db=_db(),
+            )
+
+        self.assertEqual(ctx.exception.status_code, 422)
 
 
 class RouteWiringTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add workflow import/export authz regression tests for foreign workflow export and foreign folder import
- centralize workflow trigger validation and reject invalid cron triggers during import/create/update
- filter the `computer_use` core tool when Codex detects an active Desktop Bridge MCP server, while preserving fallback behavior without MCP
- add regression coverage for `computer_use` in `TASK_STARTUP_PREFIX`

## Validation
- `python -m py_compile orchestrator/app/api/workflows.py agent/app/llm_chat_handler.py agent/app/llm_runner.py agent/app/codex_runner.py agent/app/runner_hooks.py agent/tests/test_computer_use_tool.py orchestrator/tests/test_api/test_workflow_import_export.py`
- `PYTHONPATH=agent /tmp/ai-employee-482-487-venv/bin/python -m pytest agent/tests/test_computer_use_tool.py`
- `PYTHONPATH=orchestrator /tmp/ai-employee-482-487-venv/bin/python -m pytest orchestrator/tests/test_api/test_workflow_import_export.py`
- `git diff --check`

Fixes #482
Fixes #483
Fixes #484
Fixes #486
Fixes #487