### PR TITLE
Fix #507: /shared volume writable by agents (root:1000, setgid+sticky)

### DIFF
--- a/orchestrator/app/core/shared_volume.py
+++ b/orchestrator/app/core/shared_volume.py
@@ -1,0 +1,63 @@
+"""Repair ownership/permissions of the ``/shared`` volume so agents can write to it.
+
+Docker creates the named volume ``ai-employee-shared`` as ``root:root 0755``.
+It is mounted read-write into every agent container, but the agent process runs
+as uid 1000 — the directory's own permission bits deny that uid the write bit,
+so agents can read ``/shared`` but never create an entry in it. Yet the injected
+system prompt promises every agent that ``/shared`` is the writable cross-agent
+file-exchange path, so file handovers (a generated PDF, PPTX, export) silently
+fail with ``Permission denied``.
+
+The orchestrator runs as root and already has ``/shared`` mounted read-write, so
+fixing the directory here at startup repairs both fresh and already-provisioned
+installations (a fix in ``setup.sh``'s ``docker volume create`` would only help
+new installs). The permissions live in the volume on disk, so they survive
+container recreation and platform updates.
+
+Mode ``3775`` (``rwxrwsr-t``) is deliberate — two bits beyond plain group write:
+
+* **sticky** — ``/shared`` holds root-owned platform credentials
+  (``.auth/token.json``, ``.codex/auth.json``). With the sticky bit an agent can
+  only remove or rename entries it *owns*, so it cannot swap the shared token
+  every other agent reads. This is the ``/tmp`` model.
+* **setgid** — new subdirectories inherit the agent group, so two agents can
+  genuinely collaborate inside the same folder instead of locking each other out.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+SHARED_DIR = "/shared"
+AGENT_GID = 1000
+# rwxrwsr-t : owner=root, group=agent (writable), setgid + sticky
+SHARED_MODE = 0o3775
+
+
+def ensure_shared_volume_perms(path: str = SHARED_DIR) -> bool:
+    """Give ``path`` to the agent group with setgid+sticky. Idempotent.
+
+    Returns True if the permissions are in place, False if they could not be
+    applied (e.g. the orchestrator is not running as root). Never raises — a
+    failure here must not block startup.
+    """
+    try:
+        if not os.path.isdir(path):
+            os.makedirs(path, exist_ok=True)
+        os.chown(path, 0, AGENT_GID)  # root:agent
+        os.chmod(path, SHARED_MODE)
+        logger.info("Shared volume perms ensured (%s -> root:%d, %o)", path, AGENT_GID, SHARED_MODE)
+        return True
+    except PermissionError:
+        logger.warning(
+            "Could not adjust %s permissions (orchestrator not root?); "
+            "agents may be unable to write to the shared volume",
+            path,
+        )
+        return False
+    except Exception as e:  # noqa: BLE001 - never let this block startup
+        logger.warning("Ensuring %s permissions failed: %s", path, e)
+        return False

--- a/orchestrator/app/main.py
+++ b/orchestrator/app/main.py
@@ -788,6 +788,11 @@ async def lifespan(app: FastAPI):
     # Validate config on startup
     _validate_config()
 
+    # Repair /shared ownership/mode so agents (uid 1000) can write to it
+    # (Docker creates the volume root:root 0755 -> agents can only read).
+    from app.core.shared_volume import ensure_shared_volume_perms
+    ensure_shared_volume_perms()
+
     # Mirror WARNING+ logs (redacted) to /shared/platform-errors.log so agents can
     # read platform errors from the shared volume and help fix the platform.
     from app.core.platform_error_log import setup_platform_error_log

--- a/orchestrator/tests/test_shared_volume_perms.py
+++ b/orchestrator/tests/test_shared_volume_perms.py
@@ -1,0 +1,78 @@
+"""Tests for the /shared volume permission repair (issue #507).
+
+Docker creates the shared volume root:root 0755, so agents (uid 1000) can read
+but never write it. ``ensure_shared_volume_perms`` fixes ownership/mode at
+orchestrator startup. These tests pin the exact owner/group/mode and prove the
+function never raises (a failure must not block startup).
+"""
+
+import os
+import stat
+
+import pytest
+
+from app.core.shared_volume import (
+    AGENT_GID,
+    SHARED_MODE,
+    ensure_shared_volume_perms,
+)
+
+
+def test_mode_constant_is_setgid_sticky_group_writable():
+    # 3775 = rwxrwsr-t
+    assert SHARED_MODE == 0o3775
+    assert SHARED_MODE & stat.S_ISGID  # new subdirs inherit the agent group
+    assert SHARED_MODE & stat.S_ISVTX  # sticky: agent can only remove its own entries
+    assert SHARED_MODE & stat.S_IWGRP  # group (agent) may write
+
+
+def test_applies_owner_group_and_mode(tmp_path, monkeypatch):
+    target = tmp_path / "shared"
+    target.mkdir()
+    calls = {}
+
+    def fake_chown(path, uid, gid):
+        calls["chown"] = (path, uid, gid)
+
+    def fake_chmod(path, mode):
+        calls["chmod"] = (path, mode)
+
+    monkeypatch.setattr(os, "chown", fake_chown)
+    monkeypatch.setattr(os, "chmod", fake_chmod)
+
+    assert ensure_shared_volume_perms(str(target)) is True
+    # owner root (uid 0), group = agent gid
+    assert calls["chown"] == (str(target), 0, AGENT_GID)
+    assert calls["chmod"] == (str(target), 0o3775)
+
+
+def test_creates_dir_when_missing(tmp_path, monkeypatch):
+    target = tmp_path / "shared"  # does not exist yet
+    monkeypatch.setattr(os, "chown", lambda *a: None)
+    monkeypatch.setattr(os, "chmod", lambda *a: None)
+
+    assert ensure_shared_volume_perms(str(target)) is True
+    assert target.is_dir()
+
+
+def test_permission_error_is_swallowed_returns_false(tmp_path, monkeypatch):
+    target = tmp_path / "shared"
+    target.mkdir()
+
+    def deny(*_a, **_k):
+        raise PermissionError("not root")
+
+    monkeypatch.setattr(os, "chown", deny)
+    # must not raise -> startup keeps going even without root
+    assert ensure_shared_volume_perms(str(target)) is False
+
+
+def test_generic_error_is_swallowed_returns_false(tmp_path, monkeypatch):
+    target = tmp_path / "shared"
+    target.mkdir()
+
+    def boom(*_a, **_k):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(os, "chown", boom)
+    assert ensure_shared_volume_perms(str(target)) is False


### PR DESCRIPTION
## Summary
Fixes #507. Docker creates the `ai-employee-shared` volume as `root:root 0755`, so agents (uid 1000) could only **read** `/shared` — every write failed with `Permission denied`, breaking the cross-agent file-exchange path the injected system prompt promises (`/shared/` "all agents can read/write"). File handovers (PDF/PPTX/export) between agents silently failed.

## Fix
New `app/core/shared_volume.py` → `ensure_shared_volume_perms()`, called once at orchestrator startup. The orchestrator runs as root and already has `/shared` mounted rw, so it repairs **both fresh and already-provisioned** installs (a `setup.sh` `docker volume create` fix would only help new installs). It sets:

- **owner `root:1000`** — group = agent gid, so agents get the group-write bit
- **mode `3775` (`rwxrwsr-t`)**:
  - **setgid** — new subdirs inherit the agent group → two agents can collaborate in the same folder
  - **sticky** — `/shared` holds root-owned platform credentials (`.auth/token.json`, `.codex/auth.json`); the sticky bit means an agent can only remove/rename entries it *owns*, so it cannot swap the shared token every other agent reads (the `/tmp` model)

Idempotent; never raises (a failure — e.g. not-root — is logged and returns `False`, startup continues). Permissions live in the volume on disk, so they survive container recreation and platform updates.

## Security note
Mirrors the approach and rationale from the issue's verification table:
- Agent A creates subdir + file in `/shared` → now passes
- Agent B reads/overwrites it (shared work) → now passes
- Agent may **not** delete root-owned `platform-errors.log` / rename `.auth` away → still blocked (sticky bit)

## Tests
`tests/test_shared_volume_perms.py` (5 tests, all green in isolated venv):
- mode constant is setgid+sticky+group-writable
- applies `chown(root, 1000)` + `chmod(3775)` on the exact path
- creates the dir when missing
- `PermissionError` and generic `OSError` are swallowed → returns `False`, no raise

## Deploy gate
Orchestrator image rebuild required (`orchestrator/app/main.py` + new core module).

## Test plan
- [ ] `docker compose up --build -d orchestrator`
- [ ] `stat -c '%U:%G %a' /shared` inside the volume → `root:<agent-group> 3775`
- [ ] From an agent container: `touch /shared/_probe && rm /shared/_probe` succeeds
- [ ] Agent may NOT `rm /shared/platform-errors.log` (root-owned) — still denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)