### PR TITLE
fix(security): sanitize user-controlled log values — 19 py/log-injection (part of #513)

### DIFF
--- a/orchestrator/app/api/admin.py
+++ b/orchestrator/app/api/admin.py
@@ -9,6 +9,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_agent_version, settings
+from app.core.log_redaction import scrub_log
 from app.db.session import get_db
 from app.dependencies import get_docker_service, get_redis_service, require_auth
 from app.models.agent import Agent
@@ -95,7 +96,8 @@ async def restart_system_component(
         )
     name = targets[payload.target]
     actor = getattr(user, "email", None) or getattr(user, "id", "?")
-    logger.warning("[AdminSystem] restart '%s' (%s) requested by %s", payload.target, name, actor)
+    logger.warning("[AdminSystem] restart '%s' (%s) requested by %s",
+                   scrub_log(payload.target), name, scrub_log(actor))
 
     if payload.target == "orchestrator":
         # Self-restart: answer first, then restart detached so the HTTP response

--- a/orchestrator/app/api/agents.py
+++ b/orchestrator/app/api/agents.py
@@ -2544,7 +2544,7 @@ async def set_agent_telegram(
     from sqlalchemy.orm.attributes import flag_modified
     from app.telegram.bot_manager import generate_auth_key
 
-    from app.core.log_redaction import redact_logs
+    from app.core.log_redaction import redact_logs, scrub_log
 
     bot_token = body.bot_token.strip()
     # Reject a malformed value (e.g. a pasted BotFather message) before it is
@@ -2584,7 +2584,7 @@ async def set_agent_telegram(
             # can retry the token.
             logger.warning(
                 "Telegram bot failed to start for agent %s: %s",
-                agent_id, redact_logs(str(e)),
+                scrub_log(agent_id), redact_logs(str(e)),
             )
             return {
                 "agent_id": agent_id,

--- a/orchestrator/app/api/apps_overview.py
+++ b/orchestrator/app/api/apps_overview.py
@@ -25,6 +25,7 @@ from app.core.app_sharing import (
     is_app_owner,
     shared_projects_for_user,
 )
+from app.core.log_redaction import scrub_log
 from app.db.session import get_db
 from app.dependencies import get_docker_service, get_redis_service, require_auth
 from app.models.agent import Agent
@@ -521,7 +522,8 @@ async def create_app_share(
               "expires_at": expires_at.isoformat() if expires_at else None},
     ))
     await db.commit()
-    logger.info("[Apps] share created project=%s scope=%s by=%s", project, scope, user.id)
+    logger.info("[Apps] share created project=%s scope=%s by=%s",
+                scrub_log(project), scrub_log(scope), user.id)
 
     out = _share_dict(s)
     if token:

--- a/orchestrator/app/api/computer_use.py
+++ b/orchestrator/app/api/computer_use.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
+from app.core.log_redaction import scrub_log
 from app.dependencies import get_db, is_agent_principal, require_auth, require_auth_or_agent
 from app.services.redis_service import RedisService
 
@@ -169,7 +170,7 @@ async def _persist_session(session_id: str) -> None:
             _SESSION_KEY + session_id, json.dumps(payload), ex=_SESSION_TTL_SECS
         )
     except Exception:  # noqa: BLE001 — persistence is an optimization, not a gate
-        logger.debug("Could not persist computer-use session %s", session_id, exc_info=True)
+        logger.debug("Could not persist computer-use session %s", scrub_log(session_id), exc_info=True)
 
 
 async def _forget_session(session_id: str) -> None:
@@ -187,7 +188,7 @@ async def _forget_session(session_id: str) -> None:
     try:
         await _redis.client.delete(_SESSION_KEY + session_id)
     except Exception:  # noqa: BLE001 — Löschen darf keinen Request scheitern lassen
-        logger.warning("Could not delete computer-use session %s from Redis", session_id, exc_info=True)
+        logger.warning("Could not delete computer-use session %s from Redis", scrub_log(session_id), exc_info=True)
 
 
 async def _restore_session(session_id: str) -> dict | None:
@@ -225,7 +226,7 @@ async def _restore_session(session_id: str) -> dict | None:
         "capture_human": False,
     }
     _sessions[session_id] = session
-    logger.info("Restored computer-use session %s from Redis", session_id)
+    logger.info("Restored computer-use session %s from Redis", scrub_log(session_id))
     return session
 
 
