### PR TITLE
fix(security): sanitize user-controlled values before logging (chunk 1/#513)

### DIFF
--- a/orchestrator/app/api/brains.py
+++ b/orchestrator/app/api/brains.py
@@ -74,7 +74,7 @@ def _seed_file(path: str, content: str, mode: int = 0o666) -> None:
                 fh.write(content)
             os.chmod(path, mode)
         except OSError as e:
-            log.warning("Could not write %s: %s", path, e)
+            log.warning("Could not write %s: %s", vault.safe_log(path), vault.safe_log(e))
 
 
 def _require_admin(user) -> None:
@@ -108,7 +108,7 @@ def _provision_vault(host_path: str, name: str, standard: str = "freeform") -> N
     try:
         os.chmod(real, 0o777)
     except OSError as e:
-        log.warning("Could not chmod vault %s: %s", real, e)
+        log.warning("Could not chmod vault %s: %s", vault.safe_log(real), vault.safe_log(e))
     # Scaffold folders for the standard
     for folder in _FOLDERS.get(standard, []):
         d = os.path.join(real, folder)
@@ -130,7 +130,7 @@ def _provision_vault(host_path: str, name: str, standard: str = "freeform") -> N
             subprocess.run(["git", "add", "-A"], cwd=real, check=False, timeout=20)
             subprocess.run(["git", "commit", "-q", "-m", "init vault"], cwd=real, check=False, env=env, timeout=20)
         except (OSError, subprocess.SubprocessError) as e:
-            log.warning("git init for vault %s failed (history disabled): %s", real, e)
+            log.warning("git init for vault %s failed (history disabled): %s", vault.safe_log(real), vault.safe_log(e))
 
 
 async def _audit(db: AsyncSession, event: AuditEventType, brain: SecondBrain, user_id: str) -> None:
@@ -432,7 +432,7 @@ async def brain_write_file(brain_id: int, body: BrainFileWrite, user=Depends(req
     try:
         await vault_indexer.index_file(db, brain.label, brain.host_path, body.path)
     except Exception as e:
-        log.warning("reindex after write failed brain=%s path=%s: %s", brain.slug, vault.safe_log(body.path), e)
+        log.warning("reindex after write failed brain=%s path=%s: %s", brain.slug, vault.safe_log(body.path), vault.safe_log(e))
     return {"ok": True, "path": body.path}
 
 
@@ -454,7 +454,7 @@ async def brain_delete_file(brain_id: int, path: str, user=Depends(require_auth)
     try:
         await vault_indexer.remove_file(db, brain.label, path)
     except Exception as e:
-        log.warning("deindex after delete failed brain=%s path=%s: %s", brain.slug, vault.safe_log(path), e)
+        log.warning("deindex after delete failed brain=%s path=%s: %s", brain.slug, vault.safe_log(path), vault.safe_log(e))
     return {"ok": True, "path": path}
 
 

--- a/orchestrator/app/api/meeting_rooms.py
+++ b/orchestrator/app/api/meeting_rooms.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_db
 from app.dependencies import require_auth
+from app.core.log_redaction import scrub_log
 from app.models.meeting_room import MeetingRoom
 from app.models.agent import Agent, AgentState
 
@@ -341,7 +342,7 @@ async def launch_deliverable(
             _yaml.safe_dump(spec, fh)
         compose_path = f"/shared/taskforce/{room_id}/{launch_name}"
     except Exception as e:  # noqa: BLE001 — fall back to the original file
-        logger.warning("[Taskforce %s] compose rewrite failed: %s", room_id, e)
+        logger.warning("[Taskforce %s] compose rewrite failed: %s", scrub_log(room_id), scrub_log(e))
         compose_path = f"/shared/taskforce/{room_id}/{compose_name}"
 
     def _run():
@@ -361,10 +362,10 @@ async def launch_deliverable(
         # Log the raw compose/docker stderr server-side ONLY — never echo it to the
         # client (may contain paths, image/registry details, env hints).
         err = e.stderr.decode("utf-8", "replace") if isinstance(e.stderr, (bytes, bytearray)) else str(e)
-        logger.warning("[Taskforce %s] launch failed: %s", room_id, err)
+        logger.warning("[Taskforce %s] launch failed: %s", scrub_log(room_id), scrub_log(err))
         raise HTTPException(status_code=500, detail="Start fehlgeschlagen — Build/Start-Fehler (Details im Server-Log).")
     except Exception as e:  # noqa: BLE001
-        logger.warning("[Taskforce %s] launch error: %s", room_id, e)
+        logger.warning("[Taskforce %s] launch error: %s", scrub_log(room_id), scrub_log(e))
         raise HTTPException(status_code=500, detail="Start fehlgeschlagen.")
 
     _connect_containers_to_network(docker, project)
@@ -723,10 +724,10 @@ async def _start_moderator_container(room_id: str, docker, redis_url_internal: s
             needs_sudo=False,
         )
         _moderator_containers[room_id] = container.id
-        logger.info(f"[Moderator] Container started for room {room_id}: {container.id[:12]}")
+        logger.info(f"[Moderator] Container started for room {scrub_log(room_id)}: {container.id[:12]}")
         return mod_id
     except Exception as e:
-        logger.warning(f"[Moderator] Failed to start container for room {room_id}: {e}")
+        logger.warning(f"[Moderator] Failed to start container for room {scrub_log(room_id)}: {scrub_log(e)}")
         return None
 
 
@@ -740,7 +741,7 @@ async def _stop_moderator_container(room_id: str, docker) -> None:
         try:
             c = docker.client.containers.get(ref)
             c.remove(force=True)
-            logger.info(f"[Moderator] Container removed for room {room_id}")
+            logger.info(f"[Moderator] Container removed for room {scrub_log(room_id)}")
         except Exception:
             pass
 
@@ -767,7 +768,7 @@ async def _moderator_request(room_id: str, mod_id: str, prompt: str, redis, time
         if result:
             return result if isinstance(result, str) else result.decode()
         await asyncio.sleep(5)
-    logger.warning(f"[Moderator] No response from container for room {room_id} within {timeout_rounds * 5}s")
+    logger.warning(f"[Moderator] No response from container for room {scrub_log(room_id)} within {timeout_rounds * 5}s")
     return None
 
 
@@ -1064,7 +1065,7 @@ async def _run_meeting(room_id: str, redis, mod_agent_id: str | None = None, doc
                     break
 
                 if room.max_rounds > 0 and room.rounds_completed >= room.max_rounds:
-                    logger.info(f"Meeting room {room_id} completed after {room.rounds_completed} rounds")
+                    logger.info(f"Meeting room {scrub_log(room_id)} completed after {room.rounds_completed} rounds")
                     await _generate_todo_summary(room, redis, mod_agent_id=mod_agent_id, docker=docker)
                     room.state = "completed"
                     await db.commit()
@@ -1307,9 +1308,9 @@ async def _run_meeting(room_id: str, redis, mod_agent_id: str | None = None, doc
                 await asyncio.sleep(2)
 
     except asyncio.CancelledError:
-        logger.info(f"Meeting room {room_id} cancelled")
+        logger.info(f"Meeting room {scrub_log(room_id)} cancelled")
     except Exception as e:
-        logger.error(f"Meeting room {room_id} error: {e}")
+        logger.error(f"Meeting room {scrub_log(room_id)} error: {scrub_log(e)}")
         async with async_session_factory() as db:
             room = await db.scalar(select(MeetingRoom).where(MeetingRoom.id == room_id))
             if room:
@@ -1925,7 +1926,7 @@ async def dispatch_integration_task(room_id: str, redis, docker=None) -> bool:
         _json.dumps({"id": task_id, "prompt": prompt_text, "model": None, "priority": priority}),
     )
     await redis.client.publish(f"meeting:{room_id}:updates", _json.dumps(msg))
-    logger.info(f"[Meeting {room_id}] Integration task dispatched to coordinator {coordinator_id}")
+    logger.info(f"[Meeting {scrub_log(room_id)}] Integration task dispatched to coordinator {scrub_log(coordinator_id)}")
     return True
 
 

--- a/orchestrator/app/core/skill_file_storage.py
+++ b/orchestrator/app/core/skill_file_storage.py
@@ -10,6 +10,7 @@ import os
 from pathlib import Path
 
 from app.config import settings
+from app.core.log_redaction import scrub_log
 
 logger = logging.getLogger(__name__)
 
@@ -87,5 +88,5 @@ def get_all_files_for_agent(skill_id: int) -> list[tuple[str, bytes]]:
         try:
             result.append((name, read_file(skill_id, name)))
         except Exception as e:
-            logger.warning(f"Could not read skill file {name} for skill {skill_id}: {e}")
+            logger.warning(f"Could not read skill file {scrub_log(name)} for skill {skill_id}: {scrub_log(e)}")
     return result


### PR DESCRIPTION
## Summary
- Part of the #513 CodeQL security sprint — the tracking note said ~19 open `py/log-injection` alerts remained after PR #515/#516, but a fresh scan shows **~100+ open alerts** across ~25 files. Fixing in reviewable chunks instead of one giant PR.
- Chunk 1 covers the 16 alerts in the files already named in the original #513 triage notes:
  - `orchestrator/app/api/brains.py` (5 alerts) — vault paths + exception text now go through the existing `vault.safe_log()` helper (already partially used in this file)
  - `orchestrator/app/api/meeting_rooms.py` (10 alerts + a few unflagged sibling occurrences of the same pattern, fixed for consistency) — `room_id`/`coordinator_id`/exception text now go through `app.core.log_redaction.scrub_log()`, the convention already established in `agent_manager.py`, `admin.py`, `ws.py`, `docker_apps.py`, `computer_use.py`, `agents.py`
  - `orchestrator/app/core/skill_file_storage.py` (1 alert) — user-supplied filename now scrubbed
- No behavior change — only log-line sanitization (CWE-117 log forging). CR/LF and other control chars stripped from attacker-controlled values before they reach `logger.*`.

## Follow-up
Remaining ~85 alerts (mostly `orchestrator/app/core/agent_manager.py`, `msgraph_mcp.py`, `oauth_service.py`, `task_router.py`, `computer_use.py`, `docker_apps.py`, `ws.py`, `secrets.py`, `agent_guard.py`, `sso_service.py`) will follow in subsequent chunked PRs against the same rule. Issue #513 should stay open until all chunks land.

## Test plan
- [x] `python3 -m py_compile` on all 3 changed files
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)