### PR TITLE
Fix #488 Phase 2: refresh MCP credentials on running agents

### DIFF
--- a/agent/app/main.py
+++ b/agent/app/main.py
@@ -53,6 +53,21 @@ def _run_mcp_add(args: list[str]) -> bool:
         return False
 
 
+def _run_mcp_remove(name: str) -> bool:
+    """Run `claude mcp remove` for a --scope user server. Returns True on success.
+
+    `claude mcp add` refuses to overwrite an existing server name ("already
+    exists"), so refreshing a server's credentials requires removing it first.
+    """
+    cmd = ["claude", "mcp", "remove", name, "--scope", "user"]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        return result.returncode == 0
+    except Exception as e:
+        print(f"[Agent] claude mcp remove error: {e}")
+        return False
+
+
 def _load_custom_mcp_auth() -> dict:
     """Parse CUSTOM_MCP_AUTH ({server_name: bearer_token}) from the environment."""
     raw = os.environ.get("CUSTOM_MCP_AUTH", "")
@@ -303,6 +318,73 @@ def _write_mcp_json_fallback() -> None:
         json.dump(mcp_config, f, indent=2)
 
 
+async def refresh_mcp_credentials_loop(agent_id: str, register_via_cli: bool, interval_seconds: int = 300) -> None:
+    """Periodically re-fetch custom MCP credentials and apply anything that rotated.
+
+    CUSTOM_MCP_AUTH/CUSTOM_MCP_HEADERS are only ever set once, at container
+    creation. An OAuth access token lives roughly one to two hours, so a
+    long-running agent silently loses OAuth-protected MCP servers within its
+    first hour (#488). This mirrors the orchestrator's own periodic
+    refresh_all_oauth_servers sweep from the agent side: pull the current
+    credentials from the orchestrator, and for anything that changed, update
+    the in-process env (picked up by MCPHTTPClient — custom_llm mode reads
+    it fresh on every instantiation) and, in Claude Code mode, remove +
+    re-add the affected servers via the CLI (it caches headers in
+    ~/.claude.json at registration time and never rereads the environment).
+    """
+    import httpx
+
+    url = f"{settings.orchestrator_url}/api/v1/agents/{agent_id}/mcp-credentials"
+    request_headers = {"Authorization": f"Bearer {settings.agent_token}", "X-Agent-ID": agent_id}
+    last_auth = _load_custom_mcp_auth()
+    last_headers = _load_custom_mcp_headers()
+
+    while True:
+        await asyncio.sleep(interval_seconds)
+        try:
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                resp = await client.get(url, headers=request_headers)
+            if resp.status_code != 200:
+                print(f"[Agent] MCP credential refresh failed: HTTP {resp.status_code}")
+                continue
+            data = resp.json()
+        except Exception as e:
+            print(f"[Agent] MCP credential refresh error: {e}")
+            continue
+
+        servers = data.get("servers") or {}
+        auth = data.get("auth") or {}
+        headers = data.get("headers") or {}
+        changed_names = {
+            name for name in set(auth) | set(headers)
+            if auth.get(name) != last_auth.get(name) or headers.get(name) != last_headers.get(name)
+        }
+        if not changed_names:
+            continue
+
+        # Always refresh the in-process env — cheap, and covers custom_llm mode.
+        os.environ["CUSTOM_MCP_SERVERS"] = json.dumps(servers)
+        os.environ["CUSTOM_MCP_AUTH"] = json.dumps(auth)
+        os.environ["CUSTOM_MCP_HEADERS"] = json.dumps(headers)
+
+        if register_via_cli:
+            for name in changed_names:
+                server_url = servers.get(name)
+                if not server_url:
+                    continue
+                safe_name = _sanitize_mcp_name(name)
+                _run_mcp_remove(safe_name)
+                cmd_args = ["--transport", "http", safe_name, server_url]
+                for header in _auth_header_args(name, auth, headers):
+                    cmd_args += ["--header", header]
+                if _run_mcp_add(cmd_args):
+                    print(f"[Agent] Refreshed MCP credentials: {safe_name}")
+                else:
+                    print(f"[Agent] WARN: Failed to refresh MCP credentials: {safe_name}")
+
+        last_auth, last_headers = auth, headers
+
+
 def setup_github_credentials() -> None:
     """Configure git/gh authentication from an assigned GitHub token secret."""
     token = (
@@ -522,13 +604,21 @@ async def main() -> None:
     chat_consumer = ChatConsumer(agent_id)
     message_consumer = MessageConsumer(agent_id)
 
+    # Periodic MCP credential refresh (#488 Phase 2) — codex_cli manages its
+    # own MCP config and doesn't use CUSTOM_MCP_* at all, so it's excluded.
+    mcp_refresh_task = None
+    if mode != "codex_cli" and os.environ.get("CUSTOM_MCP_SERVERS"):
+        mcp_refresh_task = asyncio.create_task(
+            refresh_mcp_credentials_loop(agent_id, register_via_cli=(mode != "custom_llm"))
+        )
+
     # Graceful shutdown on SIGTERM/SIGINT
     loop = asyncio.get_running_loop()
     for sig in (signal.SIGTERM, signal.SIGINT):
         loop.add_signal_handler(
             sig,
             lambda: asyncio.create_task(
-                shutdown(task_consumer, chat_consumer, message_consumer, health_runner)
+                shutdown(task_consumer, chat_consumer, message_consumer, health_runner, mcp_refresh_task)
             ),
         )
 
@@ -544,12 +634,14 @@ async def main() -> None:
     )
 
 
