### PR TITLE
fix(security): redact Claude OAuth token bytes from logs (part of #513)

### DIFF
--- a/orchestrator/app/services/claude_token_service.py
+++ b/orchestrator/app/services/claude_token_service.py
@@ -122,18 +122,12 @@ class ClaudeTokenService:
         token_suffix = token[-8:]
 
         if token_suffix != self._last_token_suffix:
-            old_suffix = (
-                settings.claude_code_oauth_token[-8:]
-                if settings.claude_code_oauth_token
-                else "n/a"
-            )
             settings.claude_code_oauth_token = token
             self._last_token_suffix = token_suffix
             self._write_shared_token(token)
-            logger.info(
-                f"Claude token updated from {source} "
-                f"(…{old_suffix} → …{token_suffix})"
-            )
+            # Never log any part of the token itself. This branch only runs on
+            # rotation, so the message alone already signals that it changed.
+            logger.info(f"Claude token updated from {source}")
 
         return True
 
@@ -173,7 +167,7 @@ class ClaudeTokenService:
             settings.claude_code_oauth_token = token
             self._last_token_suffix = token[-8:]
             self._write_shared_token(token)
-            logger.info(f"Loaded initial Claude token from {source} (…{token[-8:]})")
+            logger.info(f"Loaded initial Claude token from {source}")
 
     def _write_shared_token(self, access_token: str) -> None:
         """Write token to shared volume for agent containers.

--- a/orchestrator/tests/test_claude_token_initial_priority.py
+++ b/orchestrator/tests/test_claude_token_initial_priority.py
@@ -118,5 +118,53 @@ class TestClaudeTokenInitialPriority(unittest.TestCase):
         self.assertTrue(found, "_MIN_PLAUSIBLE_TOKEN_LEN constant must be defined")
 
 
+class TestNoTokenBytesLogged(unittest.TestCase):
+    """Regression guard for #513 (py/clear-text-logging-sensitive-data): the
+    token-loading functions must not log any part of the token itself — not a
+    ``token[-8:]`` suffix, not a captured ``old_suffix`` / ``token_suffix``.
+    Even 8 real characters of an OAuth token are secret material in logs.
+    """
+
+    _LOG_METHODS = {"info", "warning", "error", "debug", "critical", "exception"}
+    _FORBIDDEN_NAMES = {"old_suffix", "token_suffix"}
+
+    def _logger_call_args(self, fn: ast.AST):
+        for n in ast.walk(fn):
+            if (
+                isinstance(n, ast.Call)
+                and isinstance(n.func, ast.Attribute)
+                and n.func.attr in self._LOG_METHODS
+                and isinstance(n.func.value, ast.Name)
+                and n.func.value.id == "logger"
+            ):
+                for arg in n.args:
+                    yield arg
+
+    def _assert_no_token_bytes(self, fn_name: str):
+        fn = _find_func(_module(), fn_name)
+        for arg in self._logger_call_args(fn):
+            for sub in ast.walk(arg):
+                # token[...] slice anywhere inside a log argument
+                if isinstance(sub, ast.Subscript) and isinstance(sub.value, ast.Name):
+                    self.assertNotEqual(
+                        sub.value.id, "token",
+                        f"{fn_name}: logger call must not embed a token slice "
+                        "(clear-text-logging of secret) — issue #513",
+                    )
+                # a captured token suffix reused in the log message
+                if isinstance(sub, ast.Name):
+                    self.assertNotIn(
+                        sub.id, self._FORBIDDEN_NAMES,
+                        f"{fn_name}: logger call must not reference '{sub.id}' "
+                        "(derived token bytes) — issue #513",
+                    )
+
+    def test_refresh_access_token_logs_no_token_bytes(self):
+        self._assert_no_token_bytes("refresh_access_token")
+
+    def test_write_initial_token_logs_no_token_bytes(self):
+        self._assert_no_token_bytes("write_initial_token")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Fixes the two HIGH CodeQL `py/clear-text-logging-sensitive-data` alerts (#7008 line 176, #7009 line 134) in `orchestrator/app/services/claude_token_service.py` — **real findings**, not false positives.

Both `refresh_access_token()` and `write_initial_token()` logged the **last 8 real characters** of the Claude OAuth token (`token[-8:]` / `old_suffix`). Even a partial suffix is secret material once it lands in aggregated logs.

## Changes
- Drop the `(…{old_suffix} → …{token_suffix})` / `(…{token[-8:]})` fragments from both log lines.
- The `token updated` branch only runs on rotation, so the message alone already signals the change — no operational value lost.
- Remove the now-dead `old_suffix` computation. The in-memory `_last_token_suffix` comparison (never logged) is unchanged, so rotation detection still works.
- Add stdlib AST regression guard (`TestNoTokenBytesLogged`) asserting neither function embeds a `token[...]` slice or a derived suffix name in any `logger.*` call.

## Test plan
- [x] `pytest tests/test_claude_token_initial_priority.py` → 7 passed (5 existing + 2 new)
- [x] `py_compile` + module import clean
- [ ] CodeQL python re-run clears #7008 / #7009
- Deploy gate: orchestrator image rebuild for the alert to clear on `main`.

Part of #513 (does not close it — path-injection bulk + overly-permissive-file chunks remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)