### PR TITLE
fix(security): tighten /shared perms + stop stack-trace exposure (part of #513)

### DIFF
--- a/orchestrator/app/api/agents.py
+++ b/orchestrator/app/api/agents.py
@@ -2577,13 +2577,20 @@ async def set_agent_telegram(
                 await tg_manager.start_bot(agent_id, agent.name, bot_token, auth_key)
                 bot_running = True
         except Exception as e:
-            # Token may be invalid - save config but report error. Redact so a
-            # provider error that echoes the token verbatim never leaks (#372).
+            # Token may be invalid - save config but report a generic error. The
+            # exception detail is logged server-side only; echoing it to the client
+            # would expose exception/stack internals (redact_logs still lets the
+            # message body through). Config is already committed above, so the admin
+            # can retry the token.
+            logger.warning(
+                "Telegram bot failed to start for agent %s: %s",
+                agent_id, redact_logs(str(e)),
+            )
             return {
                 "agent_id": agent_id,
                 "auth_key": auth_key,
                 "bot_running": False,
-                "error": redact_logs(str(e)),
+                "error": "Bot konnte nicht gestartet werden — bitte Bot-Token prüfen.",
             }
 
         return {

--- a/orchestrator/app/core/shared_volume.py
+++ b/orchestrator/app/core/shared_volume.py
@@ -14,7 +14,8 @@ installations (a fix in ``setup.sh``'s ``docker volume create`` would only help
 new installs). The permissions live in the volume on disk, so they survive
 container recreation and platform updates.
 
-Mode ``3775`` (``rwxrwsr-t``) is deliberate — two bits beyond plain group write:
+Mode ``3770`` (``rwxrws--T``) is deliberate — two bits beyond plain group write,
+and no access at all for *others*:
 
 * **sticky** — ``/shared`` holds the credential *sub-directories* ``.auth`` and
   ``.codex``. With the sticky bit an agent can only remove or rename entries it
@@ -25,6 +26,13 @@ Mode ``3775`` (``rwxrwsr-t``) is deliberate — two bits beyond plain group writ
   (see ``codex_auth_service._lock_agent_readonly`` / ``_secure_codex_dir``).
 * **setgid** — new subdirectories inherit the agent group, so two agents can
   genuinely collaborate inside the same folder instead of locking each other out.
+
+The *others* bits are stripped (``0`` instead of ``5``): the only processes that
+touch ``/shared`` are the orchestrator (root, via the owner bits) and the agent
+containers (uid 1000 / gid ``AGENT_GID``, via the group bits). Nothing legitimate
+reads ``/shared`` as "other", so world-read/execute is unnecessary exposure of a
+directory that carries credential sub-dirs — dropping it keeps every real actor's
+full access while removing the surface CodeQL flags as world-readable.
 """
 
 from __future__ import annotations
@@ -36,8 +44,8 @@ logger = logging.getLogger(__name__)
 
 SHARED_DIR = "/shared"
 AGENT_GID = 1000
-# rwxrwsr-t : owner=root, group=agent (writable), setgid + sticky
-SHARED_MODE = 0o3775
+# rwxrws--T : owner=root, group=agent (writable), setgid + sticky, no world access
+SHARED_MODE = 0o3770
 
 
 def ensure_shared_volume_perms(path: str = SHARED_DIR) -> bool:

--- a/orchestrator/tests/test_shared_volume_perms.py
+++ b/orchestrator/tests/test_shared_volume_perms.py
@@ -19,11 +19,19 @@ from app.core.shared_volume import (
 
 
 def test_mode_constant_is_setgid_sticky_group_writable():
-    # 3775 = rwxrwsr-t
-    assert SHARED_MODE == 0o3775
+    # 3770 = rwxrws--T
+    assert SHARED_MODE == 0o3770
     assert SHARED_MODE & stat.S_ISGID  # new subdirs inherit the agent group
     assert SHARED_MODE & stat.S_ISVTX  # sticky: agent can only remove its own entries
     assert SHARED_MODE & stat.S_IWGRP  # group (agent) may write
+
+
+def test_mode_grants_no_world_access():
+    # Only root (owner) and the agent group need /shared; "others" get nothing.
+    # World-read on a dir carrying credential sub-dirs is unnecessary exposure.
+    assert not SHARED_MODE & stat.S_IROTH  # no world read
+    assert not SHARED_MODE & stat.S_IWOTH  # no world write
+    assert not SHARED_MODE & stat.S_IXOTH  # no world execute
 
 
 def test_applies_owner_group_and_mode(tmp_path, monkeypatch):
@@ -43,7 +51,7 @@ def test_applies_owner_group_and_mode(tmp_path, monkeypatch):
     assert ensure_shared_volume_perms(str(target)) is True
     # owner root (uid 0), group = agent gid
     assert calls["chown"] == (str(target), 0, AGENT_GID)
-    assert calls["chmod"] == (str(target), 0o3775)
+    assert calls["chmod"] == (str(target), 0o3770)
 
 
 def test_creates_dir_when_missing(tmp_path, monkeypatch):


### PR DESCRIPTION
Third CodeQL triage chunk for #513. **Does not close #513** (multi-part issue).

## Alerts addressed

| Alert | Rule | Sev | Action |
|---|---|---|---|
| #7054 `shared_volume.py:54` | py/overly-permissive-file | HIGH | **Fix** — `0o3775`→`0o3770` |
| #7007 `agents.py:2582` | py/stack-trace-exposure | MED | **Fix** — log server-side, generic client message |
| #7047 `docker_apps.py:714` | py/cookie-injection | MED | **Dismissed** (false positive) |

## #7054 — overly-permissive-file (HIGH)
`/shared` was created `root:agent 0o3775` (`rwxrwsr-t`), i.e. world-readable + world-executable. The only processes that touch `/shared` are the orchestrator (root → owner bits) and agent containers (uid 1000 / gid `AGENT_GID` → group bits). Nothing legitimate accesses it as *other*, and `/shared` carries the credential sub-dirs `.auth`/`.codex`, so world read/execute is pure unnecessary exposure. Tightened to `0o3770` (`rwxrws--T`): **setgid + sticky preserved**, every real actor keeps full access, world access removed. New test `test_mode_grants_no_world_access` guards it.

## #7007 — stack-trace-exposure (MEDIUM)
The telegram-bot-start handler returned `redact_logs(str(e))` in the HTTP response body. `redact_logs` scrubs secrets but still lets the exception message/internals through to the client. Now the redacted detail is logged **server-side only** and the client gets a generic, actionable message (config is already committed, so the admin can retry the token).

## #7047 — cookie-injection (dismissed, FP)
`share_token` is only written to the cookie after `resolve_app_access()` validates it against an active DB share (`access == ACCESS_PUBLIC` gate). Starlette's `set_cookie` escapes the value via `SimpleCookie`, so CRLF/attribute injection is impossible. Dismissed via code-scanning API as *false positive*.

## Verification
- `pytest tests/test_shared_volume_perms.py` → 6 passed
- AST parse OK for both changed source files; `redact_logs` still imported/used

## Deploy gate
Orchestrator image rebuild for the perms change to re-run on existing installs (`docker compose up --build -d`). CodeQL clears #7054/#7007 on next scan of `main`.