### PR TITLE
fix(admin): reset githubConnected to null on transient create-issue error

### DIFF
--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1514,7 +1514,7 @@ function FeedbackTab({
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       if (msg.toLowerCase().includes("not connected") || msg.toLowerCase().includes("integration not connected")) {
-        setGithubConnected(false);
+        setGithubConnected(null);
         toast.warning(
           "GitHub nicht verbunden",
           "Bitte zuerst unter Einstellungen → Integrationen einen GitHub-Account (PAT) verbinden."


### PR DESCRIPTION
## Summary
- `handleCreateIssue`'s catch block set `githubConnected(false)` on any "not connected" error, permanently disabling the button even for transient/non-definitive errors
- Changed to `null` (unknown/re-check), matching the tri-state pattern already used by the initial `getIntegrations().catch(() => setGithubConnected(null))` handler

Note: this PR does not close any tracked issue (the earlier "Fixes #191" reference was incorrect — #191 is an unrelated open SIP/phone-adapter feature and would have been auto-closed wrongly on merge).

## Test plan
- [ ] Trigger a "not connected" error while creating a GitHub issue from feedback and confirm the button returns to an unknown/re-checkable state instead of being permanently locked to disconnected

🤖 Generated with [Claude Code](https://claude.com/claude-code)