### PR TITLE
fix(security): sanitize user-controlled values before logging (chunk 4/#513)

### DIFF
--- a/orchestrator/app/api/brain_mcp.py
+++ b/orchestrator/app/api/brain_mcp.py
@@ -266,11 +266,11 @@ async def _call_tool(name: str, args: dict, brain: SecondBrain, db: AsyncSession
             return _tool_result(f"File already exists: {path} (set overwrite=true to replace).", is_error=True)
         except ValueError as e:
             return _tool_result(f"Error: {e}", is_error=True)
-        logger.info("brain_write brain=%s path=%s created=%s bytes=%s", brain.slug, vault.safe_log(path), res["created"], res["bytes"])
+        logger.info("brain_write brain=%s path=%s created=%s bytes=%s", vault.safe_log(brain.slug), vault.safe_log(path), res["created"], res["bytes"])
         try:
             await vault_indexer.index_file(db, brain.label, brain.host_path, path)
         except Exception as e:  # indexing must not fail the write
-            logger.warning("brain_write reindex failed brain=%s path=%s: %s", brain.slug, vault.safe_log(path), e)
+            logger.warning("brain_write reindex failed brain=%s path=%s: %s", brain.slug, vault.safe_log(path), vault.safe_log(e))
         verb = "Created" if res["created"] else "Updated"
         return _tool_result(f"{verb} {path} in {brain.name} ({res['bytes']} bytes).")
 
@@ -286,11 +286,11 @@ async def _call_tool(name: str, args: dict, brain: SecondBrain, db: AsyncSession
             return _tool_result(f"File not found: {path}", is_error=True)
         except ValueError as e:
             return _tool_result(f"Error: {e}", is_error=True)
-        logger.info("brain_delete brain=%s path=%s", brain.slug, vault.safe_log(path))
+        logger.info("brain_delete brain=%s path=%s", vault.safe_log(brain.slug), vault.safe_log(path))
         try:
             await vault_indexer.remove_file(db, brain.label, path)
         except Exception as e:
-            logger.warning("brain_delete deindex failed brain=%s path=%s: %s", brain.slug, vault.safe_log(path), e)
+            logger.warning("brain_delete deindex failed brain=%s path=%s: %s", brain.slug, vault.safe_log(path), vault.safe_log(e))
         return _tool_result(f"Deleted {path} from {brain.name}.")
 
     return _tool_result(f"Unknown tool: {name}", is_error=True)

--- a/orchestrator/app/core/msgraph_mcp.py
+++ b/orchestrator/app/core/msgraph_mcp.py
@@ -19,6 +19,8 @@ from urllib.parse import quote
 
 import httpx
 
+from app.core.log_redaction import scrub_log
+
 logger = logging.getLogger(__name__)
 
 GRAPH_BASE = "https://graph.microsoft.com/v1.0"
@@ -890,7 +892,7 @@ async def _graph(method: str, path: str, token: str, **kwargs) -> dict:
                     detail = str((body.get("error", {}) or {}).get("message", ""))[:300]
             except Exception:
                 detail = resp.text[:300]
-            logger.warning("Graph API %s on %s: %s", resp.status_code, path, detail)
+            logger.warning("Graph API %s on %s: %s", resp.status_code, scrub_log(path), scrub_log(detail))
             raise GraphError(resp.status_code, f"Microsoft Graph request failed (HTTP {resp.status_code}).")
         try:
             return resp.json()
@@ -993,7 +995,7 @@ async def _graph_bytes(method: str, path: str, token: str, content: bytes | None
     async with httpx.AsyncClient(timeout=30.0) as client:
         resp = await client.request(method, f"{GRAPH_BASE}{path}", headers=headers, content=content)
         if resp.status_code >= 400:
-            logger.warning("Graph API %s on %s: %s", resp.status_code, path, resp.text[:200])
+            logger.warning("Graph API %s on %s: %s", resp.status_code, scrub_log(path), scrub_log(resp.text[:200]))
             raise RuntimeError(f"Microsoft Graph request failed (HTTP {resp.status_code}).")
         return resp
 
@@ -1056,7 +1058,7 @@ def _extract_document_text(raw: bytes, filename: str, content_type: str, max_cha
                     break
             return _clip("\n".join(parts)) or "Die Excel-Datei enthält keine Daten."
     except Exception as e:  # noqa: BLE001
-        logger.warning("document extraction failed for %s: %s", filename, e)
+        logger.warning("document extraction failed for %s: %s", scrub_log(filename), scrub_log(e))
         return f"Inhalt konnte nicht extrahiert werden ({type(e).__name__})."
     return None  # not a recognized document format → caller tries plain text
 
@@ -2005,7 +2007,7 @@ async def handle_tool(name: str, args: dict, token: str) -> str:
                 content=json.dumps(body),
             )
         if resp.status_code not in (200, 202):
-            logger.warning("Graph copy %s on %s: %s", resp.status_code, rel, resp.text[:300])
+            logger.warning("Graph copy %s on %s: %s", resp.status_code, scrub_log(rel), scrub_log(resp.text[:300]))
             return f"Kopieren fehlgeschlagen (HTTP {resp.status_code})."
         src_name = str(args["path"]).rstrip("/").split("/")[-1]
         as_name = f" als '{args['new_name']}'" if args.get("new_name") else ""
@@ -2127,7 +2129,7 @@ async def handle_mcp_request(
         try:
             token = await resolve_token()
         except Exception as e:  # token refresh can fail on a Microsoft/network outage
-            logger.warning("MS Graph token resolution failed for [%s]: %s", tool_name, e)
+            logger.warning("MS Graph token resolution failed for [%s]: %s", scrub_log(tool_name), scrub_log(e))
             token = None
         if not token:
             return mcp_result(id_, tool_result(
@@ -2159,7 +2161,7 @@ async def handle_mcp_request(
         except RuntimeError as e:
             return mcp_result(id_, tool_result(str(e), is_error=True)), 200
         except Exception as e:
-            logger.error(f"MS Graph tool error [{tool_name}]: {e}", exc_info=True)
+            logger.error(f"MS Graph tool error [{scrub_log(tool_name)}]: {scrub_log(e)}", exc_info=True)
             return mcp_result(id_, tool_result(f"Error: {e}", is_error=True)), 200
 
     return mcp_error(id_, -32601, f"Method not found: {method}"), 404

--- a/orchestrator/app/security/agent_guard.py
+++ b/orchestrator/app/security/agent_guard.py
@@ -15,6 +15,8 @@ import re
 import time
 from collections import defaultdict
 
+from app.core.log_redaction import scrub_log
+
 logger = logging.getLogger(__name__)
 
 # Patterns that indicate prompt injection attempts
@@ -128,7 +130,7 @@ def check_webhook_payload(payload: dict, source: str) -> SecurityVerdict:
     is_suspicious, matched = detect_injection(payload_str)
     if is_suspicious:
         logger.warning(
-            f"BLOCKED: Prompt injection in webhook from {source}: '{matched}'"
+            f"BLOCKED: Prompt injection in webhook from {scrub_log(source)}: '{scrub_log(matched)}'"
         )
         return SecurityVerdict(
             allowed=False,
@@ -144,7 +146,7 @@ def check_inter_agent_message(text: str, from_agent: str, to_agent: str) -> Secu
     is_suspicious, matched = detect_injection(text)
     if is_suspicious:
         logger.warning(
-            f"BLOCKED: Injection in inter-agent message from {from_agent} to {to_agent}: '{matched}'"
+            f"BLOCKED: Injection in inter-agent message from {scrub_log(from_agent)} to {scrub_log(to_agent)}: '{scrub_log(matched)}'"
         )
         return SecurityVerdict(
             allowed=False,
@@ -163,7 +165,7 @@ def sanitize_webhook_payload(payload: dict, source: str, event_type: str) -> str
     warning = ""
     if is_suspicious:
         logger.warning(
-            f"Potential prompt injection in webhook from {source}: '{matched}'"
+            f"Potential prompt injection in webhook from {scrub_log(source)}: '{scrub_log(matched)}'"
         )
         warning = (
             "\n\nWARNING: This payload contains text that matches known prompt "

--- a/orchestrator/app/services/sso_service.py
+++ b/orchestrator/app/services/sso_service.py
@@ -15,6 +15,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
+from app.core.log_redaction import scrub_log
 from app.core.sso_providers import (
     SSOProviderConfig,
     get_sso_client_id,
@@ -156,10 +157,10 @@ class SSOService:
                     provider_name, user.id, token_data
                 )
                 logger.info("Stored %s Graph tokens for user %s during login",
-                            provider_name, email)
+                            scrub_log(provider_name), scrub_log(email))
             except Exception as e:
                 logger.warning("Could not persist %s Graph tokens during login: %s",
-                               provider_name, e)
+                               scrub_log(provider_name), scrub_log(e))
 
         return user
 
@@ -241,7 +242,7 @@ class SSOService:
                 user.sso_provider = provider_name
                 user.sso_subject = subject
                 await self.db.commit()
-                logger.info(f"SSO linked {provider_name} to existing user {email}")
+                logger.info(f"SSO linked {scrub_log(provider_name)} to existing user {scrub_log(email)}")
             else:
                 logger.warning(
                     f"SSO email not verified for {email}, skipping account link"
@@ -275,7 +276,7 @@ class SSOService:
         await self.db.refresh(user)
 
         logger.info(
-            f"SSO user created: {email} via {provider_name} "
+            f"SSO user created: {scrub_log(email)} via {scrub_log(provider_name)} "
             f"(role: {user.role.value}, first: {is_first}, approved: {approved})"
         )
         return user

--- a/orchestrator/app/services/user_lifecycle.py
+++ b/orchestrator/app/services/user_lifecycle.py
@@ -15,6 +15,7 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.log_redaction import scrub_log
 from app.models.agent import Agent, AgentState
 from app.models.user import User
 
@@ -234,10 +235,10 @@ async def wake_agent(db: AsyncSession, docker_service, agent_id: str, wait: bool
                             return True
                 return True
             except Exception as e:
-                logger.warning(f"[UserLifecycle] start_container failed for {agent_id}: {e}")
+                logger.warning(f"[UserLifecycle] start_container failed for {scrub_log(agent_id)}: {scrub_log(e)}")
 
     # Container missing or start failed — recreate via AgentManager
-    logger.info(f"[UserLifecycle] Container gone for {agent_id}, recreating via AgentManager")
+    logger.info(f"[UserLifecycle] Container gone for {scrub_log(agent_id)}, recreating via AgentManager")
     try:
         from app.core.agent_manager import AgentManager
         from app.services.redis_service import RedisService
@@ -255,5 +256,5 @@ async def wake_agent(db: AsyncSession, docker_service, agent_id: str, wait: bool
                         return True
         return True
     except Exception as e:
-        logger.warning(f"[UserLifecycle] Could not recreate agent {agent_id}: {e}")
+        logger.warning(f"[UserLifecycle] Could not recreate agent {scrub_log(agent_id)}: {scrub_log(e)}")
         return False


### PR DESCRIPTION
## Summary
Continues the `py/log-injection` (CWE-117) remediation from chunks 1-3 (#527, #529, #530). Wraps provider names, emails, agent/tool identifiers, and exception text with the existing `scrub_log()`/`vault.safe_log()` helpers before they reach `logger.*` calls.

## Files fixed (20 CodeQL alerts)
- `orchestrator/app/api/brain_mcp.py` (4) — two of these lines already wrapped `path` with `vault.safe_log()` but were still flagged because `brain.slug` and the exception object weren't wrapped too; fixed both.
- `orchestrator/app/core/msgraph_mcp.py` (6)
- `orchestrator/app/services/sso_service.py` (3)
- `orchestrator/app/services/user_lifecycle.py` (3)
- `orchestrator/app/security/agent_guard.py` (3) — worth calling out: these are the `"BLOCKED: Prompt injection ..."` audit-log lines. An attacker who successfully triggers detection could otherwise inject fake/misleading log entries via the matched pattern text or the `source`/`from_agent`/`to_agent` identifiers, undermining the security audit trail these lines exist to produce. Only the log arguments are wrapped — the actual detection/blocking logic (`detect_injection`, `SecurityVerdict`) is untouched.

## Scope
Part of #513. Combined with chunks 1-3, **89 of ~103** open alerts are now covered. Remaining ~14 are spread across smaller files (`skill_marketplace.py`, `scheduler_service.py`, `templates.py`, `ratings.py`, and a handful of single-alert files) — final chunk to follow. #513 should stay open until that lands.

## Test plan
- [x] `python3 -m py_compile` on all five touched files
- [x] `python3 -c "import app.security.agent_guard"` to confirm no circular import from the new `log_redaction` import
- [x] Manual review of each diff — only wraps log arguments, no change to detection/blocking logic
- [ ] CodeReview (not self-merging security PRs, per team convention from #515/#516)

🤖 Generated with [Claude Code](https://claude.com/claude-code)