### PR TITLE
fix(security): sanitize user-controlled values before logging (chunk 2/#513)

### DIFF
--- a/orchestrator/app/api/ws.py
+++ b/orchestrator/app/api/ws.py
@@ -935,7 +935,7 @@ async def ws_agent_voice(
         async with async_session_factory() as db:
             await session.init(db)
     except Exception as e:  # noqa: BLE001
-        logger.exception("voice session init failed agent=%s model=%s", agent_id, interaction_model)
+        logger.exception("voice session init failed agent=%s model=%s", scrub_log(agent_id), scrub_log(interaction_model))
         try:
             await websocket.send_text(json.dumps({
                 "type": "error",
@@ -954,7 +954,7 @@ async def ws_agent_voice(
                 except (WebSocketDisconnect, RuntimeError):
                     break
         except Exception:
-            logger.warning("voice outbound pump stopped agent=%s", agent_id, exc_info=True)
+            logger.warning("voice outbound pump stopped agent=%s", scrub_log(agent_id), exc_info=True)
 
     def _log_voice_turn_done(task: asyncio.Task) -> None:
         try:
@@ -1000,20 +1000,20 @@ async def ws_agent_voice(
                         session.push_audio_chunk(chunk)
                         logger.debug(
                             "voice ws chunk agent=%s session=%s bytes=%d",
-                            agent_id,
+                            scrub_log(agent_id),
                             session.session_id,
                             len(chunk),
                         )
                     except Exception:
-                        logger.warning("voice ws invalid audio chunk agent=%s", agent_id, exc_info=True)
+                        logger.warning("voice ws invalid audio chunk agent=%s", scrub_log(agent_id), exc_info=True)
             elif mtype == "commit":
                 lang = mdata.get("language")
                 # Process turn in background so we keep accepting interrupts
                 logger.debug(
                     "voice ws commit agent=%s session=%s language=%s",
-                    agent_id,
+                    scrub_log(agent_id),
                     session.session_id,
-                    lang,
+                    scrub_log(lang),
                 )
                 task = asyncio.create_task(session.commit_turn(language=lang))
                 task.add_done_callback(_log_voice_turn_done)

--- a/orchestrator/app/core/agent_manager.py
+++ b/orchestrator/app/core/agent_manager.py
@@ -789,7 +789,7 @@ class AgentManager:
             await self.redis.client.rpush(history_key, event)
             await self.redis.client.ltrim(history_key, -200, -1)
         except Exception as e:
-            logger.warning(f"Could not publish event for agent {agent_id}: {e}")
+            logger.warning(f"Could not publish event for agent {scrub_log(agent_id)}: {scrub_log(e)}")
 
     async def _cancel_open_chats(self, agent_id: str, reason: str) -> None:
         """Broadcast a terminal ``cancelled`` event to any open chat streams for this
@@ -815,7 +815,7 @@ class AgentManager:
             })
             await self.redis.client.publish(f"agent:{agent_id}:chat:response", event)
         except Exception as e:  # noqa: BLE001 — best effort, never block the restart
-            logger.warning(f"Could not cancel open chats for agent {agent_id}: {e}")
+            logger.warning(f"Could not cancel open chats for agent {scrub_log(agent_id)}: {scrub_log(e)}")
 
     async def _get_custom_mcp_env(self, agent_config: dict | None = None, agent_id: str | None = None, agent_integrations: list[str] | None = None) -> dict[str, str]:
         """Load custom MCP servers and return as env var dict.
@@ -1191,7 +1191,7 @@ class AgentManager:
                 "chmod 0440 /etc/sudoers.d/agent-permissions",
                 user="root",
             )
-            logger.info(f"Applied permissions {permissions} to container {container_id[:12]}")
+            logger.info(f"Applied permissions {scrub_log(permissions)} to container {scrub_log(container_id[:12])}")
         else:
             # No permissions - remove any existing sudoers file
             self.docker.exec_in_container(
@@ -1372,7 +1372,7 @@ class AgentManager:
                 except Exception:
                     pass
         except Exception as e:
-            logger.warning(f"Could not refresh instructions file for agent {agent_id}: {e}")
+            logger.warning(f"Could not refresh instructions file for agent {scrub_log(agent_id)}: {scrub_log(e)}")
 
         # 6. Update DB
         agent.container_id = container.id
@@ -1380,7 +1380,7 @@ class AgentManager:
         await self.db.commit()
         await self.db.refresh(agent)
 
-        logger.info(f"Agent {agent_id} restarted with fresh config")
+        logger.info(f"Agent {scrub_log(agent_id)} restarted with fresh config")
         await self._publish_event(agent_id, "system", "Agent restarted successfully with updated config")
         return agent
 
@@ -1391,7 +1391,7 @@ class AgentManager:
             try:
                 self.docker.stop_container(agent.container_id)
             except (NotFound, APIError) as e:
-                logger.warning(f"Container {agent.container_id} not found when stopping agent {agent_id}: {e}")
+                logger.warning(f"Container {scrub_log(agent.container_id)} not found when stopping agent {scrub_log(agent_id)}: {scrub_log(e)}")
         agent.state = AgentState.STOPPED
         await self.db.commit()
         await self._publish_event(agent_id, "system", "Agent stopped")
@@ -1402,12 +1402,12 @@ class AgentManager:
         agent = await self._get_agent(agent_id)
         if not agent.container_id:
             # No container exists — recreate it (keeps volumes/data)
-            logger.info(f"Agent {agent_id} has no container — recreating via update_agent")
+            logger.info(f"Agent {scrub_log(agent_id)} has no container — recreating via update_agent")
             return await self.update_agent(agent_id)
         try:
             self.docker.start_container(agent.container_id)
         except NotFound:
-            logger.warning(f"Container {agent.container_id} not found for agent {agent_id} — recreating")
+            logger.warning(f"Container {scrub_log(agent.container_id)} not found for agent {scrub_log(agent_id)} — recreating")
             return await self.update_agent(agent_id)
         await self.refresh_instructions(agent)
         agent.state = AgentState.RUNNING
@@ -1605,7 +1605,7 @@ class AgentManager:
         await self.db.commit()
         await self.db.refresh(agent)
 
-        logger.info(f"Agent {agent_id} updated to new image version")
+        logger.info(f"Agent {scrub_log(agent_id)} updated to new image version")
         return agent
 
     async def update_llm_config(self, agent_id: str, updates: dict) -> dict:
@@ -1658,7 +1658,7 @@ class AgentManager:
             try:
                 self.docker.remove_container(agent.container_id)
             except (NotFound, APIError) as e:
-                logger.warning(f"Container {agent.container_id} already gone for agent {agent_id}: {e}")
+                logger.warning(f"Container {scrub_log(agent.container_id)} already gone for agent {scrub_log(agent_id)}: {scrub_log(e)}")
         if remove_data and agent.volume_name:
             self.docker.remove_volume(agent.volume_name)
             config = agent.config or {}
@@ -1720,7 +1720,7 @@ class AgentManager:
                     )
                     await sync_session.commit()
                 agent.state = new_state
-                logger.info(f"Agent {agent_id} container status={container_status}, state→{new_state.name}")
+                logger.info(f"Agent {scrub_log(agent_id)} container status={scrub_log(container_status)}, state→{new_state.name}")
 
         config = agent.config or {}
 

--- a/orchestrator/app/core/task_router.py
+++ b/orchestrator/app/core/task_router.py
@@ -10,6 +10,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.load_balancer import LoadBalancer
+from app.core.log_redaction import scrub_log
 from app.models.approval_rule import ApprovalRule
 from app.models.task import Task, TaskStatus, is_terminal_task_status
 from app.models.task_step import TaskStep
@@ -278,7 +279,7 @@ class TaskRouter:
                 return task
 
         if not await self._agent_exists(agent_id):
-            logger.warning("Cannot route task %s to missing agent %s", task_id, agent_id)
+            logger.warning("Cannot route task %s to missing agent %s", scrub_log(task_id), scrub_log(agent_id))
             task = Task(
                 id=task_id,
                 title=title,
@@ -347,7 +348,7 @@ class TaskRouter:
                 from app.services.user_lifecycle import wake_agent
                 await wake_agent(self.db, self.docker, agent_id)
             except Exception as e:
-                logger.warning(f"Could not wake agent {agent_id} before task: {e}")
+                logger.warning(f"Could not wake agent {scrub_log(agent_id)} before task: {scrub_log(e)}")
 
         # Push to agent's Redis queue
         task_payload = json.dumps(
@@ -390,7 +391,7 @@ class TaskRouter:
                 await self.redis.client.rpush(history_key, event)
                 await self.redis.client.ltrim(history_key, -200, -1)
         except Exception as e:
-            logger.warning(f"Could not publish activity for agent {agent_id}: {e}")
+            logger.warning(f"Could not publish activity for agent {scrub_log(agent_id)}: {scrub_log(e)}")
 
     async def handle_task_start(self, data: dict) -> None:
         """Update task status to RUNNING when agent picks it up."""
@@ -472,7 +473,7 @@ class TaskRouter:
                     except (json.JSONDecodeError, TypeError):
                         pass
         except Exception as e:
-            logger.warning(f"Could not remove task {task_id} from Redis queue: {e}")
+            logger.warning(f"Could not remove task {scrub_log(task_id)} from Redis queue: {scrub_log(e)}")
 
     async def handle_task_completion(self, data: dict) -> None:
         task_id = data["task_id"]
@@ -1061,7 +1062,7 @@ class TaskRouter:
                     self.docker.stop_container(agent.container_id)
                 except Exception as e:
                     logger.warning(
-                        f"Could not stop over-budget agent {agent_id}: {e}"
+                        f"Could not stop over-budget agent {scrub_log(agent_id)}: {scrub_log(e)}"
                     )
             await self.db.commit()
             raise ValueError(
@@ -1071,7 +1072,7 @@ class TaskRouter:
 
         # Default action: downgrade to the cheap fallback model.
         logger.info(
-            f"[Budget] {reason} → agent {agent_id} downgraded to {BUDGET_FALLBACK_MODEL}"
+            f"[Budget] {scrub_log(reason)} → agent {scrub_log(agent_id)} downgraded to {BUDGET_FALLBACK_MODEL}"
         )
         return BUDGET_FALLBACK_MODEL
 
@@ -1107,11 +1108,11 @@ class TaskRouter:
             if coerced != model:
                 logger.info(
                     "[ModelCoerce] task model %s incompatible with agent %s (mode=%s) → %s",
-                    model, agent_id, mode, coerced,
+                    scrub_log(model), scrub_log(agent_id), scrub_log(mode), scrub_log(coerced),
                 )
             return coerced
         except Exception as e:
-            logger.warning(f"Model coercion skipped for agent {agent_id}: {e}")
+            logger.warning(f"Model coercion skipped for agent {scrub_log(agent_id)}: {scrub_log(e)}")
             return model
 
     async def _check_budget_thresholds(self, agent_id: str) -> None:


### PR DESCRIPTION
## Summary
Continues the `py/log-injection` (CWE-117) remediation started in #527 (chunk 1). Wraps `agent_id`, `task_id`, exception text, and other request/DB-derived values with the existing `app.core.log_redaction.scrub_log()` helper before they reach `logger.*` calls, preventing CR/LF or control-char injection into log entries.

Same convention as chunk 1 — no new sanitization logic invented, just reusing the established helper.

## Files fixed (27 CodeQL alerts)
- `orchestrator/app/core/agent_manager.py` — 11 alerts
- `orchestrator/app/api/ws.py` — 6 alerts (voice session sub-flows)
- `orchestrator/app/core/task_router.py` — 10 alerts (added `scrub_log` import, wasn't previously used in this file)

## Scope
Part of #513. Combined with chunk 1 (#527), 43 of the ~103 open alerts are now covered. Remaining ~58 are concentrated in `computer_use.py`, `msgraph_mcp.py`, `oauth_service.py`, `docker_apps.py`, `brain_mcp.py`, `skill_marketplace.py`, and a handful of smaller files — planned as further follow-up chunks. #513 should stay open until all chunks are merged.

## Test plan
- [x] `python3 -m py_compile` on all three touched files
- [x] Manual review of each diff — only wraps log arguments, no behavior change
- [ ] CodeReview (not self-merging security PRs, per team convention from #515/#516)

🤖 Generated with [Claude Code](https://claude.com/claude-code)