### PR TITLE
Fix #510: keep shared Codex auth.json root-owned (agents cannot tamper)

### DIFF
--- a/orchestrator/app/core/shared_volume.py
+++ b/orchestrator/app/core/shared_volume.py
@@ -16,10 +16,13 @@ container recreation and platform updates.
 
 Mode ``3775`` (``rwxrwsr-t``) is deliberate — two bits beyond plain group write:
 
-* **sticky** — ``/shared`` holds root-owned platform credentials
-  (``.auth/token.json``, ``.codex/auth.json``). With the sticky bit an agent can
-  only remove or rename entries it *owns*, so it cannot swap the shared token
-  every other agent reads. This is the ``/tmp`` model.
+* **sticky** — ``/shared`` holds the credential *sub-directories* ``.auth`` and
+  ``.codex``. With the sticky bit an agent can only remove or rename entries it
+  *owns*, so it cannot delete or swap those directories. This is the ``/tmp``
+  model. Note this only guards ``/shared``'s *direct* entries — the credential
+  *files* nested inside (e.g. ``.codex/auth.json``) are protected separately by
+  making both the file and its parent directory root-owned and non-agent-writable
+  (see ``codex_auth_service._lock_agent_readonly`` / ``_secure_codex_dir``).
 * **setgid** — new subdirectories inherit the agent group, so two agents can
   genuinely collaborate inside the same folder instead of locking each other out.
 """

--- a/orchestrator/app/services/codex_auth_service.py
+++ b/orchestrator/app/services/codex_auth_service.py
@@ -48,11 +48,32 @@ def _agent_file_owner() -> tuple[int, int]:
         return DEFAULT_AGENT_UID, DEFAULT_AGENT_GID
 
 
-def _make_agent_readable(path: str) -> None:
-    """Let the non-root agent user read Codex auth without making it world-readable."""
-    uid, gid = _agent_file_owner()
-    os.chown(path, uid, gid)
-    os.chmod(path, 0o600)
+def _lock_agent_readonly(path: str) -> None:
+    """Make Codex auth readable but NOT writable by the agent user.
+
+    All agent containers run as the same uid (1000), so a file *owned* by that
+    uid is writable by every agent — a rogue agent could overwrite the shared
+    Codex refresh token in place (issue #510). We therefore keep the file
+    root-owned and only grant the agent *group* read access: root (the
+    orchestrator) writes it, agents read it, no agent can tamper with it.
+    """
+    _, gid = _agent_file_owner()
+    os.chown(path, 0, gid)  # root:agent — owned by root, not the agent uid
+    os.chmod(path, 0o640)  # root rw, agent group read-only, no world access
+
+
+def _secure_codex_dir(path: str) -> None:
+    """Root-own the shared Codex dir so agents cannot unlink/recreate auth.json.
+
+    The sticky bit on ``/shared`` only guards ``/shared``'s *direct* entries; the
+    credential file nested inside ``/shared/.codex`` is governed by this
+    directory's own permissions. Making the directory root-owned and
+    non-agent-writable stops a rogue agent from deleting the real auth.json and
+    dropping a forged one in its place.
+    """
+    _, gid = _agent_file_owner()
+    os.chown(path, 0, gid)  # root:agent
+    os.chmod(path, 0o750)  # root rwx, agent group traverse/read, no world access
 
 
 def _access_token_exp(parsed: dict) -> int | None:
@@ -90,10 +111,11 @@ class CodexAuthService:
                 auth_json = decrypt_token(integration.access_token_encrypted)
                 parsed = json.loads(auth_json)
                 os.makedirs(os.path.dirname(SHARED_CODEX_AUTH_PATH), exist_ok=True)
+                _secure_codex_dir(SHARED_CODEX_HOME)
                 tmp_path = SHARED_CODEX_AUTH_PATH + ".tmp"
                 with open(tmp_path, "w") as f:
                     json.dump(parsed, f)
-                _make_agent_readable(tmp_path)
+                _lock_agent_readonly(tmp_path)
                 os.replace(tmp_path, SHARED_CODEX_AUTH_PATH)
                 logger.info("Synced Codex auth.json to shared agent volume")
                 return True
@@ -133,6 +155,11 @@ class CodexAuthService:
             if not os.path.exists(SHARED_CODEX_AUTH_PATH):
                 return await self.sync_auth_json()
 
+            # Repair perms on already-provisioned installs whose auth.json was
+            # written before #510 (agent-owned, agent-writable). Idempotent.
+            _secure_codex_dir(SHARED_CODEX_HOME)
+            _lock_agent_readonly(SHARED_CODEX_AUTH_PATH)
+
             with open(SHARED_CODEX_AUTH_PATH) as f:
                 parsed = json.load(f)
             exp = _access_token_exp(parsed)
@@ -151,7 +178,7 @@ class CodexAuthService:
                 logger.warning("Central Codex refresh exec failed: %s", e)
                 return False
 
-            _make_agent_readable(SHARED_CODEX_AUTH_PATH)
+            _lock_agent_readonly(SHARED_CODEX_AUTH_PATH)
             if _file_hash(SHARED_CODEX_AUTH_PATH) != before:
                 await self._store_shared_to_db()
                 logger.info("Codex token centrally refreshed + re-stored to DB")

--- a/orchestrator/tests/test_codex_auth_service.py
+++ b/orchestrator/tests/test_codex_auth_service.py
@@ -28,16 +28,42 @@ class CodexAuthServiceTests(unittest.TestCase):
         ):
             self.assertEqual(codex_auth_service._agent_file_owner(), (1000, 1000))
 
-    def test_make_agent_readable_chowns_before_locking_permissions(self):
+    def test_lock_agent_readonly_keeps_file_root_owned(self):
+        # #510: the file must be owned by root (uid 0), NOT the agent uid, so a
+        # rogue agent (all agents share uid 1000) cannot overwrite it in place.
         with (
             patch.dict(os.environ, {}, clear=True),
             patch.object(codex_auth_service.os, "chown") as chown,
             patch.object(codex_auth_service.os, "chmod") as chmod,
         ):
-            codex_auth_service._make_agent_readable("/shared/.codex/auth.json.tmp")
+            codex_auth_service._lock_agent_readonly("/shared/.codex/auth.json.tmp")
 
-        chown.assert_called_once_with("/shared/.codex/auth.json.tmp", 1000, 1000)
-        chmod.assert_called_once_with("/shared/.codex/auth.json.tmp", 0o600)
+        chown.assert_called_once_with("/shared/.codex/auth.json.tmp", 0, 1000)
+        chmod.assert_called_once_with("/shared/.codex/auth.json.tmp", 0o640)
+
+    def test_lock_agent_readonly_respects_configured_gid(self):
+        with (
+            patch.dict(os.environ, {"AGENT_CONTAINER_GID": "5678"}, clear=True),
+            patch.object(codex_auth_service.os, "chown") as chown,
+            patch.object(codex_auth_service.os, "chmod") as chmod,
+        ):
+            codex_auth_service._lock_agent_readonly("/shared/.codex/auth.json")
+
+        chown.assert_called_once_with("/shared/.codex/auth.json", 0, 5678)
+        chmod.assert_called_once_with("/shared/.codex/auth.json", 0o640)
+
+    def test_secure_codex_dir_root_owns_and_denies_agent_write(self):
+        # The parent dir must be root-owned and non-agent-writable so an agent
+        # cannot unlink the real auth.json and drop a forged one in its place.
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch.object(codex_auth_service.os, "chown") as chown,
+            patch.object(codex_auth_service.os, "chmod") as chmod,
+        ):
+            codex_auth_service._secure_codex_dir("/shared/.codex")
+
+        chown.assert_called_once_with("/shared/.codex", 0, 1000)
+        chmod.assert_called_once_with("/shared/.codex", 0o750)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #510.

## Problem
`codex_auth_service._make_agent_readable()` chowned `/shared/.codex/auth.json` to **uid 1000** (mode `0600`) so the non-root agent user could read it. But all agent containers share uid 1000, so a file *owned* by 1000 is **writable by every agent** — any rogue/compromised agent could overwrite the shared Codex refresh token in place (no delete/rename needed, so the `/shared` sticky bit from #508 never even applies).

## Fix (Option A from the issue)
Keep the credential **root-owned**; grant only the agent *group* read access. Root (the orchestrator) writes it, agents read it, no agent can tamper with it.

- `_lock_agent_readonly()` → `chown(root:agent)`, `chmod 0640`.
- `_secure_codex_dir()` → roots `/shared/.codex` at `0750` so an agent cannot `unlink` the real auth.json and drop a forged one (the `/shared` sticky bit only guards `/shared`'s *direct* entries, not files nested inside subdirectories).
- `ensure_fresh()` repairs perms on **already-provisioned installs** on each scheduler run (idempotent).

## Why no write path is lost
Agents **copy** the shared file into their own container-local `CODEX_HOME` (`agent/app/main.py::setup_codex_auth`, `shutil.copyfile`), so they only ever READ `/shared/.codex/auth.json`. The central refresh (`ensure_fresh` → `codex exec`) runs as root and can still read+write both the file and the directory.

## Also
Corrects the inaccurate sticky-bit claim in `shared_volume.py`'s module docstring (it implied the sticky bit protects nested credential *files*; it only protects `/shared`'s direct sub-directory entries).

## Tests
`orchestrator/tests/test_codex_auth_service.py` — 6 pass:
- file stays root-owned (`0:gid`, `0640`), honouring `AGENT_CONTAINER_GID`
- `_secure_codex_dir` roots the dir at `0750`

## Deploy gate
Orchestrator image rebuild + `docker compose up --build -d`. On existing installs the perms self-repair on the next `ensure_fresh` sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)