### PR TITLE
fix: unbreak main CI after FastAPI's lazy include_router change

### DIFF
--- a/orchestrator/tests/test_concierge.py
+++ b/orchestrator/tests/test_concierge.py
@@ -78,7 +78,16 @@ class WiringTests(unittest.TestCase):
     def test_router_is_registered(self):
         from app.api.router import api_router
 
-        paths = {r.path for r in api_router.routes}
+        # FastAPI >=0.141 resolves include_router() lazily: api_router.routes holds
+        # _IncludedRouter wrappers (no .path) instead of flat routes. Walk through
+        # fastapi.routing.iter_route_contexts() to get the effective paths; fall back
+        # to the old flat attribute for pre-0.141 installs.
+        try:
+            from fastapi.routing import iter_route_contexts
+
+            paths = {rc.path for rc in iter_route_contexts(api_router.routes)}
+        except ImportError:
+            paths = {r.path for r in api_router.routes if hasattr(r, "path")}
         self.assertIn("/concierge/overview", paths)
         self.assertIn("/concierge/action", paths)
 


### PR DESCRIPTION
## Problem
Main CI has been red for every push/merge since 2026-08-08 ~18:28 UTC (confirmed via `gh run list`): `tests/test_concierge.py::WiringTests::test_router_is_registered` fails with `AttributeError: '_IncludedRouter' object has no attribute 'path'`.

Root cause: `pyproject.toml` pins `fastapi>=0.115` with no upper bound. `starlette` released 1.6.0 and `fastapi` released 0.141.1 on 2026-08-08, which made `APIRouter.include_router()` lazy — `api_router.routes` (in `app/api/router.py`, ~30 nested `include_router()` calls) now holds internal `_IncludedRouter` wrapper objects instead of flat `Route` objects, so the direct `.path` access in the test breaks.

This is test-only — confirmed no runtime app code relies on `.routes` directly (`grep` across `app/`), so actual request routing/serving is unaffected. Other similar tests (`test_chat_history.py`, `test_meeting_templates.py`, `test_saml.py`) inspect *leaf* routers that don't call `include_router()` themselves, so they still return flat routes and were unaffected.

## Fix
Use the new public `fastapi.routing.iter_route_contexts()` helper to resolve the effective route paths through the lazy wrapper, with a fallback to the old flat-attribute access for pre-0.141 fastapi installs.

## Verification
- Reproduced the failure locally in a fresh venv with `fastapi==0.141.1`/`starlette==1.6.0` (matches what CI installs given the unpinned dependency).
- After the fix: `pytest tests/test_concierge.py` → 12 passed.
- Full suite: `pytest -q` → 1666 passed, 272 subtests passed, 0 failed (previously 1 failed).

This unblocks CI for all other open PRs (e.g. #550, #351), which were failing this same unrelated test.