### PR TITLE
fix(security): sanitize remaining py/log-injection sinks (chunk 6/#513)

### DIFF
--- a/orchestrator/app/api/audit.py
+++ b/orchestrator/app/api/audit.py
@@ -92,7 +92,7 @@ async def create_audit_log(
     await db.refresh(entry)
 
     logger.info(
-        f"Audit: agent={scrub_log(agent_id)} event={body.event_type} outcome={scrub_log(body.outcome)} "
+        f"Audit: agent={scrub_log(agent_id)} event={scrub_log(body.event_type)} outcome={scrub_log(body.outcome)} "
         f"cmd={scrub_log(body.command)!r:.80}"
     )
 

--- a/orchestrator/app/api/computer_use.py
+++ b/orchestrator/app/api/computer_use.py
@@ -443,7 +443,7 @@ async def update_capabilities(
         raise HTTPException(status_code=422, detail=f"Unknown capability groups: {sorted(unknown)}")
 
     session["allowed_capabilities"] = set(req.allowed_capabilities)
-    logger.info(f"Session {scrub_log(session_id)}: capabilities updated to {sorted(req.allowed_capabilities)}")
+    logger.info(f"Session {scrub_log(session_id)}: capabilities updated to {scrub_log(sorted(req.allowed_capabilities))}")
     return {
         "session_id": session_id,
         "allowed_capabilities": sorted(session["allowed_capabilities"]),

--- a/orchestrator/app/api/day_plan.py
+++ b/orchestrator/app/api/day_plan.py
@@ -125,7 +125,7 @@ async def replace_day_plan(
     await db.commit()
     for row in created:
         await db.refresh(row)
-    logger.info("[DayPlan] agent=%s date=%s items=%d", scrub_log(agent_id), plan_date, len(created))
+    logger.info("[DayPlan] agent=%s date=%s items=%d", scrub_log(agent_id), scrub_log(plan_date), len(created))
     return {"agent_id": agent_id, "plan_date": plan_date.isoformat(),
             "items": [_to_response(r) for r in created]}
 

--- a/orchestrator/app/api/ratings.py
+++ b/orchestrator/app/api/ratings.py
@@ -238,8 +238,8 @@ async def rate_task(
             # Auto-trigger skill improvement if user rating dropped vs agent self-rating
             if usage.agent_self_rating and body.rating < usage.agent_self_rating - 1:
                 logger.info(
-                    f"User rating {body.rating} significantly below agent self-rating "
-                    f"{usage.agent_self_rating} for skill {usage.skill_id} — will queue improvement"
+                    f"User rating {scrub_log(body.rating)} significantly below agent self-rating "
+                    f"{scrub_log(usage.agent_self_rating)} for skill {scrub_log(usage.skill_id)} — will queue improvement"
                 )
             await db.commit()
     except Exception as e:
@@ -289,7 +289,7 @@ async def rate_task(
                     priority=8 if body.rating < 4 else 3,
                 )
                 await redis.disconnect()
-                logger.info(f"Queued skill-update follow-up for skill {skill.id} after {body.rating}★ feedback")
+                logger.info(f"Queued skill-update follow-up for skill {scrub_log(skill.id)} after {scrub_log(body.rating)}★ feedback")
         except Exception as e:
             logger.warning(f"Could not queue skill-update follow-up: {scrub_log(e)}")
 

--- a/orchestrator/app/api/templates.py
+++ b/orchestrator/app/api/templates.py
@@ -223,7 +223,7 @@ async def publish_template(
     template.is_published = True
     template.published_at = datetime.now(timezone.utc)
     await db.commit()
-    logger.info(f"Template {template_id} published by {user.id}")
+    logger.info(f"Template {scrub_log(template_id)} published by {scrub_log(user.id)}")
     return _template_to_dict(template)
 
 
@@ -247,7 +247,7 @@ async def unpublish_template(
     template.is_published = False
     template.published_at = None
     await db.commit()
-    logger.info(f"Template {template_id} unpublished by {user.id}")
+    logger.info(f"Template {scrub_log(template_id)} unpublished by {scrub_log(user.id)}")
     return _template_to_dict(template)
 
 


### PR DESCRIPTION
## Summary
- Chunk 5 (#540) fixed 26 py/log-injection alerts across 17 files but 5 sinks remained open because they share a log line with an already-scrubbed value (only one of two/three interpolated values was wrapped):
  - `audit.py`: `body.event_type`
  - `day_plan.py`: `plan_date`
  - `computer_use.py`: `sorted(req.allowed_capabilities)`
  - `ratings.py`: `body.rating`, `usage.agent_self_rating`, `usage.skill_id`, `skill.id`
  - `templates.py`: `template_id`, `user.id` (publish/unpublish)
- Two other open alerts (`skill_file_storage.py:91`, and the `session_id` half of `computer_use.py:446`) are already fixed by chunks 1 and 5 respectively — stale, pending CodeQL re-scan of `main`. No code change made there.

part of #513

## Test plan
- [x] `python3 -c "import ast; ..."` syntax-checked all 5 edited files
- [x] `pytest tests/test_day_plan.py tests/test_computer_use_session_persistence.py` — 55 passed
- [ ] CI (CodeQL, pytest, dependency audit) — will verify after push