### PR TITLE
chore: Sammel-Issue #521 Samstags-Batch (#502, #503, log-hardening, rate-limit throttle)

### DIFF
--- a/agent/app/main.py
+++ b/agent/app/main.py
@@ -363,9 +363,13 @@ async def refresh_mcp_credentials_loop(agent_id: str, register_via_cli: bool, in
             continue
 
         # Always refresh the in-process env — cheap, and covers custom_llm mode.
-        os.environ["CUSTOM_MCP_SERVERS"] = json.dumps(servers)
-        os.environ["CUSTOM_MCP_AUTH"] = json.dumps(auth)
-        os.environ["CUSTOM_MCP_HEADERS"] = json.dumps(headers)
+        # Hold MCP_ENV_LOCK so a concurrent reader (MCPHTTPClient._load_servers,
+        # which may run in a worker thread) never sees a torn trio (#502).
+        from app.tools.mcp_client import MCP_ENV_LOCK
+        with MCP_ENV_LOCK:
+            os.environ["CUSTOM_MCP_SERVERS"] = json.dumps(servers)
+            os.environ["CUSTOM_MCP_AUTH"] = json.dumps(auth)
+            os.environ["CUSTOM_MCP_HEADERS"] = json.dumps(headers)
 
         failed_names: set[str] = set()
         if register_via_cli:

--- a/agent/app/tools/mcp_client.py
+++ b/agent/app/tools/mcp_client.py
@@ -10,9 +10,18 @@ from __future__ import annotations
 import json
 import logging
 import os
+import threading
 from typing import Any
 
 import httpx
+
+# Guards the three CUSTOM_MCP_* env vars as a set (#502). The credential-refresh
+# loop rewrites all three in sequence; a reader running in a worker thread (custom_llm
+# mode instantiates a client via asyncio.to_thread) must not observe a torn view —
+# e.g. new SERVERS paired with stale AUTH. Writers and readers both hold this lock
+# so the trio is always read/written atomically. os.environ writes are individually
+# atomic under the GIL; the lock makes the *sequence* atomic too.
+MCP_ENV_LOCK = threading.Lock()
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +52,11 @@ class MCPHTTPClient:
 
     def _load_servers(self) -> None:
         """Load MCP server config from environment."""
-        custom_mcp = os.environ.get("CUSTOM_MCP_SERVERS", "")
+        # Snapshot all three env vars atomically w.r.t. the refresh loop (#502).
+        with MCP_ENV_LOCK:
+            custom_mcp = os.environ.get("CUSTOM_MCP_SERVERS", "")
+            custom_auth = os.environ.get("CUSTOM_MCP_AUTH", "")
+            custom_headers = os.environ.get("CUSTOM_MCP_HEADERS", "")
         if not custom_mcp:
             return
         try:
@@ -53,7 +66,6 @@ class MCPHTTPClient:
         except (json.JSONDecodeError, TypeError):
             logger.warning("Could not parse CUSTOM_MCP_SERVERS env var")
         # Optional per-server bearer tokens
-        custom_auth = os.environ.get("CUSTOM_MCP_AUTH", "")
         if custom_auth:
             try:
                 auth = json.loads(custom_auth)
@@ -62,7 +74,6 @@ class MCPHTTPClient:
             except (json.JSONDecodeError, TypeError):
                 logger.warning("Could not parse CUSTOM_MCP_AUTH env var")
         # Optional per-server custom auth headers (x-api-key etc.)
-        custom_headers = os.environ.get("CUSTOM_MCP_HEADERS", "")
         if custom_headers:
             try:
                 hdrs = json.loads(custom_headers)

--- a/agent/tests/test_mcp_env_lock.py
+++ b/agent/tests/test_mcp_env_lock.py
@@ -1,0 +1,84 @@
+"""Tests for #502: the CUSTOM_MCP_{SERVERS,AUTH,HEADERS} trio must be read/written
+atomically as a set.
+
+Background: refresh_mcp_credentials_loop (app/main.py) rewrites the three env vars
+in sequence on every credential rotation. MCPHTTPClient._load_servers (app/tools/
+mcp_client.py) reads them — and in custom_llm mode is instantiated via
+asyncio.to_thread, i.e. from a worker thread concurrently with the loop's writes.
+Without a shared lock a reader could observe a torn view (new SERVERS paired with
+stale AUTH/HEADERS from the previous generation). Both sides now hold
+``MCP_ENV_LOCK`` (app/tools/mcp_client.py) around their respective read/write
+sequence.
+"""
+import json
+import os
+import threading
+
+from app import main as agent_main
+from app.tools.mcp_client import MCP_ENV_LOCK, MCPHTTPClient
+
+
+def test_main_and_mcp_client_share_the_same_lock():
+    # main.py imports MCP_ENV_LOCK from mcp_client lazily inside the loop body
+    # rather than re-declaring its own — assert the module actually exposes it
+    # for that `from app.tools.mcp_client import MCP_ENV_LOCK` to resolve to the
+    # one _load_servers uses.
+    import app.tools.mcp_client as mcp_client_module
+
+    assert agent_main.__name__  # sanity: module imported
+    assert mcp_client_module.MCP_ENV_LOCK is MCP_ENV_LOCK
+
+
+def test_load_servers_reads_the_trio_under_the_lock(monkeypatch):
+    """No torn reads: a writer flipping between two consistent generations must
+    never let a concurrent reader see a mix of the two."""
+    gen_a = (
+        json.dumps({"srv": "http://a"}),
+        json.dumps({"srv": "token-a"}),
+        json.dumps({"srv": {"x-api-key": "a"}}),
+    )
+    gen_b = (
+        json.dumps({"srv": "http://b"}),
+        json.dumps({"srv": "token-b"}),
+        json.dumps({"srv": {"x-api-key": "b"}}),
+    )
+
+    stop = threading.Event()
+    torn_read = threading.Event()
+
+    def writer():
+        toggle = True
+        while not stop.is_set():
+            servers, auth, headers = gen_a if toggle else gen_b
+            with MCP_ENV_LOCK:
+                os.environ["CUSTOM_MCP_SERVERS"] = servers
+                os.environ["CUSTOM_MCP_AUTH"] = auth
+                os.environ["CUSTOM_MCP_HEADERS"] = headers
+            toggle = not toggle
+
+    def reader():
+        client = MCPHTTPClient.__new__(MCPHTTPClient)
+        while not stop.is_set():
+            client._servers = {}
+            client._auth = {}
+            client._headers = {}
+            client._load_servers()
+            url = client._servers.get("srv")
+            token = client._auth.get("srv")
+            key = (client._headers.get("srv") or {}).get("x-api-key")
+            if url is None:
+                continue
+            expected_suffix = url.rsplit("/", 1)[-1]  # "a" or "b"
+            if token != f"token-{expected_suffix}" or key != expected_suffix:
+                torn_read.set()
+                stop.set()
+
+    threads = [threading.Thread(target=writer), threading.Thread(target=reader)]
+    for t in threads:
+        t.start()
+    stop.wait(timeout=1.0)
+    stop.set()
+    for t in threads:
+        t.join(timeout=2.0)
+
+    assert not torn_read.is_set(), "reader observed a torn CUSTOM_MCP_* trio"

--- a/orchestrator/app/api/docker_apps.py
+++ b/orchestrator/app/api/docker_apps.py
@@ -31,7 +31,7 @@ from app.core.app_sharing import (
     is_app_owner,
     resolve_app_access,
 )
-from app.core.log_redaction import scrub_log
+from app.core.log_redaction import redact_logs, scrub_log
 from app.db.session import get_db
 from app.dependencies import get_docker_service, optional_auth, require_auth
 from app.models.agent import Agent
@@ -455,6 +455,11 @@ async def _start_core(docker: DockerService, agent: Agent, agent_id: str, path: 
         ["up", "-d", "--build"],
     )
 
+    # Compose-Ausgabe kann Build-Argumente und Env-Dumps enthalten. `scrub_log`
+    # entfernt nur Steuerzeichen (Log-Injection) — Geheimnisse maskiert erst
+    # `redact_logs`. Und sie gehoert auch nicht in die Antwort an den Aufrufer,
+    # sonst ist der Weg ueber HTTP offen, waehrend der Log dicht ist.
+    output = redact_logs(output)
     if exit_code != 0:
         logger.error(f"Failed to start {scrub_log(project_name)}: {scrub_log(output)}")
         raise HTTPException(status_code=500, detail=f"Failed to start app: {output}")
@@ -478,6 +483,7 @@ async def _stop_core(docker: DockerService, agent: Agent, agent_id: str, path: s
     exit_code, output = await asyncio.to_thread(
         _run_compose, docker, workspace_volume, project_name, compose_file, ["down"],
     )
+    output = redact_logs(output)          # siehe _start_core
     if exit_code != 0:
         logger.warning(f"Compose down warning for {scrub_log(project_name)}: {scrub_log(output)}")
     return {"project": project_name, "status": "stopped", "output": output}
@@ -501,6 +507,7 @@ async def _rebuild_core(docker: DockerService, agent: Agent, agent_id: str, path
         _run_compose, docker, workspace_volume, project_name, compose_file,
         ["up", "-d", "--build", "--force-recreate"],
     )
+    output = redact_logs(output)          # siehe _start_core
     if exit_code != 0:
         logger.error(f"Failed to rebuild {scrub_log(project_name)}: {scrub_log(output)}")
         raise HTTPException(status_code=500, detail=f"Failed to rebuild app: {output}")

--- a/orchestrator/app/api/docker_apps.py
+++ b/orchestrator/app/api/docker_apps.py
@@ -456,7 +456,7 @@ async def _start_core(docker: DockerService, agent: Agent, agent_id: str, path: 
     )
 
     if exit_code != 0:
-        logger.error(f"Failed to start {scrub_log(project_name)}: {output}")
+        logger.error(f"Failed to start {scrub_log(project_name)}: {scrub_log(output)}")
         raise HTTPException(status_code=500, detail=f"Failed to start app: {output}")
 
     _connect_containers_to_network(docker, project_name)
@@ -479,7 +479,7 @@ async def _stop_core(docker: DockerService, agent: Agent, agent_id: str, path: s
         _run_compose, docker, workspace_volume, project_name, compose_file, ["down"],
     )
     if exit_code != 0:
-        logger.warning(f"Compose down warning for {scrub_log(project_name)}: {output}")
+        logger.warning(f"Compose down warning for {scrub_log(project_name)}: {scrub_log(output)}")
     return {"project": project_name, "status": "stopped", "output": output}
 
 

--- a/orchestrator/app/main.py
+++ b/orchestrator/app/main.py
@@ -84,6 +84,18 @@ class APIRateLimitMiddleware:
         self.window = window_seconds
         # In-memory fallback (only used if Redis is unreachable)
         self._fallback: dict[str, list[float]] = {}
+        # Log "rate limit exceeded" at most once per key per window instead of once
+        # per rejected request — a single hammering client can otherwise produce
+        # hundreds of identical WARNING lines per window (observed: 126x for one
+        # user in one window on 2026-08-05), drowning out real signal in the log.
+        self._last_logged: dict[str, float] = {}
+
+    def _should_log(self, key: str, now: float) -> bool:
+        last = self._last_logged.get(key)
+        if last is not None and now - last < self.window:
+            return False
+        self._last_logged[key] = now
+        return True
 
     async def __call__(self, scope, receive, send):
         if scope["type"] != "http":
@@ -128,7 +140,8 @@ class APIRateLimitMiddleware:
                 if current > self.max_requests:
                     ttl = await redis_client.ttl(redis_key)
                     retry_after = max(ttl, 1)
-                    logger.warning(f"Rate limit exceeded for {key} ({current}/{self.max_requests})")
+                    if self._should_log(key, time.time()):
+                        logger.warning(f"Rate limit exceeded for {key} ({current}/{self.max_requests})")
                 redis_ok = True
             except Exception:
                 pass  # Redis unavailable — fall through to in-memory
@@ -153,7 +166,8 @@ class APIRateLimitMiddleware:
         self._fallback[key] = [t for t in self._fallback[key] if now - t < self.window]
 
         if len(self._fallback[key]) >= self.max_requests:
-            logger.warning(f"Rate limit exceeded for {key} (in-memory fallback)")
+            if self._should_log(key, now):
+                logger.warning(f"Rate limit exceeded for {key} (in-memory fallback)")
             response = Response(
                 content='{"detail":"Rate limit exceeded. Try again later."}',
                 status_code=429,

--- a/orchestrator/app/services/mcp_oauth_refresh.py
+++ b/orchestrator/app/services/mcp_oauth_refresh.py
@@ -7,6 +7,7 @@ the agent manager (mint a fresh access token just before an agent starts).
 from __future__ import annotations
 
 import logging
+import time
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 
@@ -27,6 +28,28 @@ _TOKEN_TIMEOUT = 15.0
 # server id can never collide with another advisory-lock user in the cluster.
 # Arbitrary fixed int4 ("mcp\0"); must stay stable across releases.
 _REFRESH_LOCK_NAMESPACE = 0x6D63_7000
+
+# Per-server in-process debounce (#503). With many agents (>20) polling
+# /mcp-credentials on a 300s cycle, ``refresh_if_needed`` runs once per agent per
+# server per tick. When a token crosses the expiry-skew threshold, every one of
+# those calls would otherwise contend on the per-server advisory lock for the same
+# refresh. After a server is confirmed to hold a usable (fresh or still-valid)
+# token, we remember that verdict for a short window and short-circuit subsequent
+# calls, so only one caller per window does the expiry-check / lock / token dance.
+# MUST stay strictly below EXPIRY_SKEW_SECONDS (60): a token confirmed "not expiring
+# within the skew" cannot actually expire before the debounce elapses, so a cached
+# "usable" verdict can never mask a token that has since gone stale.
+_REFRESH_DEBOUNCE_SECONDS = 30.0
+_recently_verified: dict[int, float] = {}  # server_id -> monotonic deadline
+
+
+def _mark_verified(server_id: int) -> None:
+    _recently_verified[server_id] = time.monotonic() + _REFRESH_DEBOUNCE_SECONDS
+
+
+def _debounced(server_id: int) -> bool:
+    deadline = _recently_verified.get(server_id)
+    return deadline is not None and time.monotonic() < deadline
 
 
 def _is_postgres(db: AsyncSession) -> bool:
@@ -135,9 +158,15 @@ async def refresh_if_needed(server: McpServer, db: AsyncSession) -> bool:
     if not getattr(server, "oauth_enabled", False):
         return bool(server.auth_token_encrypted)
 
+    # Recently confirmed usable by another caller (#503) — skip the expiry-check,
+    # advisory lock and any token request for the debounce window.
+    if _debounced(server.id):
+        return True
+
     expires_at = server.oauth_access_expires_at
     epoch = expires_at.timestamp() if expires_at else None
     if server.auth_token_encrypted and not oc.is_expired(epoch):
+        _mark_verified(server.id)
         return True
 
     if not server.oauth_refresh_token_encrypted or not server.oauth_token_endpoint:
@@ -157,6 +186,7 @@ async def refresh_if_needed(server: McpServer, db: AsyncSession) -> bool:
         if server.auth_token_encrypted and not oc.is_expired(epoch):
             # A concurrent winner already refreshed; release the lock promptly.
             await _release(db)
+            _mark_verified(server.id)
             return True
 
         try:
@@ -185,6 +215,7 @@ async def refresh_if_needed(server: McpServer, db: AsyncSession) -> bool:
             await db.rollback()
             logger.warning("Could not persist refreshed MCP token for server %s", server.name)
             return bool(server.auth_token_encrypted)
+        _mark_verified(server.id)
         return True
 
 

--- a/orchestrator/tests/test_docker_apps_output_scrub_guard.py
+++ b/orchestrator/tests/test_docker_apps_output_scrub_guard.py
@@ -1,0 +1,86 @@
+"""Guard test for the Sammel-Issue #521 docker_apps.py log-hardening item.
+
+Background: ``_start_core`` and ``_stop_core`` logged the raw ``compose`` command
+output on failure without scrubbing it, while ``project_name`` right next to it was
+already passed through ``scrub_log()``. Compose output can carry build-arg secrets
+or env dumps (see the #513/#520 log-injection review). Both call sites must wrap
+``output`` in ``scrub_log(...)`` before it reaches ``logger.*``.
+
+AST-based so it runs without docker/yaml/fastapi installed in this container (same
+pattern as test_scheduler_transient_db_guard.py).
+"""
+
+import ast
+import unittest
+from pathlib import Path
+
+_MODULE = Path(__file__).resolve().parent.parent / "app" / "api" / "docker_apps.py"
+
+_GUARDED_FUNCS = ("_start_core", "_stop_core")
+
+
+def _module() -> ast.Module:
+    return ast.parse(_MODULE.read_text())
+
+
+def _find_func(mod: ast.Module, name: str) -> ast.AsyncFunctionDef:
+    for node in ast.walk(mod):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name} not found in docker_apps.py")
+
+
+def _logger_calls(node: ast.AST) -> list[ast.Call]:
+    return [
+        n for n in ast.walk(node)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Attribute)
+        and isinstance(n.func.value, ast.Name)
+        and n.func.value.id == "logger"
+    ]
+
+
+def _fstring_calls_scrub_log_on(call: ast.Call, var_name: str) -> bool:
+    """True if any f-string argument of ``call`` wraps ``var_name`` in scrub_log(...)."""
+    for arg in call.args:
+        if not isinstance(arg, ast.JoinedStr):
+            continue
+        for value in arg.values:
+            if not isinstance(value, ast.FormattedValue):
+                continue
+            expr = value.value
+            if (
+                isinstance(expr, ast.Call)
+                and isinstance(expr.func, ast.Name)
+                and expr.func.id == "scrub_log"
+                and len(expr.args) == 1
+                and isinstance(expr.args[0], ast.Name)
+                and expr.args[0].id == var_name
+            ):
+                return True
+    return False
+
+
+class DockerAppsOutputScrubGuardTests(unittest.TestCase):
+    def test_output_is_scrubbed_in_failure_logs(self):
+        mod = _module()
+        for func_name in _GUARDED_FUNCS:
+            func = _find_func(mod, func_name)
+            calls = [
+                c for c in _logger_calls(func)
+                if c.func.attr in ("error", "warning")
+            ]
+            self.assertTrue(
+                calls, f"{func_name} should have an error/warning log on compose failure"
+            )
+            scrubbed = any(_fstring_calls_scrub_log_on(c, "output") for c in calls)
+            self.assertTrue(
+                scrubbed,
+                f"{func_name}: the failure logger.error/warning(...) call must wrap "
+                f"`output` in scrub_log(output) — raw compose output can contain "
+                f"build-arg secrets or env dumps",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orchestrator/tests/test_docker_apps_output_scrub_guard.py
+++ b/orchestrator/tests/test_docker_apps_output_scrub_guard.py
@@ -61,6 +61,29 @@ def _fstring_calls_scrub_log_on(call: ast.Call, var_name: str) -> bool:
     return False
 
 
+class DockerAppsOutputSecretGuardTests(unittest.TestCase):
+    """`scrub_log` entfernt nur Steuerzeichen — Geheimnisse maskiert `redact_logs`.
+
+    Die Begruendung im Ursprungs-PR („kann Build-Arg-Secrets enthalten") traf zu, das
+    Mittel aber nicht: ein Token waere weiter im Log gelandet, nur einzeilig. Und in
+    der HTTP-Antwort stand die Ausgabe ohnehin ungefiltert — der Weg nach draussen war
+    also offen, waehrend der Log als dicht galt.
+    """
+
+    def test_output_is_redacted_before_it_is_used_anywhere(self):
+        src = _MODULE.read_text()
+        self.assertIn("from app.core.log_redaction import redact_logs, scrub_log", src)
+        # Einmal pro Compose-Aufruf, der eine Ausgabe zurueckgibt: start, stop, rebuild.
+        self.assertEqual(src.count("output = redact_logs(output)"), 3)
+
+    def test_secrets_really_disappear(self):
+        from app.core.log_redaction import redact_logs
+        text = "Step 3/9 : ARG API_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz012345\nBearer eyJhbGciOi.JIUzI1NiJ9.sig"
+        out = redact_logs(text)
+        self.assertNotIn("ghp_abcdefghijklmnopqrstuvwxyz012345", out)
+        self.assertIn("REDACTED", out)
+
+
 class DockerAppsOutputScrubGuardTests(unittest.TestCase):
     def test_output_is_scrubbed_in_failure_logs(self):
         mod = _module()

--- a/orchestrator/tests/test_mcp_oauth_refresh_debounce.py
+++ b/orchestrator/tests/test_mcp_oauth_refresh_debounce.py
@@ -1,0 +1,130 @@
+"""Tests for issue #503: per-server debounce in ``refresh_if_needed``.
+
+With many agents polling ``/mcp-credentials`` on a 300s cycle, ``refresh_if_needed``
+ran once per agent per server per tick. When a token crossed the expiry-skew
+threshold, every one of those calls contended on the same per-server advisory lock
+for one refresh. A short in-process debounce records a "usable" verdict per server
+so only the first caller per window does the expiry-check / lock / token dance; the
+rest short-circuit. The window MUST stay below ``EXPIRY_SKEW_SECONDS`` so a debounced
+verdict can never outlive the validity it was based on.
+"""
+
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.models.mcp_server import McpServer
+from app.services import mcp_oauth_client as oc
+from app.services import mcp_oauth_refresh as mor
+
+
+def _make_server(*, expires_in: int | None, server_id: int = 42) -> McpServer:
+    s = McpServer()
+    s.id = server_id
+    s.name = "debounced-oauth-mcp"
+    s.oauth_enabled = True
+    s.oauth_token_endpoint = "https://idp.example/token"
+    s.oauth_client_id = "client-abc"
+    s.oauth_client_secret_encrypted = None
+    s.oauth_scope = "read"
+    s.oauth_resource = None
+    s.oauth_refresh_token_encrypted = "enc:rt-old"
+    s.auth_token_encrypted = "enc:at-old"
+    s.oauth_access_expires_at = (
+        None if expires_in is None
+        else datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+    )
+    return s
+
+
+def _pg_session() -> AsyncMock:
+    db = AsyncMock()
+    db.bind = MagicMock()
+    db.bind.dialect.name = "postgresql"
+    db.execute = AsyncMock()
+    db.refresh = AsyncMock()
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+    return db
+
+
+class DebounceWindowTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        mor._recently_verified.clear()
+
+    def test_debounce_window_is_below_expiry_skew(self):
+        # Core safety invariant: a token confirmed "not expiring within the skew"
+        # cannot actually expire before the debounce elapses.
+        assert mor._REFRESH_DEBOUNCE_SECONDS < oc.EXPIRY_SKEW_SECONDS
+
+    async def test_second_call_short_circuits_after_valid_verdict(self):
+        """A still-valid token is verified once; the next call skips the DB entirely."""
+        server = _make_server(expires_in=3600)
+        db = _pg_session()
+
+        with patch.object(mor, "perform_token_request", new=AsyncMock()) as ptr:
+            assert await mor.refresh_if_needed(server, db) is True
+            db.execute.assert_not_awaited()  # fast path, no lock
+            # Second call within the window: debounced, no expiry re-check, no lock.
+            assert await mor.refresh_if_needed(server, db) is True
+
+        ptr.assert_not_awaited()
+        assert mor._debounced(server.id) is True
+
+    async def test_second_call_short_circuits_after_a_refresh(self):
+        """After one caller refreshes, sibling callers skip the token request."""
+        server = _make_server(expires_in=-10)  # expired → first call refreshes
+        db = _pg_session()
+        db.refresh.side_effect = None  # reload leaves it expired
+
+        parsed = {
+            "access_token": "at-new",
+            "refresh_token": "rt-new",
+            "expires_at": (datetime.now(timezone.utc) + timedelta(hours=1)).timestamp(),
+            "scope": "read",
+        }
+        with patch.object(mor, "perform_token_request",
+                          new=AsyncMock(return_value=parsed)) as ptr, \
+                patch.object(mor, "decrypt_token", side_effect=lambda t: t.split(":", 1)[1]), \
+                patch.object(mor, "encrypt_token", side_effect=lambda t: f"enc:{t}"):
+            assert await mor.refresh_if_needed(server, db) is True
+            ptr.assert_awaited_once()
+            # Second call within the window must NOT fire another token request.
+            assert await mor.refresh_if_needed(server, db) is True
+            ptr.assert_awaited_once()
+
+    async def test_expired_debounce_re_checks(self):
+        """Once the window elapses, the next call re-evaluates instead of trusting the cache."""
+        server = _make_server(expires_in=3600)
+        db = _pg_session()
+
+        with patch.object(mor, "perform_token_request", new=AsyncMock()):
+            assert await mor.refresh_if_needed(server, db) is True
+        assert mor._debounced(server.id) is True
+
+        # Simulate the window having elapsed.
+        mor._recently_verified[server.id] = 0.0
+        assert mor._debounced(server.id) is False
+
+    async def test_failed_refresh_is_not_debounced(self):
+        """A caller that could not refresh must not leave a 'usable' verdict behind."""
+        server = _make_server(expires_in=-10)
+        db = _pg_session()
+        db.refresh.side_effect = None
+        with patch.object(mor, "perform_token_request",
+                          new=AsyncMock(side_effect=mor.OAuthTokenError("boom"))), \
+                patch.object(mor, "decrypt_token", side_effect=lambda t: t.split(":", 1)[1]):
+            await mor.refresh_if_needed(server, db)
+        # Degraded state (stale token, refresh failed) → next caller must retry.
+        assert mor._debounced(server.id) is False
+
+    async def test_disabled_server_is_not_debounced(self):
+        server = _make_server(expires_in=3600)
+        server.oauth_enabled = False
+        db = _pg_session()
+        assert await mor.refresh_if_needed(server, db) is True
+        assert mor._debounced(server.id) is False
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orchestrator/tests/test_mcp_oauth_refresh_lock.py
+++ b/orchestrator/tests/test_mcp_oauth_refresh_lock.py
@@ -90,6 +90,11 @@ class RefreshLockDialectTests(unittest.IsolatedAsyncioTestCase):
 
 
 class RefreshIfNeededRaceTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        # The #503 debounce keeps a process-global "recently verified" cache; clear
+        # it so these tests never short-circuit on a verdict left by a sibling test.
+        mor._recently_verified.clear()
+
     async def test_late_caller_skips_token_request_after_winner_refreshed(self):
         """#462 core: if the reload under the lock shows a fresh token, no request."""
         server = _make_server(expires_in=-10)  # currently expired → needs refresh

--- a/orchestrator/tests/test_rate_limit_log_throttle_guard.py
+++ b/orchestrator/tests/test_rate_limit_log_throttle_guard.py
@@ -1,0 +1,116 @@
+"""Guard test for the Sammel-Issue #521 rate-limit log throttle.
+
+Background: APIRateLimitMiddleware logged a full WARNING line for every single
+rejected request once a caller was over the limit — observed 126x for one user in
+one 60s window on 2026-08-05, flooding /shared/platform-errors.log. The fix adds
+``_should_log(key, now)``, a per-key dedup gate (log at most once per window), and
+both call sites (Redis path + in-memory fallback path) must go through it.
+
+``_should_log`` has no external dependencies (dict + time arithmetic only), so its
+real source is extracted via AST and exercised directly against a minimal stub —
+this runs without fastapi/sqlalchemy/redis/docker, none of which are installed in
+this container (see test_scheduler_transient_db_guard.py for the same pattern).
+"""
+
+import ast
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+_MAIN = Path(__file__).resolve().parent.parent / "app" / "main.py"
+
+
+def _module() -> ast.Module:
+    return ast.parse(_MAIN.read_text())
+
+
+def _find_class(mod: ast.Module, name: str) -> ast.ClassDef:
+    for node in ast.walk(mod):
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"class {name} not found in main.py")
+
+
+def _find_method(cls: ast.ClassDef, name: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    for node in cls.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"method {name} not found on {cls.name}")
+
+
+def _load_should_log():
+    """Compile the real ``_should_log`` source into a standalone callable."""
+    cls = _find_class(_module(), "APIRateLimitMiddleware")
+    method = _find_method(cls, "_should_log")
+    wrapper = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(wrapper)
+    ns: dict = {}
+    exec(compile(wrapper, str(_MAIN), "exec"), ns)
+    return ns["_should_log"]
+
+
+def _calls_in(node: ast.AST) -> list[ast.Call]:
+    return [n for n in ast.walk(node) if isinstance(n, ast.Call)]
+
+
+class RateLimitThrottleSourceTests(unittest.TestCase):
+    def test_both_warning_call_sites_are_gated_by_should_log(self):
+        call_meth = _find_method(_find_class(_module(), "APIRateLimitMiddleware"), "__call__")
+        warning_calls = [
+            n for n in ast.walk(call_meth)
+            if isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Attribute)
+            and n.func.attr == "warning"
+        ]
+        self.assertEqual(
+            len(warning_calls), 2,
+            "expected exactly 2 logger.warning(...) call sites (Redis + in-memory fallback)",
+        )
+        for warn_call in warning_calls:
+            # Walk up: find the nearest enclosing If whose test calls _should_log.
+            enclosing_if = None
+            for node in ast.walk(call_meth):
+                if isinstance(node, ast.If) and warn_call in ast.walk(node):
+                    if any(
+                        isinstance(c.func, ast.Attribute) and c.func.attr == "_should_log"
+                        for c in _calls_in(node.test)
+                    ):
+                        enclosing_if = node
+                        break
+            self.assertIsNotNone(
+                enclosing_if,
+                "each 'Rate limit exceeded' logger.warning(...) call must be gated "
+                "by an `if self._should_log(...)` check",
+            )
+
+
+class ShouldLogBehaviorTests(unittest.TestCase):
+    def setUp(self):
+        self.should_log = _load_should_log()
+
+    def _stub(self, window=60):
+        return SimpleNamespace(window=window, _last_logged={})
+
+    def test_first_call_for_a_key_logs(self):
+        self_ = self._stub()
+        self.assertTrue(self.should_log(self_, "user:1", 1000.0))
+
+    def test_second_call_within_window_is_suppressed(self):
+        self_ = self._stub(window=60)
+        self.assertTrue(self.should_log(self_, "user:1", 1000.0))
+        self.assertFalse(self.should_log(self_, "user:1", 1010.0))
+
+    def test_call_after_window_elapses_logs_again(self):
+        self_ = self._stub(window=60)
+        self.assertTrue(self.should_log(self_, "user:1", 1000.0))
+        self.assertTrue(self.should_log(self_, "user:1", 1061.0))
+
+    def test_keys_are_independent(self):
+        self_ = self._stub(window=60)
+        self.assertTrue(self.should_log(self_, "user:1", 1000.0))
+        self.assertTrue(self.should_log(self_, "user:2", 1000.0))
+        self.assertFalse(self.should_log(self_, "user:1", 1005.0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Samstags-Batch aus dem lebenden Sammel-Issue #521 (siehe Spielregeln dort).

- **Fixes #502** — W2: `CUSTOM_MCP_{SERVERS,AUTH,HEADERS}` wurden als 3 einzelne `os.environ`-Writes gesetzt, ohne dass ein gleichzeitiger Reader (`MCPHTTPClient._load_servers`, läuft im custom_llm-Modus über `asyncio.to_thread` in einem Worker-Thread) geschützt war. Ein Reader konnte einen "torn" Stand sehen (neue SERVERS, aber alte AUTH/HEADERS). Fix: gemeinsamer `MCP_ENV_LOCK` (`app/tools/mcp_client.py`) um beide Seiten.
- **Fixes #503** — W3: Bei vielen Agenten (>20) rief `refresh_if_needed` pro Agent/Server/Tick auf; sobald ein Token die Expiry-Skew-Schwelle überschritt, haben alle gleichzeitig um denselben Advisory-Lock konkurriert. Fix: kurzes In-Process-Debounce (30s, strikt unter den 60s Expiry-Skew) pro Server — nur der erste Caller im Fenster macht Expiry-Check/Lock/Token-Request.
- **part of #521** — `docker_apps.py`: `_start_core`/`_stop_core` loggten den rohen Compose-Output bei Fehlern ungescrubt (kann Build-Arg-Secrets/Env-Dumps enthalten), obwohl `project_name` direkt daneben bereits `scrub_log()` durchläuft.
- **part of #521** — `APIRateLimitMiddleware`: loggte pro über dem Limit liegendem Request eine volle WARNING-Zeile (126x für einen User in einem Fenster am 2026-08-05 beobachtet). Jetzt max. 1x pro Key+Fenster.

Nicht Teil dieses PRs: der `docker_apps.py`-Log-Scrubbing-Punkt für `_rebuild_core` war beim Code-Check bereits korrekt (kein Handlungsbedarf mehr). Der `analytics.py`-Fund gehört inhaltlich zu #513 (Log-Injection-Serie) und wird dort als Teil von Chunk 5 mitgeführt, nicht hier gebündelt.

## Test plan
- [x] `python3 -m unittest tests.test_mcp_oauth_refresh_lock tests.test_mcp_oauth_refresh_debounce tests.test_rate_limit_log_throttle_guard tests.test_docker_apps_output_scrub_guard` (orchestrator) — 19/19 grün
- [x] `python3 -m pytest tests/` (agent) — 137/138 grün, 1 vorbestehender Fail (`test_present_file_marker.py`, unabhängig von diesem Diff, auch auf `main` reproduzierbar — Sandbox-Pfad `/tmp` liegt außerhalb des erwarteten Workspace-Roots)
- [x] Neue Regressionstests für alle 4 Punkte hinzugefügt (`test_mcp_env_lock.py`, `test_mcp_oauth_refresh_debounce.py`, `test_docker_apps_output_scrub_guard.py`, `test_rate_limit_log_throttle_guard.py`)

Alle 4 Fixes sind deploy-gated (Agent-Image + Orchestrator-Rebuild).