### PR TITLE
Fix #501: retry MCP credential re-registration after failed add

### DIFF
--- a/agent/app/main.py
+++ b/agent/app/main.py
@@ -367,6 +367,7 @@ async def refresh_mcp_credentials_loop(agent_id: str, register_via_cli: bool, in
         os.environ["CUSTOM_MCP_AUTH"] = json.dumps(auth)
         os.environ["CUSTOM_MCP_HEADERS"] = json.dumps(headers)
 
+        failed_names: set[str] = set()
         if register_via_cli:
             for name in changed_names:
                 server_url = servers.get(name)
@@ -381,8 +382,24 @@ async def refresh_mcp_credentials_loop(agent_id: str, register_via_cli: bool, in
                     print(f"[Agent] Refreshed MCP credentials: {safe_name}")
                 else:
                     print(f"[Agent] WARN: Failed to refresh MCP credentials: {safe_name}")
+                    failed_names.add(name)
 
-        last_auth, last_headers = auth, headers
+        # Commit the freshly-applied credentials as the new baseline, but keep the
+        # OLD value for any server whose CLI re-registration failed so the next tick
+        # re-detects it as changed and retries — otherwise the server stays
+        # de-registered until container restart (#501).
+        new_last_auth = dict(auth)
+        new_last_headers = dict(headers)
+        for name in failed_names:
+            if name in last_auth:
+                new_last_auth[name] = last_auth[name]
+            else:
+                new_last_auth.pop(name, None)
+            if name in last_headers:
+                new_last_headers[name] = last_headers[name]
+            else:
+                new_last_headers.pop(name, None)
+        last_auth, last_headers = new_last_auth, new_last_headers
 
 
 def setup_github_credentials() -> None:

--- a/agent/tests/test_mcp_credential_refresh.py
+++ b/agent/tests/test_mcp_credential_refresh.py
@@ -151,6 +151,84 @@ async def test_refresh_tolerates_http_error(monkeypatch):
     assert called == []
 
 
+@pytest.mark.asyncio
+async def test_refresh_retries_on_next_tick_when_add_fails(monkeypatch):
+    """#501: a failed `claude mcp add` must NOT be recorded as applied — the next
+    poll tick must re-detect the unchanged rotation and retry, instead of leaving
+    the server de-registered until container restart."""
+    monkeypatch.setenv("CUSTOM_MCP_SERVERS", json.dumps({"srv": "https://x/mcp"}))
+    monkeypatch.setenv("CUSTOM_MCP_AUTH", json.dumps({"srv": "old-token"}))
+    monkeypatch.delenv("CUSTOM_MCP_HEADERS", raising=False)
+
+    added = []
+    # First add fails, second add succeeds.
+    add_results = iter([False, True])
+    monkeypatch.setattr(main, "_run_mcp_remove", lambda name: True)
+    monkeypatch.setattr(main, "_run_mcp_add", lambda args: added.append(args) or next(add_results))
+
+    payload = {"servers": {"srv": "https://x/mcp"}, "auth": {"srv": "new-token"}, "headers": {}}
+
+    import httpx as httpx_module
+    monkeypatch.setattr(
+        httpx_module,
+        "AsyncClient",
+        lambda *a, **kw: _FakeAsyncClient(_FakeResponse(200, payload), **kw),
+    )
+
+    # Allow exactly two fetch cycles, then cancel on the third sleep.
+    sleep_calls = {"n": 0}
+
+    async def fake_sleep(_seconds):
+        sleep_calls["n"] += 1
+        if sleep_calls["n"] > 2:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(main.asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await main.refresh_mcp_credentials_loop("agent-1", register_via_cli=True, interval_seconds=0)
+
+    # Two add attempts: the failed one and the retry on the next tick.
+    assert len(added) == 2
+
+
+@pytest.mark.asyncio
+async def test_refresh_no_retry_after_successful_add(monkeypatch):
+    """A successful add must be recorded so the next tick sees no change and does
+    not needlessly re-register the server."""
+    monkeypatch.setenv("CUSTOM_MCP_SERVERS", json.dumps({"srv": "https://x/mcp"}))
+    monkeypatch.setenv("CUSTOM_MCP_AUTH", json.dumps({"srv": "old-token"}))
+    monkeypatch.delenv("CUSTOM_MCP_HEADERS", raising=False)
+
+    added = []
+    monkeypatch.setattr(main, "_run_mcp_remove", lambda name: True)
+    monkeypatch.setattr(main, "_run_mcp_add", lambda args: added.append(args) or True)
+
+    payload = {"servers": {"srv": "https://x/mcp"}, "auth": {"srv": "new-token"}, "headers": {}}
+
+    import httpx as httpx_module
+    monkeypatch.setattr(
+        httpx_module,
+        "AsyncClient",
+        lambda *a, **kw: _FakeAsyncClient(_FakeResponse(200, payload), **kw),
+    )
+
+    sleep_calls = {"n": 0}
+
+    async def fake_sleep(_seconds):
+        sleep_calls["n"] += 1
+        if sleep_calls["n"] > 2:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(main.asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await main.refresh_mcp_credentials_loop("agent-1", register_via_cli=True, interval_seconds=0)
+
+    # Only one add: the second tick sees an unchanged token and skips.
+    assert len(added) == 1
+
+
 def test_run_mcp_remove_uses_scope_user(monkeypatch):
     calls = []
 


### PR DESCRIPTION
Fixes #501

## Problem
In the MCP credential poller (`refresh_mcp_credentials_loop`, Phase 2 of #488, merged in PR #499), `last_auth`/`last_headers` were updated unconditionally after each poll tick — even when `_run_mcp_add` failed. On the next tick `changed_names` was then empty, so no retry occurred and the affected server stayed de-registered until container restart.

## Fix
Track which servers failed CLI re-registration. Commit the freshly-applied credentials as the new baseline, but keep the **old** value for any failed server so the next tick re-detects it as changed and retries. custom_llm mode (no CLI) is unaffected — the in-process env is still updated fully.

## Tests
Two new regression tests in `test_mcp_credential_refresh.py`, both driving two poll cycles:
- `test_refresh_retries_on_next_tick_when_add_fails` — first `add` fails, asserts a second (retry) `add` on the next tick.
- `test_refresh_no_retry_after_successful_add` — a successful `add` is recorded, asserts no needless re-registration next tick.

14 mcp tests pass locally.

## Deploy gate
Agent image rebuild required (`agent/app/main.py` changed).