### PR TITLE
fix(voice): keep live sessions across navigation

### DIFF
--- a/frontend/src/app/kiosk/page.tsx
+++ b/frontend/src/app/kiosk/page.tsx
@@ -20,7 +20,7 @@ import {
   ListTodo, CircleDot, Send, ArrowLeft, Wifi, WifiOff, LayoutDashboard, Users, Server,
   Settings as SettingsIcon, Coins, Hash, ShieldCheck, Boxes, Save, RefreshCw, Mic,
 } from "lucide-react";
-import { VoiceSessionModal } from "@/components/agents/voice-session";
+import { VoiceSessionProvider, useVoiceSession } from "@/components/agents/voice-session-provider";
 
 type AgentInfo = {
   id: string; name: string; state: string; model: string;
@@ -74,15 +74,23 @@ const RANK: Record<string, number> = { error: 5, working: 4, running: 3, idle: 1
 function rank(s: string): number { return RANK[s] ?? 2; }
 
 export default function KioskPage() {
+  return (
+    <VoiceSessionProvider>
+      <KioskContent />
+    </VoiceSessionProvider>
+  );
+}
+
+function KioskContent() {
   const [data, setData] = useState<Overview | null>(null);
   const [online, setOnline] = useState(false);
   const [now, setNow] = useState<Date | null>(null);
   const [tab, setTab] = useState<Tab>("overview");
   const [detailId, setDetailId] = useState<string | null>(null);
   const [chatAgent, setChatAgent] = useState<AgentInfo | null>(null);
-  const [voiceAgent, setVoiceAgent] = useState<AgentInfo | null>(null);
   const [idle, setIdle] = useState(false);
   const lastActivity = useRef<number>(Date.now());
+  const voiceSession = useVoiceSession();
 
   useEffect(() => { const t = setInterval(() => setNow(new Date()), 1000); setNow(new Date()); return () => clearInterval(t); }, []);
 
@@ -91,9 +99,9 @@ export default function KioskPage() {
     const evs = ["pointerdown", "keydown", "touchstart", "mousemove"];
     evs.forEach((e) => window.addEventListener(e, wake, { passive: true }));
     const idleMs = lsGet("kiosk_idle_ms", 90000);
-    const t = setInterval(() => { if (!chatAgent && !voiceAgent && Date.now() - lastActivity.current > idleMs) setIdle(true); }, 2000);
+    const t = setInterval(() => { if (!chatAgent && !voiceSession.activeSession && Date.now() - lastActivity.current > idleMs) setIdle(true); }, 2000);
     return () => { evs.forEach((e) => window.removeEventListener(e, wake)); clearInterval(t); };
-  }, [idle, chatAgent, voiceAgent]);
+  }, [idle, chatAgent, voiceSession.activeSession]);
 
   useEffect(() => {
     let alive = true;
@@ -128,18 +136,6 @@ export default function KioskPage() {
   return (
     <div className="kiosk-root h-screen w-screen overflow-hidden kiosk-bg text-slate-100 select-none flex flex-col">
       <KioskStyles />
-      {voiceAgent && (
-        <VoiceSessionModal
-          agentId={voiceAgent.id}
-          agentName={voiceAgent.name}
-          onClose={() => { lastActivity.current = Date.now(); setVoiceAgent(null); }}
-          getTicket={async () => {
-            const r = await fetch(`/api/v1/kiosk/ws-ticket/${voiceAgent.id}`, { method: "POST" });
-            if (!r.ok) throw new Error("ticket failed");
-            return (await r.json()).ticket as string;
-          }}
-        />
-      )}
       <header className="flex items-center justify-between px-4 h-12 border-b border-white/5 bg-gradient-to-r from-[#0a1020] to-[#0a0f1a] shrink-0">
         <div className="flex items-center gap-2">
           <div className="w-7 h-7 rounded-lg bg-gradient-to-br from-cyan-400 to-violet-500 grid place-items-center kiosk-glow"><Bot className="w-4 h-4 text-white" /></div>
@@ -157,7 +153,23 @@ export default function KioskPage() {
       <main className="flex-1 min-h-0 overflow-hidden p-3">
         {tab === "overview" && <OverviewView data={data} onOpenAgent={(id) => { setDetailId(id); setTab("agents"); }} />}
         {tab === "agents" && (detailId
-          ? <AgentDetailView id={detailId} onBack={() => setDetailId(null)} onChat={(a) => setChatAgent(a)} onVoice={(a) => setVoiceAgent(a)} />
+          ? <AgentDetailView
+              id={detailId}
+              onBack={() => setDetailId(null)}
+              onChat={(a) => setChatAgent(a)}
+              onVoice={(a) => {
+                lastActivity.current = Date.now();
+                voiceSession.startSession({
+                  agentId: a.id,
+                  agentName: a.name,
+                  getTicket: async () => {
+                    const r = await fetch(`/api/v1/kiosk/ws-ticket/${a.id}`, { method: "POST" });
+                    if (!r.ok) throw new Error("ticket failed");
+                    return (await r.json()).ticket as string;
+                  },
+                });
+              }}
+            />
           : <AgentsView data={data} onOpen={(id) => setDetailId(id)} />)}
         {tab === "tasks" && <TasksView data={data} />}
         {tab === "system" && <SystemView data={data} />}

--- a/frontend/src/components/agents/agent-speech-tab.tsx
+++ b/frontend/src/components/agents/agent-speech-tab.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { PanelLeft, PanelLeftClose } from "lucide-react";
+import { Maximize2, Mic, PanelLeft, PanelLeftClose, PhoneOff, Radio } from "lucide-react";
 import * as api from "@/lib/api";
 import type { ChatSession } from "@/lib/api";
 import { SessionRail } from "./session-rail";
-import { VoiceSessionModal } from "./voice-session";
+import { useVoiceSession } from "./voice-session-provider";
 
 /** Speech tab: a "Gespräche" rail (shared component with the text chat, incl.
  *  pin/rename/delete) plus the embedded live voice view. Picking a conversation
@@ -17,6 +17,7 @@ export function AgentSpeechTab({ agentId, agentName }: { agentId: string; agentN
   const [selected, setSelected] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [railOpen, setRailOpen] = useState(true);  // collapsible like the chat rail
+  const voiceSession = useVoiceSession();
 
   const loadSessions = useCallback(async () => {
     try {
@@ -80,7 +81,7 @@ export function AgentSpeechTab({ agentId, agentName }: { agentId: string; agentN
         />
       )}
 
-      {/* Right — live voice view (remounts per selected session) */}
+      {/* Right — app-level live voice session control */}
       <div className="flex min-w-0 flex-1 flex-col">
         {/* Toolbar — mirrors the chat's collapse control (icon-only). */}
         <div className="flex items-center gap-1 border-b border-border px-3 py-1.5 shrink-0">
@@ -93,14 +94,62 @@ export function AgentSpeechTab({ agentId, agentName }: { agentId: string; agentN
           </button>
         </div>
         <div className="min-h-0 flex-1 pt-3">
-          <VoiceSessionModal
-            key={`voice-${agentId}-${selected ?? "new"}`}
-            agentId={agentId}
-            agentName={agentName}
-            resumeSessionId={selected ?? undefined}
-            onClose={() => setSelected(null)}
-            embedded
-          />
+          <div className="flex h-full min-h-[360px] flex-col items-center justify-center rounded-2xl border border-border bg-card px-6 text-center">
+            <div className="grid h-14 w-14 place-items-center rounded-full bg-fuchsia-500/15 text-fuchsia-300">
+              <Mic className="h-6 w-6" />
+            </div>
+            <h3 className="mt-4 text-base font-semibold">Live-Gespräch</h3>
+            <p className="mt-1 max-w-md text-sm text-muted-foreground">
+              {voiceSession.activeSession
+                ? `Aktive Session mit ${voiceSession.activeSession.agentName}`
+                : selected
+                  ? "Setzt das ausgewählte Gespräch per Sprache fort."
+                  : "Startet ein neues Sprachgespräch mit diesem Agenten."}
+            </p>
+            {voiceSession.activeSession && (
+              <div className="mt-4 inline-flex items-center gap-1.5 rounded-full bg-fuchsia-500/10 px-3 py-1 text-xs text-fuchsia-300">
+                {voiceSession.snapshot?.mode === "nova_sonic" && <Radio className="h-3 w-3" />}
+                {voiceSession.snapshot?.state === "speaking"
+                  ? "Spricht"
+                  : voiceSession.snapshot?.state === "listening"
+                    ? "Hört zu"
+                    : voiceSession.snapshot?.state === "processing"
+                      ? "Arbeitet"
+                      : "Verbunden"}
+              </div>
+            )}
+            <div className="mt-5 flex flex-wrap justify-center gap-2">
+              <button
+                onClick={() => voiceSession.startSession({
+                  agentId,
+                  agentName,
+                  resumeSessionId: selected ?? undefined,
+                })}
+                className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+              >
+                <Mic className="h-4 w-4" />
+                {voiceSession.isActiveForAgent(agentId) ? "Gespräch öffnen" : "Gespräch starten"}
+              </button>
+              {voiceSession.activeSession && (
+                <>
+                  <button
+                    onClick={voiceSession.expandSession}
+                    className="inline-flex items-center gap-2 rounded-lg bg-foreground/[0.06] px-4 py-2 text-sm font-medium hover:bg-foreground/[0.10]"
+                  >
+                    <Maximize2 className="h-4 w-4" />
+                    Aufklappen
+                  </button>
+                  <button
+                    onClick={voiceSession.endSession}
+                    className="inline-flex items-center gap-2 rounded-lg bg-red-500/10 px-4 py-2 text-sm font-medium text-red-400 hover:bg-red-500/20"
+                  >
+                    <PhoneOff className="h-4 w-4" />
+                    Beenden
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/components/agents/chat.tsx
+++ b/frontend/src/components/agents/chat.tsx
@@ -96,7 +96,7 @@ interface SessionTab {
 }
 
 import { getWsUrl, getApiUrl } from "@/lib/config";
-import { VoiceSessionModal } from "./voice-session";
+import { useVoiceSession } from "./voice-session-provider";
 const MAX_RECONNECT_ATTEMPTS = 5;
 
 /* ─── Tool Display Helper ───────────────────────────────────────────── */
@@ -248,7 +248,7 @@ export function AgentChat({ agentId, initialSessionId, embedded, busySessionIds 
   const [pendingImages, setPendingImages] = useState<ChatImage[]>([]);
   // Files attached via drag&drop or paperclip — uploaded on send, like pasted images.
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
-  const [voiceOpen, setVoiceOpen] = useState(false);
+  const voiceSession = useVoiceSession();
   const [isConnected, setIsConnected] = useState(false);
   const [isWaiting, setIsWaiting] = useState(false);
   // Resume (#chat-live): the agent is working on THIS session but the turn wasn't
@@ -1197,18 +1197,6 @@ export function AgentChat({ agentId, initialSessionId, embedded, busySessionIds 
           </div>
         </div>
       )}
-      {voiceOpen && (
-        <VoiceSessionModal
-          agentId={agentId}
-          agentName={agentId}
-          onClose={() => {
-            setVoiceOpen(false);
-            // Surface the just-persisted voice conversation as a session tab without reload.
-            void refreshSessions();
-          }}
-          resumeSessionId={activeSessionId ?? undefined}
-        />
-      )}
       {/* Conversation rail (shared with the Speech tab) — hidden in embedded (modal) mode */}
       {!embedded && railOpen && (
         <SessionRail
@@ -1467,7 +1455,15 @@ export function AgentChat({ agentId, initialSessionId, embedded, busySessionIds 
             {isUploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Paperclip className="h-4 w-4" />}
           </button>
           <button
-            onClick={() => setVoiceOpen(true)}
+            onClick={() => {
+              voiceSession.startSession({
+                agentId,
+                agentName: agentId,
+                resumeSessionId: activeSessionId ?? undefined,
+              });
+              // Surface a just-persisted voice conversation as a session tab without reload.
+              void refreshSessions();
+            }}
             disabled={!isConnected}
             className="flex h-10 w-10 items-center justify-center rounded-xl border border-border bg-background/80 text-muted-foreground hover:text-foreground hover:bg-foreground/[0.06] disabled:opacity-40 transition-all shrink-0"
             title="Live-Sprachsession starten"

--- a/frontend/src/components/agents/chat.tsx
+++ b/frontend/src/components/agents/chat.tsx
@@ -1460,9 +1460,10 @@ export function AgentChat({ agentId, initialSessionId, embedded, busySessionIds 
                 agentId,
                 agentName: agentId,
                 resumeSessionId: activeSessionId ?? undefined,
+                // Surface the persisted voice conversation as a session tab once
+                // the call has actually ended and the backend has saved it.
+                onEnd: () => { void refreshSessions(); },
               });
-              // Surface a just-persisted voice conversation as a session tab without reload.
-              void refreshSessions();
             }}
             disabled={!isConnected}
             className="flex h-10 w-10 items-center justify-center rounded-xl border border-border bg-background/80 text-muted-foreground hover:text-foreground hover:bg-foreground/[0.06] disabled:opacity-40 transition-all shrink-0"

--- a/frontend/src/components/agents/voice-session-provider.tsx
+++ b/frontend/src/components/agents/voice-session-provider.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { Loader2, Maximize2, Mic, PhoneOff, Radio } from "lucide-react";
+import { VoiceSessionModal, type VoiceSessionSnapshot } from "./voice-session";
+
+type VoiceSessionRequest = {
+  agentId: string;
+  agentName: string;
+  getTicket?: () => Promise<string>;
+  resumeSessionId?: string;
+};
+
+type ActiveVoiceSession = VoiceSessionRequest & {
+  sessionKey: string;
+};
+
+type VoiceSessionContextValue = {
+  activeSession: ActiveVoiceSession | null;
+  snapshot: VoiceSessionSnapshot | null;
+  expanded: boolean;
+  startSession: (request: VoiceSessionRequest) => void;
+  collapseSession: () => void;
+  expandSession: () => void;
+  endSession: () => void;
+  isActiveForAgent: (agentId: string) => boolean;
+};
+
+const VoiceSessionContext = createContext<VoiceSessionContextValue | null>(null);
+
+export function VoiceSessionProvider({ children }: { children: ReactNode }) {
+  const [activeSession, setActiveSession] = useState<ActiveVoiceSession | null>(null);
+  const [snapshot, setSnapshot] = useState<VoiceSessionSnapshot | null>(null);
+  const [expanded, setExpanded] = useState(false);
+
+  const startSession = useCallback((request: VoiceSessionRequest) => {
+    setActiveSession((current) => {
+      if (
+        current
+        && current.agentId === request.agentId
+        && current.resumeSessionId === request.resumeSessionId
+      ) {
+        return { ...current, ...request };
+      }
+      setSnapshot(null);
+      return {
+        ...request,
+        sessionKey: `${request.agentId}:${request.resumeSessionId ?? "new"}:${Date.now()}`,
+      };
+    });
+    setExpanded(true);
+  }, []);
+
+  const collapseSession = useCallback(() => setExpanded(false), []);
+  const expandSession = useCallback(() => setExpanded(true), []);
+  const endSession = useCallback(() => {
+    setExpanded(false);
+    setSnapshot(null);
+    setActiveSession(null);
+  }, []);
+  const isActiveForAgent = useCallback(
+    (agentId: string) => activeSession?.agentId === agentId,
+    [activeSession],
+  );
+
+  const value = useMemo<VoiceSessionContextValue>(() => ({
+    activeSession,
+    snapshot,
+    expanded,
+    startSession,
+    collapseSession,
+    expandSession,
+    endSession,
+    isActiveForAgent,
+  }), [activeSession, snapshot, expanded, startSession, collapseSession, expandSession, endSession, isActiveForAgent]);
+
+  return (
+    <VoiceSessionContext.Provider value={value}>
+      {children}
+      {activeSession && (
+        <>
+          <VoiceSessionModal
+            key={activeSession.sessionKey}
+            agentId={activeSession.agentId}
+            agentName={activeSession.agentName}
+            getTicket={activeSession.getTicket}
+            resumeSessionId={activeSession.resumeSessionId}
+            onClose={collapseSession}
+            onEnd={endSession}
+            onSnapshot={setSnapshot}
+            hidden={!expanded}
+          />
+          {!expanded && (
+            <VoiceSessionIndicator
+              session={activeSession}
+              snapshot={snapshot}
+              onExpand={expandSession}
+              onEnd={endSession}
+            />
+          )}
+        </>
+      )}
+    </VoiceSessionContext.Provider>
+  );
+}
+
+export function useVoiceSession(): VoiceSessionContextValue {
+  const ctx = useContext(VoiceSessionContext);
+  if (!ctx) throw new Error("useVoiceSession must be used inside <VoiceSessionProvider>");
+  return ctx;
+}
+
+function VoiceSessionIndicator({
+  session,
+  snapshot,
+  onExpand,
+  onEnd,
+}: {
+  session: ActiveVoiceSession;
+  snapshot: VoiceSessionSnapshot | null;
+  onExpand: () => void;
+  onEnd: () => void;
+}) {
+  const state = snapshot?.state ?? "connecting";
+  const busy = state === "connecting" || state === "processing";
+  const speaking = state === "speaking";
+  const label = speaking ? "Spricht" : state === "listening" ? "Hört zu" : busy ? "Arbeitet" : "Verbunden";
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 flex max-w-[calc(100vw-2rem)] items-center gap-2 rounded-full border border-border bg-card/95 px-3 py-2 text-sm shadow-2xl shadow-black/30 backdrop-blur-xl">
+      <button
+        onClick={onExpand}
+        className="flex min-w-0 items-center gap-2 rounded-full pr-1 text-left"
+        title="Live-Gespräch öffnen"
+      >
+        <span className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-fuchsia-500/15 text-fuchsia-300">
+          {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Mic className="h-4 w-4" />}
+        </span>
+        <span className="min-w-0">
+          <span className="flex items-center gap-1.5 text-xs font-medium text-foreground">
+            {snapshot?.mode === "nova_sonic" && <Radio className="h-3 w-3 text-fuchsia-400" />}
+            {label}
+          </span>
+          <span className="block truncate text-[11px] text-muted-foreground">
+            spricht mit {session.agentName}
+          </span>
+        </span>
+      </button>
+      <button
+        onClick={onExpand}
+        className="grid h-8 w-8 shrink-0 place-items-center rounded-full text-muted-foreground hover:bg-foreground/[0.06] hover:text-foreground"
+        title="Aufklappen"
+        aria-label="Live-Gespräch aufklappen"
+      >
+        <Maximize2 className="h-4 w-4" />
+      </button>
+      <button
+        onClick={onEnd}
+        className="grid h-8 w-8 shrink-0 place-items-center rounded-full text-red-400 hover:bg-red-500/10"
+        title="Gespräch beenden"
+        aria-label="Live-Gespräch beenden"
+      >
+        <PhoneOff className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/agents/voice-session-provider.tsx
+++ b/frontend/src/components/agents/voice-session-provider.tsx
@@ -16,6 +16,7 @@ type VoiceSessionRequest = {
   agentName: string;
   getTicket?: () => Promise<string>;
   resumeSessionId?: string;
+  onEnd?: () => void;
 };
 
 type ActiveVoiceSession = VoiceSessionRequest & {
@@ -41,6 +42,9 @@ export function VoiceSessionProvider({ children }: { children: ReactNode }) {
   const [expanded, setExpanded] = useState(false);
 
   const startSession = useCallback((request: VoiceSessionRequest) => {
+    const sameSession = activeSession
+      && activeSession.agentId === request.agentId
+      && activeSession.resumeSessionId === request.resumeSessionId;
     setActiveSession((current) => {
       if (
         current
@@ -49,22 +53,23 @@ export function VoiceSessionProvider({ children }: { children: ReactNode }) {
       ) {
         return { ...current, ...request };
       }
-      setSnapshot(null);
       return {
         ...request,
         sessionKey: `${request.agentId}:${request.resumeSessionId ?? "new"}:${Date.now()}`,
       };
     });
+    if (!sameSession) setSnapshot(null);
     setExpanded(true);
-  }, []);
+  }, [activeSession]);
 
   const collapseSession = useCallback(() => setExpanded(false), []);
   const expandSession = useCallback(() => setExpanded(true), []);
   const endSession = useCallback(() => {
+    activeSession?.onEnd?.();
     setExpanded(false);
     setSnapshot(null);
     setActiveSession(null);
-  }, []);
+  }, [activeSession]);
   const isActiveForAgent = useCallback(
     (agentId: string) => activeSession?.agentId === agentId,
     [activeSession],

--- a/frontend/src/components/agents/voice-session.tsx
+++ b/frontend/src/components/agents/voice-session.tsx
@@ -76,6 +76,16 @@ function safeHttpUrl(raw: unknown): string | undefined {
 type VoiceState = "connecting" | "ready" | "listening" | "processing" | "speaking" | "error";
 type Mode = "classic" | "nova_sonic";
 
+export type VoiceSessionSnapshot = {
+  state: VoiceState;
+  mode: Mode;
+  transcript: string;
+  response: string;
+  statusMsg: string;
+  paused: boolean;
+  delegating: boolean;
+};
+
 /** ArrayBuffer → base64 without spreading a typed array (build-safe). */
 function bufToBase64(buf: ArrayBuffer): string {
   const bytes = new Uint8Array(buf);
@@ -130,9 +140,25 @@ interface Props {
   /** Render inline inside a page/tab instead of as a fixed modal overlay:
    *  no dark backdrop, no close button, fills its container (used by the Speech tab). */
   embedded?: boolean;
+  /** Keep the session/audio graph mounted while the provider shows only the compact indicator. */
+  hidden?: boolean;
+  /** Called when the user explicitly ends the call; unlike onClose this tears down provider state. */
+  onEnd?: () => void;
+  /** Mirrors high-level state to the app-level provider for the floating indicator. */
+  onSnapshot?: (snapshot: VoiceSessionSnapshot) => void;
 }
 
-export function VoiceSessionModal({ agentId, agentName, onClose, getTicket, resumeSessionId, embedded = false }: Props) {
+export function VoiceSessionModal({
+  agentId,
+  agentName,
+  onClose,
+  getTicket,
+  resumeSessionId,
+  embedded = false,
+  hidden = false,
+  onEnd,
+  onSnapshot,
+}: Props) {
   const [state, setState] = useState<VoiceState>("connecting");
   const [mode, setMode] = useState<Mode>("classic");
   const [transcript, setTranscript] = useState("");
@@ -174,6 +200,10 @@ export function VoiceSessionModal({ agentId, agentName, onClose, getTicket, resu
   const [pendingApproval, setPendingApproval] = useState<ApprovalRequest | null>(null);
   const [approvalBusy, setApprovalBusy] = useState(false);
   const lastApprovalIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    onSnapshot?.({ state, mode, transcript, response, statusMsg, paused, delegating });
+  }, [state, mode, transcript, response, statusMsg, paused, delegating, onSnapshot]);
 
   const changeVolume = useCallback((v: number) => {
     setVolume(v);
@@ -876,8 +906,9 @@ export function VoiceSessionModal({ agentId, agentName, onClose, getTicket, resu
   const endLive = useCallback(() => {
     teardownRealtime();
     wsRef.current?.close();
-    onClose();
-  }, [teardownRealtime, onClose]);
+    onEnd?.();
+    if (!onEnd) onClose();
+  }, [teardownRealtime, onClose, onEnd]);
 
   const bargeIn = useCallback(() => {
     beginBargeIn(); // already sends the interrupt to the server
@@ -947,8 +978,8 @@ export function VoiceSessionModal({ agentId, agentName, onClose, getTicket, resu
   return (
     <div
       className={embedded
-        ? "w-full h-full"
-        : "fixed inset-0 z-50 flex items-stretch justify-center bg-background/80 backdrop-blur-sm sm:items-center sm:p-4"}
+        ? `${hidden ? "hidden " : ""}w-full h-full`
+        : `${hidden ? "hidden " : ""}fixed inset-0 z-50 flex items-stretch justify-center bg-background/80 backdrop-blur-sm sm:items-center sm:p-4`}
       onClick={embedded ? undefined : onClose}
     >
       <div

--- a/frontend/src/components/agents/voice-session.tsx
+++ b/frontend/src/components/agents/voice-session.tsx
@@ -79,11 +79,6 @@ type Mode = "classic" | "nova_sonic";
 export type VoiceSessionSnapshot = {
   state: VoiceState;
   mode: Mode;
-  transcript: string;
-  response: string;
-  statusMsg: string;
-  paused: boolean;
-  delegating: boolean;
 };
 
 /** ArrayBuffer → base64 without spreading a typed array (build-safe). */
@@ -202,8 +197,8 @@ export function VoiceSessionModal({
   const lastApprovalIdRef = useRef<string | null>(null);
 
   useEffect(() => {
-    onSnapshot?.({ state, mode, transcript, response, statusMsg, paused, delegating });
-  }, [state, mode, transcript, response, statusMsg, paused, delegating, onSnapshot]);
+    onSnapshot?.({ state, mode });
+  }, [state, mode, onSnapshot]);
 
   const changeVolume = useCallback((v: number) => {
     setVolume(v);

--- a/frontend/src/components/auth/auth-guard.tsx
+++ b/frontend/src/components/auth/auth-guard.tsx
@@ -5,6 +5,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Menu } from "lucide-react";
 import { initAuth, useAuthStore } from "@/lib/auth";
 import { Sidebar } from "@/components/layout/sidebar";
+import { VoiceSessionProvider } from "@/components/agents/voice-session-provider";
 import { SidebarProvider, useSidebarCollapsed } from "@/hooks/use-sidebar";
 import { cn } from "@/lib/utils";
 
@@ -78,15 +79,18 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
 
   // Pages with custom layout (e.g. /chat has its own sidebar)
   const hasCustomLayout = CUSTOM_LAYOUT_PATHS.some((p) => pathname.startsWith(p));
-  if (hasCustomLayout) {
-    return <>{children}</>;
-  }
 
   // Authenticated — full layout, unless the page is being embedded somewhere.
   return (
-    <Suspense fallback={null}>
-      <ShellOrBare>{children}</ShellOrBare>
-    </Suspense>
+    <VoiceSessionProvider>
+      {hasCustomLayout ? (
+        <>{children}</>
+      ) : (
+        <Suspense fallback={null}>
+          <ShellOrBare>{children}</ShellOrBare>
+        </Suspense>
+      )}
+    </VoiceSessionProvider>
   );
 }
 


### PR DESCRIPTION
## Summary
- add an app-level `VoiceSessionProvider` with a compact floating mic indicator for active sessions
- mount the authenticated provider after `AuthGuard` login checks so `/kiosk`, `/login`, and setup flows do not inherit authenticated voice state
- convert chat, speech tab, and kiosk voice launch points into hook-based consumers while keeping kiosk on its local ticket flow
- keep `VoiceSessionModal` mounted but hidden when collapsed so the WebSocket, microphone stream, audio graph, and transcript state survive route changes

## Validation
- `git diff --check`
- `cd frontend && npm run build`

Closes #476