### PR TITLE
fix(security): scrub log-injection sinks in new code

### DIFF
--- a/orchestrator/app/api/agents.py
+++ b/orchestrator/app/api/agents.py
@@ -3023,7 +3023,7 @@ async def send_telegram_message(
                 await _db.commit()
         except Exception as e:  # noqa: BLE001 — die Meldung darf nicht am Kanal scheitern
             logger.warning("[Telegram] Meldung von %s konnte nicht in den Chat: %s",
-                           agent_id, e)
+                           scrub_log(agent_id), scrub_log(str(e)))
             raise HTTPException(
                 status_code=503,
                 detail=(

--- a/orchestrator/app/api/concierge.py
+++ b/orchestrator/app/api/concierge.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.log_redaction import scrub_log
 from app.db.session import get_db
 from app.dependencies import require_admin
 from app.models.agent import Agent, AgentState
@@ -178,5 +179,6 @@ async def concierge_action(
     elif body.action == "start_agent":
         await manager.start_agent(body.agent_id)
 
-    logger.info("[Concierge] %s auf %s durch %s", body.action, body.agent_id, user.id)
+    logger.info("[Concierge] %s auf %s durch %s",
+                scrub_log(body.action), scrub_log(body.agent_id), scrub_log(user.id))
     return {"action": body.action, "agent_id": body.agent_id, "status": "ok"}

--- a/orchestrator/app/api/teams_calling.py
+++ b/orchestrator/app/api/teams_calling.py
@@ -149,10 +149,10 @@ async def _handle_notification(note: dict) -> None:
     call_id = str(data.get("id") or "").strip()
 
     if state == "established":
-        logger.info("[Teams-Anruf] Agent ist dem Termin beigetreten (%s)", call_id[:12])
+        logger.info("[Teams-Anruf] Agent ist dem Termin beigetreten (%s)", scrub_log(call_id[:12]))
     elif state == "terminated":
-        logger.info("[Teams-Anruf] Termin verlassen (%s)", call_id[:12])
+        logger.info("[Teams-Anruf] Termin verlassen (%s)", scrub_log(call_id[:12]))
     elif "recordResponse" in resource or data.get("recordingLocation"):
-        logger.info("[Teams-Anruf] Aufnahme liegt vor (%s)", call_id[:12])
+        logger.info("[Teams-Anruf] Aufnahme liegt vor (%s)", scrub_log(call_id[:12]))
     else:
-        logger.debug("[Teams-Anruf] Ereignis: %s / %s", resource[:60], state)
+        logger.debug("[Teams-Anruf] Ereignis: %s / %s", scrub_log(resource[:60]), scrub_log(state))

--- a/orchestrator/app/api/tickets.py
+++ b/orchestrator/app/api/tickets.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.log_redaction import scrub_log
 from app.db.session import get_db
 from app.dependencies import verify_agent_token
 
@@ -88,7 +89,7 @@ async def create_ticket(
         )
     except Exception as e:  # noqa: BLE001
         raise HTTPException(status_code=502, detail=f"Anlegen fehlgeschlagen: {e}")
-    logger.info("[Tickets] Agent %s hat ein Ticket angelegt", _auth.get("agent_id"))
+    logger.info("[Tickets] Agent %s hat ein Ticket angelegt", scrub_log(_auth.get("agent_id")))
     return created
 
 

--- a/orchestrator/app/core/chat_history.py
+++ b/orchestrator/app/core/chat_history.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.log_redaction import scrub_log
 from app.models.chat_message import ChatMessage
 from app.models.chat_session import ChatSession
 
@@ -162,7 +163,7 @@ async def fork(db: AsyncSession, agent_id: str, session_id: str,
     ))
     await db.flush()
     logger.info("[Chat] %s ab %s nach %s verzweigt (%d Nachrichten)",
-                session_id, message_id, target, len(keep))
+                scrub_log(session_id), scrub_log(message_id), scrub_log(target), len(keep))
     return {"ok": True, "session_id": target, "copied": len(keep)}
 
 
@@ -200,7 +201,7 @@ async def rewind(db: AsyncSession, agent_id: str, session_id: str,
     ))
     await db.flush()
     logger.info("[Chat] %s auf %s zurueckgespult (%d verworfen, Sicherung %s)",
-                session_id, message_id, len(drop), backup)
+                scrub_log(session_id), scrub_log(message_id), len(drop), scrub_log(backup))
     return {"ok": True, "removed": len(drop), "backup_session_id": backup}
 
 