@@ -598,7 +599,7 @@ async def dispatch_bridge_command(
     try:
         await session["bridge_ws"].send_text(command_msg)
         result = await asyncio.wait_for(result_future, timeout=req.timeout)
-        logger.info(f"[computer-use] session={session_id} action={req.action} #{session['action_count']}")
+        logger.info(f"[computer-use] session={scrub_log(session_id)} action={scrub_log(req.action)} #{session['action_count']}")
         await _touch_session(session_id)
         if req.action in _SCREEN_CHANGING_ACTIONS:
             if session.get("recording"):

--- a/orchestrator/app/api/docker_apps.py
+++ b/orchestrator/app/api/docker_apps.py
@@ -31,6 +31,7 @@ from app.core.app_sharing import (
     is_app_owner,
     resolve_app_access,
 )
+from app.core.log_redaction import scrub_log
 from app.db.session import get_db
 from app.dependencies import get_docker_service, optional_auth, require_auth
 from app.models.agent import Agent
@@ -314,7 +315,7 @@ async def _discover_core(docker: DockerService, agent: Agent, agent_id: str) -> 
             "find /workspace -maxdepth 3 -name 'docker-compose.yml' -o -name 'docker-compose.yaml' -o -name 'compose.yml' -o -name 'compose.yaml'",
         )
     except Exception as e:  # noqa: BLE001 — container not running / unreachable
-        logger.info("discover_apps: workspace not reachable for agent %s: %s", agent_id, e)
+        logger.info("discover_apps: workspace not reachable for agent %s: %s", scrub_log(agent_id), e)
         return {"apps": []}
 
     if exit_code != 0 or not stdout.strip():
@@ -455,12 +456,12 @@ async def _start_core(docker: DockerService, agent: Agent, agent_id: str, path: 
     )
 
     if exit_code != 0:
-        logger.error(f"Failed to start {project_name}: {output}")
+        logger.error(f"Failed to start {scrub_log(project_name)}: {output}")
         raise HTTPException(status_code=500, detail=f"Failed to start app: {output}")
 
     _connect_containers_to_network(docker, project_name)
     containers = _get_project_containers(docker, project_name)
-    logger.info(f"Docker app started: {project_name} ({len(containers)} containers)")
+    logger.info(f"Docker app started: {scrub_log(project_name)} ({len(containers)} containers)")
     return {"project": project_name, "status": "running", "containers": containers,
             "url": _app_public_url(agent_id, containers), "output": output}
 
