### PR TITLE
fix(security): strip U+2028/U+2029 in scrub_log (part of #513)

### DIFF
--- a/orchestrator/app/core/log_redaction.py
+++ b/orchestrator/app/core/log_redaction.py
@@ -52,7 +52,9 @@ def redact_logs(text: str) -> str:
 # C0/C1 control chars *except* tab (\x09) — CR/LF are removed explicitly first
 # (that ``.replace`` is the barrier CodeQL recognises for log-injection), then
 # this drops NULs and terminal-escape bytes that could still corrupt a log line.
-_LOG_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
+# U+2028/U+2029 (LINE/PARAGRAPH SEPARATOR) are stripped too: some JSON/JS log
+# viewers treat them as line breaks, so they are a line-forging bypass candidate.
+_LOG_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f  ]")
 
 
 def scrub_log(value: object) -> str:

--- a/orchestrator/tests/test_log_redaction.py
+++ b/orchestrator/tests/test_log_redaction.py
@@ -78,6 +78,14 @@ class ScrubLogTests(unittest.TestCase):
         self.assertNotIn("\x1b", out)
         self.assertEqual(out, "id[31mred")
 
+    def test_unicode_line_separators_removed(self):
+        # U+2028/U+2029 are treated as line breaks by some JSON/JS log viewers
+        # and must not survive to forge a new log line.
+        out = scrub_log("sess DELETE /all")
+        self.assertNotIn(" ", out)
+        self.assertNotIn(" ", out)
+        self.assertEqual(out, "sessDELETE/all")
+
     def test_tab_and_plain_text_survive(self):
         self.assertEqual(scrub_log("proj\tname-42"), "proj\tname-42")
 


### PR DESCRIPTION
## Summary
Follow-up to PR #520 (log-injection scrub). CodeReview flagged that `scrub_log()` stripped C0/C1 control chars and CR/LF, but **not** the Unicode `LINE SEPARATOR` (U+2028) and `PARAGRAPH SEPARATOR` (U+2029). Some JSON/JS-based log viewers treat these as line breaks, making them a log-injection (CWE-117) bypass candidate.

- Added U+2028/U+2029 to `_LOG_CONTROL_CHARS` in `orchestrator/app/core/log_redaction.py`
- Added `test_unicode_line_separators_removed` regression test

Part of #513. Addresses Warning 1 from the PR #520 review report.

## Test plan
- [x] `python3 -m unittest tests.test_log_redaction` — 14/14 pass
- [x] Verified tab (U+0009) and plain text still survive