@@ -257,5 +258,5 @@ async def summarize_to_new_session(db: AsyncSession, agent_id: str,
         title=f"Fortsetzung: {source_title}"[:TITLE_MAX] if source_title else "Fortsetzung",
     ))
     await db.flush()
-    logger.info("[Chat] %s als Stand nach %s uebernommen", session_id, target)
+    logger.info("[Chat] %s als Stand nach %s uebernommen", scrub_log(session_id), scrub_log(target))
     return {"ok": True, "session_id": target, "summarized": len(messages)}

--- a/orchestrator/app/core/url_guard.py
+++ b/orchestrator/app/core/url_guard.py
@@ -19,6 +19,8 @@ import logging
 import socket
 from urllib.parse import urlparse
 
+from app.core.log_redaction import scrub_log
+
 logger = logging.getLogger(__name__)
 
 # Der Metadatendienst von AWS/Azure/GCP. Steht zusaetzlich zu den privaten Netzen
@@ -38,7 +40,7 @@ def _is_internal(host: str) -> bool:
     try:
         infos = socket.getaddrinfo(host, None)
     except OSError:
-        logger.debug("Host %s nicht aufloesbar — als intern behandelt", host)
+        logger.debug("Host %s nicht aufloesbar — als intern behandelt", scrub_log(host))
         return True
 
     for info in infos:
@@ -102,7 +104,7 @@ async def is_allowed_callback(url: str, db=None, agent_id: str | None = None) ->
             if cleaned and (host == cleaned or host.endswith("." + cleaned)):
                 return True
         logger.info("Rueckruf-Host %s steht nicht auf der Freigabeliste von %s",
-                    host, agent_id)
+                    scrub_log(host), scrub_log(agent_id))
         return False
     except Exception:  # noqa: BLE001 — die harte Pruefung hat bereits bestanden
         logger.debug("Freigabeliste nicht auswertbar", exc_info=True)

--- a/orchestrator/app/services/duty_service.py
+++ b/orchestrator/app/services/duty_service.py
@@ -16,6 +16,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core import agent_duty as duty_core
+from app.core.log_redaction import scrub_log
 from app.models.agent import Agent
 from app.models.agent_todo import AgentTodo, TodoStatus
 from app.models.notification import Notification
@@ -50,7 +51,7 @@ async def team_lead_for(db: AsyncSession, agent_id: str) -> str:
             if lead and lead != agent_id:
                 return lead
     except Exception:  # noqa: BLE001 — ohne Team gibt es eben keinen Lead
-        logger.debug("Team-Lead-Suche fehlgeschlagen fuer %s", agent_id, exc_info=True)
+        logger.debug("Team-Lead-Suche fehlgeschlagen fuer %s", scrub_log(agent_id), exc_info=True)
     return ""
 
 


### PR DESCRIPTION
Part of #549 — follow-up to #513 (original ~103 py/log-injection alerts fully remediated across chunks 1-6).

Applies the established `scrub_log()` pattern (see `app/core/log_redaction.py`) to the 17 new CodeQL py/log-injection alerts that appeared since 2026-08-08 in newly added code:

- `orchestrator/app/core/chat_history.py` — session_id/message_id/target/backup (was already fixed locally, uncommitted; included here)
- `orchestrator/app/api/teams_calling.py` — call_id, resource, state
- `orchestrator/app/core/url_guard.py` — host, agent_id
- `orchestrator/app/api/tickets.py` — agent_id
- `orchestrator/app/api/concierge.py` — action, agent_id, user.id
- `orchestrator/app/services/duty_service.py` — agent_id
- `orchestrator/app/api/agents.py` — agent_id, exception text

part of #549