@@ -473,12 +474,12 @@ async def _stop_core(docker: DockerService, agent: Agent, agent_id: str, path: s
     workspace_volume = agent.volume_name or f"workspace-{agent_id}"
     compose_file = _resolve_compose_file(docker, agent, path, require=False)
 
-    logger.info(f"Stopping Docker app: {project_name}")
+    logger.info(f"Stopping Docker app: {scrub_log(project_name)}")
     exit_code, output = await asyncio.to_thread(
         _run_compose, docker, workspace_volume, project_name, compose_file, ["down"],
     )
     if exit_code != 0:
-        logger.warning(f"Compose down warning for {project_name}: {output}")
+        logger.warning(f"Compose down warning for {scrub_log(project_name)}: {output}")
     return {"project": project_name, "status": "stopped", "output": output}
 
 

--- a/orchestrator/app/api/ws.py
+++ b/orchestrator/app/api/ws.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Query, WebSocket, WebSocketDisconnect, Request
 
+from app.core.log_redaction import scrub_log
 from app.core.stream_manager import StreamManager
 from app.db.session import async_session_factory
 from app.dependencies import get_current_user_ws, require_auth
@@ -133,7 +134,7 @@ async def _auto_inject_skills_for_chat(agent_id: str, text: str, is_new_session:
         async with async_session_factory() as skill_db:
             await auto_inject_skills(skill_db, agent_id, text)
     except Exception as e:
-        logger.warning(f"Skill auto-injection failed for chat session {session_id}: {e}")
+        logger.warning(f"Skill auto-injection failed for chat session {scrub_log(session_id)}: {e}")
 
 
 @router.websocket("/agents/{agent_id}/chat")

--- a/orchestrator/app/core/agent_manager.py
+++ b/orchestrator/app/core/agent_manager.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm.attributes import flag_modified
 
 from app.config import get_agent_version, settings
 from app.core.encryption import decrypt_token
+from app.core.log_redaction import scrub_log
 from app.dependencies import make_agent_token
 from app.models.agent import Agent, AgentState
 from app.models.agent_secret import AgentSecretAssignment, AgentSecret
@@ -771,7 +772,7 @@ class AgentManager:
             # No connected Redis client (e.g. a freshly instantiated RedisService in
             # the lifecycle recreate path) — nothing to publish to. Debug, not warn,
             # so the periodic sweep does not spam the log.
-            logger.debug(f"Skip publish event for agent {agent_id}: no Redis client")
+            logger.debug(f"Skip publish event for agent {scrub_log(agent_id)}: no Redis client")
             return
         try:
             event = json.dumps({
@@ -802,7 +803,7 @@ class AgentManager:
         streams responses on — no new mechanism.
         """
         if self.redis.client is None:
-            logger.debug(f"Skip cancel open chats for agent {agent_id}: no Redis client")
+            logger.debug(f"Skip cancel open chats for agent {scrub_log(agent_id)}: no Redis client")
             return
         try:
             event = json.dumps({
@@ -852,7 +853,7 @@ class AgentManager:
                         allowed_set = set(allowed)
                         servers = [s for s in servers if s.id in allowed_set]
             except Exception as e:
-                logger.warning(f"MCP role filter failed for agent {agent_id}: {e}")
+                logger.warning(f"MCP role filter failed for agent {scrub_log(agent_id)}: {e}")
 
         # OAuth-protected servers (#426): mint/refresh a fresh access token before
         # handing it to the agent, so a short-lived token never arrives already
@@ -1065,7 +1066,7 @@ class AgentManager:
         try:
             self._apply_permissions(container.id, agent_permissions)
         except Exception as e:
-            logger.warning(f"Could not apply permissions for agent {agent_id}: {e}")
+            logger.warning(f"Could not apply permissions for agent {scrub_log(agent_id)}: {e}")
 
         # Initialize workspace files
         agent_mounts = []
@@ -1348,7 +1349,7 @@ class AgentManager:
         try:
             self._apply_permissions(container.id, agent_permissions)
         except Exception as e:
-            logger.warning(f"Could not apply permissions for agent {agent_id}: {e}")
+            logger.warning(f"Could not apply permissions for agent {scrub_log(agent_id)}: {e}")
 
         # 5. Update team registry
         try:
@@ -1570,7 +1571,7 @@ class AgentManager:
         try:
             self._apply_permissions(container.id, agent_permissions)
         except Exception as e:
-            logger.warning(f"Could not apply permissions for agent {agent_id}: {e}")
+            logger.warning(f"Could not apply permissions for agent {scrub_log(agent_id)}: {e}")
 
         # 5. Refresh the instructions file — for EVERY mode (knowledge.md preserved).
         #    Claude Code reads /workspace/CLAUDE.md, Codex and Custom-LLM read
@@ -1585,7 +1586,7 @@ class AgentManager:
                 _instructions_file,
                 _render_claude_md(_agent_mounts, catalog),
             )
-            logger.info(f"Updated {_instructions_file} for agent {agent_id} (knowledge.md preserved)")
+            logger.info(f"Updated {_instructions_file} for agent {scrub_log(agent_id)} (knowledge.md preserved)")
         except Exception as e:
             logger.warning(f"Could not update {_instructions_file}: {e}")
 

--- a/orchestrator/app/core/file_manager.py
+++ b/orchestrator/app/core/file_manager.py
@@ -2,6 +2,7 @@ import logging
 import os
 import shlex
 
+from app.core.log_redaction import scrub_log
 from app.services.docker_service import DockerService
 
 logger = logging.getLogger(__name__)
@@ -156,7 +157,7 @@ class FileManager:
         self.docker.exec_in_container(container_id, ["mkdir", "-p", safe_path])
 
         self.docker.write_files_in_container(container_id, target_path, files)
-        logger.info(f"Uploaded {len(files)} files ({total_size} bytes) to {target_path}")
+        logger.info(f"Uploaded {len(files)} files ({total_size} bytes) to {scrub_log(target_path)}")
         return len(files)
 
     def search_files(

--- a/orchestrator/app/core/log_redaction.py
+++ b/orchestrator/app/core/log_redaction.py
@@ -47,3 +47,23 @@ def redact_logs(text: str) -> str:
     for pattern, repl in _PATTERNS:
         out = pattern.sub(repl, out)
     return out
+
+
+# C0/C1 control chars *except* tab (\x09) — CR/LF are removed explicitly first
+# (that ``.replace`` is the barrier CodeQL recognises for log-injection), then
+# this drops NULs and terminal-escape bytes that could still corrupt a log line.
+_LOG_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
+
+
+def scrub_log(value: object) -> str:
+    """Return ``value`` as a single-line string safe to interpolate into a log
+    record.
+
+    User-controlled input (agent/session ids, paths, request fields) can carry
+    ``\\r``/``\\n`` and forge or split log entries (CWE-117 log injection). This
+    removes line breaks and other control characters so a logged value can never
+    start a new, attacker-shaped log record. Use it to wrap any request-derived
+    value before it reaches ``logger.*``.
+    """
+    text = str(value).replace("\r", "").replace("\n", "")
+    return _LOG_CONTROL_CHARS.sub("", text)

--- a/orchestrator/tests/test_log_redaction.py
+++ b/orchestrator/tests/test_log_redaction.py
@@ -7,7 +7,7 @@ survives verbatim.
 
 import unittest
 
-from app.core.log_redaction import redact_logs
+from app.core.log_redaction import redact_logs, scrub_log
 
 
 class LogRedactionTests(unittest.TestCase):
@@ -55,6 +55,35 @@ class LogRedactionTests(unittest.TestCase):
 
     def test_empty_input(self):
         self.assertEqual(redact_logs(""), "")
+
+
+class ScrubLogTests(unittest.TestCase):
+    """CWE-117: user-controlled values must not be able to forge log records."""
+
+    def test_newlines_removed(self):
+        forged = "agent-1\nINFO fake admin login succeeded"
+        out = scrub_log(forged)
+        self.assertNotIn("\n", out)
+        self.assertEqual(out, "agent-1INFO fake admin login succeeded")
+
+    def test_carriage_return_removed(self):
+        out = scrub_log("sess\r\nDELETE /everything")
+        self.assertNotIn("\r", out)
+        self.assertNotIn("\n", out)
+
+    def test_other_control_chars_removed(self):
+        # NUL and an ANSI escape must not survive into a log line.
+        out = scrub_log("id\x00\x1b[31mred")
+        self.assertNotIn("\x00", out)
+        self.assertNotIn("\x1b", out)
+        self.assertEqual(out, "id[31mred")
+
+    def test_tab_and_plain_text_survive(self):
+        self.assertEqual(scrub_log("proj\tname-42"), "proj\tname-42")
+
+    def test_non_string_coerced(self):
+        self.assertEqual(scrub_log(1234), "1234")
+        self.assertEqual(scrub_log(None), "None")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Part of #513 — the CodeQL `py/log-injection` (CWE-117) chunk in our own Python code.

## Problem
19 open `py/log-injection` alerts: request-derived values (agent/session ids, compose project paths, upload target path, share project/scope, admin actor) reach `logger.*` without stripping line breaks. An attacker who controls such a value could embed `\r\n` and forge a second, fake log record. `redact_logs()` masks secrets but does **not** remove newlines, so it did not cover this.

## Fix
- New `scrub_log(value)` in `orchestrator/app/core/log_redaction.py`: explicit `\r`/`\n` removal (the barrier CodeQL recognises for log-injection) plus a regex that drops remaining C0/C1 control chars (NULs, ANSI escapes). Tab and normal text survive; non-strings are coerced.
- Wrapped the tainted argument at all 19 flagged sinks across: `api/admin.py`, `api/apps_overview.py`, `api/computer_use.py` (4), `api/docker_apps.py` (5), `api/ws.py`, `core/agent_manager.py` (5, incl. 2 sibling call-sites for consistency), `core/file_manager.py`.
- `ScrubLogTests` added to `tests/test_log_redaction.py` (CR/LF removal, control-char removal, tab/plain survive, non-string coercion).

## Verification
- `pytest tests/test_log_redaction.py` → 13 passed.
- `py_compile` clean on all 8 edited modules; `log_redaction` imports cleanly.
- **Deploy gate:** the alerts clear only after an orchestrator image rebuild + CodeQL re-scan on `main`.

Uses `part of #513` (not `Fixes`) so the multi-part security issue stays open for the remaining deploy-gated items.