-async def shutdown(task_consumer: TaskConsumer, chat_consumer: ChatConsumer, message_consumer: MessageConsumer, health_runner) -> None:
+async def shutdown(task_consumer: TaskConsumer, chat_consumer: ChatConsumer, message_consumer: MessageConsumer, health_runner, mcp_refresh_task=None) -> None:
     print("[Agent] Shutting down gracefully...")
     await task_consumer.stop()
     await chat_consumer.stop()
     await message_consumer.stop()
     await health_runner.cleanup()
+    if mcp_refresh_task is not None:
+        mcp_refresh_task.cancel()
 
 
 if __name__ == "__main__":

--- a/agent/tests/test_mcp_credential_refresh.py
+++ b/agent/tests/test_mcp_credential_refresh.py
@@ -1,0 +1,165 @@
+"""Tests for #488 Phase 2: agents must pick up rotated MCP OAuth tokens without
+being recreated. CUSTOM_MCP_AUTH is only ever set once at container creation, so
+refresh_mcp_credentials_loop periodically re-fetches credentials from the
+orchestrator and applies whatever changed."""
+import asyncio
+import json
+
+import pytest
+
+from app import main
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _FakeAsyncClient:
+    """Minimal httpx.AsyncClient stand-in: one canned response per instantiation."""
+
+    def __init__(self, response: _FakeResponse, *, timeout=None):
+        self._response = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url, headers=None):
+        return self._response
+
+
+async def _run_one_iteration(monkeypatch, response_payload, register_via_cli):
+    """Drive refresh_mcp_credentials_loop through exactly one sleep/fetch cycle,
+    then stop it by making the second sleep raise CancelledError."""
+    import httpx as httpx_module
+
+    sleep_calls = {"n": 0}
+
+    async def fake_sleep(_seconds):
+        sleep_calls["n"] += 1
+        if sleep_calls["n"] > 1:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(main.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(
+        httpx_module,
+        "AsyncClient",
+        lambda *a, **kw: _FakeAsyncClient(_FakeResponse(200, response_payload), **kw),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await main.refresh_mcp_credentials_loop("agent-1", register_via_cli=register_via_cli, interval_seconds=0)
+
+
+@pytest.mark.asyncio
+async def test_refresh_updates_env_when_token_rotates(monkeypatch):
+    monkeypatch.setenv("CUSTOM_MCP_SERVERS", json.dumps({"srv": "https://x/mcp"}))
+    monkeypatch.setenv("CUSTOM_MCP_AUTH", json.dumps({"srv": "old-token"}))
+    monkeypatch.delenv("CUSTOM_MCP_HEADERS", raising=False)
+    monkeypatch.setattr(main, "_run_mcp_remove", lambda name: True)
+    monkeypatch.setattr(main, "_run_mcp_add", lambda args: True)
+
+    payload = {
+        "servers": {"srv": "https://x/mcp"},
+        "auth": {"srv": "new-token"},
+        "headers": {},
+    }
+    await _run_one_iteration(monkeypatch, payload, register_via_cli=False)
+
+    assert json.loads(main.os.environ["CUSTOM_MCP_AUTH"]) == {"srv": "new-token"}
+
+
+@pytest.mark.asyncio
+async def test_refresh_reregisters_via_cli_when_token_rotates(monkeypatch):
+    monkeypatch.setenv("CUSTOM_MCP_SERVERS", json.dumps({"srv": "https://x/mcp"}))
+    monkeypatch.setenv("CUSTOM_MCP_AUTH", json.dumps({"srv": "old-token"}))
+    monkeypatch.delenv("CUSTOM_MCP_HEADERS", raising=False)
+
+    removed = []
+    added = []
+    monkeypatch.setattr(main, "_run_mcp_remove", lambda name: removed.append(name) or True)
+    monkeypatch.setattr(main, "_run_mcp_add", lambda args: added.append(args) or True)
+
+    payload = {
+        "servers": {"srv": "https://x/mcp"},
+        "auth": {"srv": "new-token"},
+        "headers": {},
+    }
+    await _run_one_iteration(monkeypatch, payload, register_via_cli=True)
+
+    assert removed == ["srv"]
+    assert len(added) == 1
+    assert "Authorization: Bearer new-token" in added[0]
+
+
+@pytest.mark.asyncio
+async def test_refresh_skips_cli_calls_when_nothing_changed(monkeypatch):
+    monkeypatch.setenv("CUSTOM_MCP_SERVERS", json.dumps({"srv": "https://x/mcp"}))
+    monkeypatch.setenv("CUSTOM_MCP_AUTH", json.dumps({"srv": "same-token"}))
+    monkeypatch.delenv("CUSTOM_MCP_HEADERS", raising=False)
+
+    removed = []
+    added = []
+    monkeypatch.setattr(main, "_run_mcp_remove", lambda name: removed.append(name) or True)
+    monkeypatch.setattr(main, "_run_mcp_add", lambda args: added.append(args) or True)
+
+    payload = {
+        "servers": {"srv": "https://x/mcp"},
+        "auth": {"srv": "same-token"},
+        "headers": {},
+    }
+    await _run_one_iteration(monkeypatch, payload, register_via_cli=True)
+
+    assert removed == []
+    assert added == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_tolerates_http_error(monkeypatch):
+    monkeypatch.setenv("CUSTOM_MCP_SERVERS", json.dumps({"srv": "https://x/mcp"}))
+    monkeypatch.setenv("CUSTOM_MCP_AUTH", json.dumps({"srv": "old-token"}))
+    monkeypatch.delenv("CUSTOM_MCP_HEADERS", raising=False)
+
+    called = []
+    monkeypatch.setattr(main, "_run_mcp_remove", lambda name: called.append(name) or True)
+    monkeypatch.setattr(main, "_run_mcp_add", lambda args: called.append(args) or True)
+
+    # 500 response: loop must not crash and must not touch the CLI.
+    await _run_one_iteration(monkeypatch, {}, register_via_cli=True)
+    import httpx as httpx_module
+    monkeypatch.setattr(
+        httpx_module, "AsyncClient", lambda *a, **kw: _FakeAsyncClient(_FakeResponse(500, {}), **kw)
+    )
+    sleep_calls = {"n": 0}
+
+    async def fake_sleep(_seconds):
+        sleep_calls["n"] += 1
+        if sleep_calls["n"] > 1:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(main.asyncio, "sleep", fake_sleep)
+    with pytest.raises(asyncio.CancelledError):
+        await main.refresh_mcp_credentials_loop("agent-1", register_via_cli=True, interval_seconds=0)
+
+    assert called == []
+
+
+def test_run_mcp_remove_uses_scope_user(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        class R:
+            returncode = 0
+        return R()
+
+    monkeypatch.setattr(main.subprocess, "run", fake_run)
+    assert main._run_mcp_remove("srv") is True
+    assert calls[0] == ["claude", "mcp", "remove", "srv", "--scope", "user"]

--- a/orchestrator/app/api/agents.py
+++ b/orchestrator/app/api/agents.py
@@ -2186,6 +2186,38 @@ async def update_agent_mcp_servers(
         raise HTTPException(status_code=404, detail="Agent not found")
 
 
+@router.get("/{agent_id}/mcp-credentials")
+async def get_agent_mcp_credentials(
+    agent_id: str,
+    manager: AgentManager = Depends(_get_agent_manager),
+    agent_auth: dict = Depends(verify_agent_token),
+):
+    """Return freshly-computed MCP server URLs/credentials for this agent.
+
+    Called by the agent's own periodic refresh loop (#488 Phase 2) so a
+    running container can pick up a rotated OAuth token without being
+    recreated. Runs the same lookup used at container-creation time
+    (including the OAuth refresh-if-needed pass), just on demand instead
+    of once. The agent diffs the result against what it last registered
+    and only re-runs `claude mcp add` for servers whose credentials changed.
+    """
+    if agent_auth["agent_id"] != agent_id:
+        raise HTTPException(status_code=403, detail="Agent token does not match target agent")
+    try:
+        agent = await manager._get_agent(agent_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    config = agent.config or {}
+    mcp_env = await manager._get_custom_mcp_env(
+        agent_config=config, agent_id=agent_id, agent_integrations=config.get("integrations", [])
+    )
+    return {
+        "servers": json.loads(mcp_env.get("CUSTOM_MCP_SERVERS", "{}")),
+        "auth": json.loads(mcp_env.get("CUSTOM_MCP_AUTH", "{}")),
+        "headers": json.loads(mcp_env.get("CUSTOM_MCP_HEADERS", "{}")),
+    }
+
+
 # --- Volume Mounts ---
 
 

--- a/orchestrator/tests/test_agent_mcp_credentials_endpoint.py
+++ b/orchestrator/tests/test_agent_mcp_credentials_endpoint.py
@@ -1,0 +1,80 @@
+"""Tests for #488 Phase 2: GET /agents/{id}/mcp-credentials.
+
+CUSTOM_MCP_AUTH is only ever computed once, at container-creation time, so a
+running agent has no way to learn that an OAuth token rotated. This endpoint
+lets the agent's own periodic refresh loop pull the current credentials
+on demand — same computation _get_custom_mcp_env already does for a new
+container, just callable repeatedly.
+"""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi import HTTPException
+
+from app.api.agents import get_agent_mcp_credentials
+
+
+def _manager(agent_config: dict, mcp_env: dict) -> MagicMock:
+    manager = MagicMock()
+    agent = MagicMock()
+    agent.config = agent_config
+    manager._get_agent = AsyncMock(return_value=agent)
+    manager._get_custom_mcp_env = AsyncMock(return_value=mcp_env)
+    return manager
+
+
+class GetAgentMcpCredentialsTests(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_servers_auth_and_headers(self):
+        manager = _manager(
+            agent_config={"integrations": ["microsoft"]},
+            mcp_env={
+                "CUSTOM_MCP_SERVERS": '{"srv": "https://x/mcp"}',
+                "CUSTOM_MCP_AUTH": '{"srv": "fresh-token"}',
+                "CUSTOM_MCP_HEADERS": '{"srv": {"X-Api-Key": "k"}}',
+            },
+        )
+
+        result = await get_agent_mcp_credentials(
+            "agent-1", manager=manager, agent_auth={"agent_id": "agent-1"}
+        )
+
+        assert result == {
+            "servers": {"srv": "https://x/mcp"},
+            "auth": {"srv": "fresh-token"},
+            "headers": {"srv": {"X-Api-Key": "k"}},
+        }
+        manager._get_custom_mcp_env.assert_awaited_once_with(
+            agent_config={"integrations": ["microsoft"]},
+            agent_id="agent-1",
+            agent_integrations=["microsoft"],
+        )
+
+    async def test_defaults_to_empty_dicts_when_no_custom_servers(self):
+        manager = _manager(agent_config={}, mcp_env={})
+
+        result = await get_agent_mcp_credentials(
+            "agent-1", manager=manager, agent_auth={"agent_id": "agent-1"}
+        )
+
+        assert result == {"servers": {}, "auth": {}, "headers": {}}
+
+    async def test_rejects_token_for_a_different_agent(self):
+        manager = _manager(agent_config={}, mcp_env={})
+
+        with self.assertRaises(HTTPException) as ctx:
+            await get_agent_mcp_credentials(
+                "agent-1", manager=manager, agent_auth={"agent_id": "agent-2"}
+            )
+        assert ctx.exception.status_code == 403
+        manager._get_agent.assert_not_awaited()
+
+    async def test_404_when_agent_missing(self):
+        manager = MagicMock()
+        manager._get_agent = AsyncMock(side_effect=ValueError("not found"))
+
+        with self.assertRaises(HTTPException) as ctx:
+            await get_agent_mcp_credentials(
+                "agent-1", manager=manager, agent_auth={"agent_id": "agent-1"}
+            )
+        assert ctx.exception.status_code == 404


### PR DESCRIPTION
## Problem

Issue #488, Phase 2. Phase 1 (PR #490) added a periodic sweep that keeps the *stored* OAuth access token valid, but `CUSTOM_MCP_AUTH`/`CUSTOM_MCP_HEADERS` are only ever computed at container-creation time and handed to the agent as environment variables — which cannot change in a running container. A long-running agent therefore still loses OAuth-protected MCP servers about an hour in, exactly as described in the original issue (`claude mcp list` shows `! Needs authentication` while the admin UI shows the server healthy).

## Fix

**Orchestrator**: `GET /agents/{id}/mcp-credentials` (agent-token authenticated, same pattern as `/telegram/send`) runs the exact same `_get_custom_mcp_env` lookup used at container creation — including the OAuth refresh-if-needed pass — but callable repeatedly instead of once.

**Agent**: `refresh_mcp_credentials_loop` polls that endpoint every 5 minutes (same cadence as the orchestrator's own sweep) and, for any server whose auth/headers changed:
- updates the in-process `os.environ` (picked up automatically by `MCPHTTPClient` in `custom_llm` mode, which re-reads the env on every instantiation — no CLI involved)
- in Claude Code mode, removes and re-adds the server via `claude mcp`

I tested the CLI directly before writing this: `claude mcp add` refuses to overwrite an existing server name ("already exists"), so a naive re-add doesn't work — remove-then-add does (verified token content changes after the cycle).

`codex_cli` mode manages its own MCP config outside `CUSTOM_MCP_*` and is excluded (tracked separately, see #475's open follow-up).

## Testing

- `agent/tests/test_mcp_credential_refresh.py` (5 tests): env update on rotation, CLI remove+add on rotation, no-op when nothing changed, tolerates HTTP errors, `_run_mcp_remove` uses `--scope user`.
- `orchestrator/tests/test_agent_mcp_credentials_endpoint.py` (4 tests): happy path, empty-server default, 403 on agent-id mismatch, 404 on missing agent.
- Full suites green: orchestrator 761 passed, agent 88/89 passed (1 pre-existing unrelated failure in `test_present_file_marker.py`, confirmed already broken on `main`).

## Deploy gate

Both agent and orchestrator images need a rebuild after merge.

Refs #488 (does not close it — Phase 2 only; codex_cli follow-up in #475 remains open).