### PR TITLE
Fix #495: add empty-server-list test for refresh_all_oauth_servers

### DIFF
--- a/orchestrator/tests/test_mcp_oauth_refresh_sweep.py
+++ b/orchestrator/tests/test_mcp_oauth_refresh_sweep.py
@@ -59,6 +59,13 @@ class RefreshAllOAuthServersTests(unittest.IsolatedAsyncioTestCase):
         sql = str(db.execute.await_args.args[0]).lower()
         assert "oauth_enabled" in sql
 
+    async def test_empty_server_list_returns_zero(self):
+        db = _session_returning([])
+        with patch.object(mor, "refresh_if_needed", new=AsyncMock()) as rin:
+            usable = await mor.refresh_all_oauth_servers(db)
+        assert usable == 0
+        rin.assert_not_awaited()
+
     async def test_one_failing_server_does_not_abort_the_sweep(self):
         servers = [_server(1, "a"), _server(2, "boom"), _server(3, "c")]
         db = _session_returning(servers)


### PR DESCRIPTION
## Summary
Adds the missing empty-server-list regression test for `refresh_all_oauth_servers` (N2 nitpick from the PR #490 review).

The new test asserts the function returns `0` and never awaits `refresh_if_needed` when there are no `oauth_enabled` servers. It reuses the existing `_session_returning([])` mock (already exercised by `test_only_selects_oauth_enabled_servers`), so no new test infrastructure is needed.

## Validation
- `python -m py_compile orchestrator/tests/test_mcp_oauth_refresh_sweep.py` ✓
- Full run happens in the CI **Orchestrator pytest** job (sqlalchemy isn't installed in the agent container, so local pytest isn't possible — same constraint as the existing 3 tests in this file).

Fixes #495