### PR TITLE
fix(security): scrub skill_id in skill_file_storage.py log sink (#543)

### DIFF
--- a/orchestrator/app/core/skill_file_storage.py
+++ b/orchestrator/app/core/skill_file_storage.py
@@ -88,5 +88,5 @@ def get_all_files_for_agent(skill_id: int) -> list[tuple[str, bytes]]:
         try:
             result.append((name, read_file(skill_id, name)))
         except Exception as e:
-            logger.warning(f"Could not read skill file {scrub_log(name)} for skill {skill_id}: {scrub_log(e)}")
+            logger.warning(f"Could not read skill file {scrub_log(name)} for skill {scrub_log(skill_id)}: {scrub_log(e)}")
     return result


### PR DESCRIPTION
## Summary
- Alert #7097 (`py/log-injection`, `skill_file_storage.py:91`) was still `open` on `main` per `gh api .../code-scanning/alerts/7097` — the taint source is `skill_id`, a FastAPI `int` path param in `skill_marketplace.py` (`assign_skill`, `unassign_skill`, `agent_install_skill`). FastAPI validates path params strictly (422 on non-int), so this is very likely a false positive, but per #543's recommended action, wraps it with `scrub_log()` anyway to match the existing pattern on the same log line (`name`, `e` were already scrubbed).
- Checked the related alert #7200 (`day_plan.py:128`, `plan_date`, #542): already fixed on branch `fix/513-chunk6-log-injection` (PR #545, not yet merged) — no action needed here, will close once #545 merges.

Fixes #543
part of #513
part of #521 (Samstags-Batch Sammel-Issue)

## Test plan
- [x] `python3 -c "import ast; ast.parse(...)"` syntax check
- [x] `pytest tests/test_api/test_skill_marketplace_usage.py` — 1 passed
- [ ] CodeQL re-scan of `main` confirms alert #7097 closes