### PR TITLE
fix(security): defuse Trivy secret false-positives in credential placeholders (part of #513)

### DIFF
--- a/frontend/src/app/integrations/page.tsx
+++ b/frontend/src/app/integrations/page.tsx
@@ -541,7 +541,7 @@ export default function IntegrationsPage() {
                               type={patVisible ? "text" : "password"}
                               value={patToken}
                               onChange={(e) => setPatToken(e.target.value)}
-                              placeholder="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                              placeholder="ghp_… (dein Personal Access Token)"
                               className="w-full rounded-lg border border-foreground/[0.08] bg-background/50 px-3 py-2 pr-9 text-sm font-mono outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all"
                               onKeyDown={(e) => e.key === "Enter" && handleSavePat(integration.provider)}
                             />

--- a/frontend/src/app/settings/view.tsx
+++ b/frontend/src/app/settings/view.tsx
@@ -943,7 +943,7 @@ export function SettingsView({ embedded = false }: { embedded?: boolean }) {
                     <textarea
                       value={vertexCredentials}
                       onChange={(e) => setVertexCredentials(e.target.value)}
-                      placeholder='{"type": "service_account", ...}'
+                      placeholder='{ … GCP-Service-Account-JSON hier einfügen … }'
                       rows={3}
                       className="w-full rounded-lg border border-foreground/[0.08] bg-foreground/[0.02] px-3.5 py-2.5 text-xs font-mono outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all placeholder:text-muted-foreground/25 resize-none"
                     />


### PR DESCRIPTION
## Summary
Part of #513 (CodeQL/Trivy security-alert triage).

Trivy's container image secret-scan raised **three CRITICAL "leaked secret" alerts** on the built frontend bundles:
- #7042 & #6205 — `gcp-service-account`
- #7043 — `github-pat`

All three are **false positives** — they are example/placeholder strings in credential input fields, not real secrets:

| Alert | Source | Why it matched |
|---|---|---|
| #7043 github-pat | `integrations/page.tsx:544` | PAT input placeholder `ghp_xxx…` (36 `x`) matches Trivy's `ghp_[0-9a-zA-Z]{36}` rule despite being an obvious dummy |
| #7042/#6205 gcp-service-account | `settings/view.tsx:946` | Vertex JSON textarea placeholder contained the literal `{"type": "service_account", ...}`, matching Trivy's GCP rule |

## Fix
Reworded both placeholders so they stay helpful for users but no longer match the secret regexes — this stops the false positives from **recurring on every image rebuild** (dismissing the alert alone would not, since Trivy re-scans the rebuilt image).

- `ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` → `ghp_… (dein Personal Access Token)`
- `{"type": "service_account", ...}` → `{ … GCP-Service-Account-JSON hier einfügen … }`

Verified at source: no remaining `ghp_[0-9a-zA-Z]{36}` or `"type": "service_account"` matches under `frontend/src`. No logic or behavior change — placeholder text only.

The three current alerts are being dismissed as false positive via the code-scanning API in parallel; this PR prevents recurrence.

## Test plan
- [ ] Frontend build + image rebuild → Trivy re-scan shows the 3 alerts gone (deploy gate: frontend image rebuild)
- [x] Static verification: secret regexes no longer match anywhere in `frontend/src`