### PR TITLE
chore: Samstags-Batch 2026-08-08 (#521)

### DIFF
--- a/agent/app/main.py
+++ b/agent/app/main.py
@@ -363,9 +363,18 @@ async def refresh_mcp_credentials_loop(agent_id: str, register_via_cli: bool, in
             continue
 
         # Always refresh the in-process env — cheap, and covers custom_llm mode.
-        os.environ["CUSTOM_MCP_SERVERS"] = json.dumps(servers)
+        # Write SERVERS *last* (#502): every reader (mcp_client, this module's
+        # config builders) reads CUSTOM_MCP_SERVERS first and only then looks up
+        # the matching CUSTOM_MCP_AUTH/CUSTOM_MCP_HEADERS. Individual os.environ
+        # writes are GIL-atomic but the three together are not, so a reader in an
+        # asyncio.to_thread() path could otherwise observe a new server whose
+        # token has not landed yet (→ 401). Writing creds before SERVERS makes
+        # that harmful torn read impossible: seeing new SERVERS guarantees the
+        # new creds are already in place. The reverse (old SERVERS + new creds)
+        # is harmless — a rotated token applied to an already-known server.
         os.environ["CUSTOM_MCP_AUTH"] = json.dumps(auth)
         os.environ["CUSTOM_MCP_HEADERS"] = json.dumps(headers)
+        os.environ["CUSTOM_MCP_SERVERS"] = json.dumps(servers)
 
         failed_names: set[str] = set()
         if register_via_cli:

--- a/orchestrator/app/api/docker_apps.py
+++ b/orchestrator/app/api/docker_apps.py
@@ -456,7 +456,7 @@ async def _start_core(docker: DockerService, agent: Agent, agent_id: str, path: 
     )
 
     if exit_code != 0:
-        logger.error(f"Failed to start {scrub_log(project_name)}: {output}")
+        logger.error(f"Failed to start {scrub_log(project_name)}: {scrub_log(output)}")
         raise HTTPException(status_code=500, detail=f"Failed to start app: {output}")
 
     _connect_containers_to_network(docker, project_name)
@@ -479,7 +479,7 @@ async def _stop_core(docker: DockerService, agent: Agent, agent_id: str, path: s
         _run_compose, docker, workspace_volume, project_name, compose_file, ["down"],
     )
     if exit_code != 0:
-        logger.warning(f"Compose down warning for {scrub_log(project_name)}: {output}")
+        logger.warning(f"Compose down warning for {scrub_log(project_name)}: {scrub_log(output)}")
     return {"project": project_name, "status": "stopped", "output": output}
 
 

--- a/orchestrator/app/main.py
+++ b/orchestrator/app/main.py
@@ -84,6 +84,9 @@ class APIRateLimitMiddleware:
         self.window = window_seconds
         # In-memory fallback (only used if Redis is unreachable)
         self._fallback: dict[str, list[float]] = {}
+        # Throttle "rate limit exceeded" WARNINGs to once per key+window in the
+        # fallback path, so a client hammering the endpoint can't flood the log.
+        self._fallback_logged: dict[str, float] = {}
 
     async def __call__(self, scope, receive, send):
         if scope["type"] != "http":
@@ -128,7 +131,12 @@ class APIRateLimitMiddleware:
                 if current > self.max_requests:
                     ttl = await redis_client.ttl(redis_key)
                     retry_after = max(ttl, 1)
-                    logger.warning(f"Rate limit exceeded for {key} ({current}/{self.max_requests})")
+                    # Log once per key+window (#521): INCR is monotonic within the
+                    # window, so exactly one request hits current == max+1. Logging
+                    # only on that first over-limit request avoids the observed
+                    # flood (126 identical WARNINGs for one user in one window).
+                    if current == self.max_requests + 1:
+                        logger.warning(f"Rate limit exceeded for {key} ({current}/{self.max_requests})")
                 redis_ok = True
             except Exception:
                 pass  # Redis unavailable — fall through to in-memory
@@ -153,7 +161,11 @@ class APIRateLimitMiddleware:
         self._fallback[key] = [t for t in self._fallback[key] if now - t < self.window]
 
         if len(self._fallback[key]) >= self.max_requests:
-            logger.warning(f"Rate limit exceeded for {key} (in-memory fallback)")
+            # Same log-once-per-window throttle as the Redis path (#521).
+            last_logged = self._fallback_logged.get(key, 0.0)
+            if now - last_logged >= self.window:
+                self._fallback_logged[key] = now
+                logger.warning(f"Rate limit exceeded for {key} (in-memory fallback)")
             response = Response(
                 content='{"detail":"Rate limit exceeded. Try again later."}',
                 status_code=429,


### PR DESCRIPTION
## Zusammenfassung
Gebündelter Samstags-Batch für die kleinen Punkte aus #521. Jeder Kandidat wurde zuerst gegen den aktuellen Code geprüft; nur noch relevante Punkte sind umgesetzt.

### Umgesetzt
- **Log-Hardening `docker_apps.py`** — `scrub_log()` jetzt auch auf die rohe compose-Ausgabe in `_start_core` (~459) und `_stop_core` (~482). Compose-Output kann Build-Arg-Secrets/Env-Dumps tragen. `_rebuild_core` (~495/505) scrubt bereits korrekt → dieser Teilpunkt war schon erledigt (obsolet). Folgepunkt aus dem #513/#520-Log-Injection-Review.
- **#502 — nicht-atomares 3-Key `os.environ`-Update** — `CUSTOM_MCP_SERVERS` wird jetzt als **letztes** geschrieben (nach `CUSTOM_MCP_AUTH`/`CUSTOM_MCP_HEADERS`). Die einzelnen Writes sind GIL-atomar, die drei zusammen nicht; ein Reader im `asyncio.to_thread`-Pfad konnte sonst einen neuen Server ohne passende Creds sehen (→ 401). Creds vor SERVERS zu schreiben macht den schädlichen Torn-Read unmöglich; der umgekehrte Fall (alte SERVERS + neue Creds) ist harmlos. Reiner Writer-Fix, keine neuen Locks.
- **Rate-Limit-Log-Spam (`app.main`)** — „Rate limit exceeded"-WARNING wird nur noch **einmal pro Key+Fenster** geloggt statt je abgelehntem Request. Redis-Pfad nutzt die INCR-Monotonie (`current == max+1`), der In-Memory-Fallback einen Timestamp pro Key. Verhindert die beobachtete Log-Flut (126× für einen User am 2026-08-05).

### Zurückgestellt
- **#503 — OAuth-Refresh skaliert linear mit Agent-Anzahl** — bereits abgemildert: `refresh_if_needed` kurzschließt bei gültigem Token (No-op) und der 300s-Background-Sweep (`refresh_all_oauth_servers`) hält den persistierten Token frisch; zusätzlich serialisiert ein Advisory-Lock parallele Refreshes. Ein echter Fix (z.B. TTL-Cache) wäre kein risikoarmer Kleinfix → bleibt in #521 offen.

## Tests
- `orchestrator/tests/test_asgi_middleware.py` — 8 passed
- `agent/tests/test_mcp_credential_refresh.py` + `test_mcp_auth_headers.py` — 14 passed
- `py_compile` grün für alle drei geänderten Dateien

Refs #521, #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)