### PR TITLE
Fix #548: atomic per-agent dispatch lock closes scheduler dispatch race

### DIFF
--- a/orchestrator/app/services/redis_service.py
+++ b/orchestrator/app/services/redis_service.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import secrets
 
 import redis.asyncio as aioredis
 from redis.asyncio.sentinel import Sentinel
@@ -99,6 +100,46 @@ class RedisService:
         if not self.client:
             return 0
         return await self.client.llen(f"agent:{agent_id}:tasks")
+
+    # Release only if we still hold the lock (compare-and-delete). Prevents a
+    # dispatcher whose TTL already expired from deleting a lock a *different*
+    # dispatcher has since acquired.
+    _RELEASE_LOCK_SCRIPT = (
+        'if redis.call("get", KEYS[1]) == ARGV[1] then '
+        'return redis.call("del", KEYS[1]) else return 0 end'
+    )
+
+    async def acquire_dispatch_lock(self, agent_id: str, ttl_seconds: int = 20) -> str | None:
+        """Atomically acquire a short-lived per-agent task-dispatch lock.
+
+        Guards the "is the agent busy" check immediately before a schedule
+        pushes a task, so two schedules due in the same tick (or overlapping
+        scheduler ticks) can't both see the agent as free and dispatch on top
+        of an already-running task (fixes #548). The short TTL means a crash
+        mid-dispatch self-heals within seconds instead of wedging the agent.
+
+        Returns a token to release the lock with, or None if another
+        dispatch for this agent is already in flight.
+        """
+        if not self.client:
+            return None
+        token = secrets.token_hex(8)
+        acquired = await self.client.set(
+            f"agent:{agent_id}:dispatch_lock", token, nx=True, ex=ttl_seconds
+        )
+        return token if acquired else None
+
+    async def release_dispatch_lock(self, agent_id: str, token: str) -> None:
+        if not self.client or not token:
+            return
+        try:
+            await self.client.eval(
+                self._RELEASE_LOCK_SCRIPT, 1, f"agent:{agent_id}:dispatch_lock", token
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to release dispatch lock for agent %s: %s", scrub_log(agent_id), e
+            )
 
     async def subscribe(self, channel: str):
         if not self.client:

--- a/orchestrator/app/services/scheduler_service.py
+++ b/orchestrator/app/services/scheduler_service.py
@@ -720,14 +720,52 @@ class SchedulerService:
         else:
             prompt = schedule.prompt
 
-        task = await router.create_and_route_task(
-            title=f"[Scheduled] {schedule.name}",
-            prompt=prompt,
-            priority=schedule.priority,
-            agent_id=schedule.agent_id,
-            model=schedule.model,
-            metadata={"schedule_id": schedule.id},
-        )
+        # Final atomic busy-check immediately before dispatch (#548): the earlier
+        # check above (line ~614) only ever covered [Proactive] schedules and
+        # even then wasn't atomic — a second scheduler tick could read
+        # queue_depth=0 in the window between our read and our push and
+        # dispatch too. This one covers EVERY schedule type (incl. [Plan]
+        # blocks, which previously had no guard at all) and is race-free: the
+        # re-check and the push both happen while holding a per-agent lock, so
+        # no other dispatch can slip in between.
+        lock_token = None
+        if schedule.agent_id:
+            lock_token = await self.redis.acquire_dispatch_lock(schedule.agent_id)
+            if lock_token is None:
+                # Another dispatch for this agent is in flight right now.
+                schedule.next_run_at = _calc_next_run(schedule, now)
+                logger.info(
+                    "[Scheduler] %s skipped - dispatch lock held for agent %s",
+                    schedule.name, schedule.agent_id,
+                )
+                return
+            queue_depth = await self.redis.get_queue_depth(schedule.agent_id)
+            status = await self.redis.get_agent_status(schedule.agent_id)
+            current_task = status.get("current_task", "")
+            is_busy_with_task = queue_depth > 0 or (
+                current_task and not current_task.startswith("chat:")
+            )
+            if is_busy_with_task:
+                await self.redis.release_dispatch_lock(schedule.agent_id, lock_token)
+                schedule.next_run_at = _calc_next_run(schedule, now)
+                logger.info(
+                    "[Scheduler] %s skipped - agent busy (queue=%s, task=%r)",
+                    schedule.name, queue_depth, current_task,
+                )
+                return
+
+        try:
+            task = await router.create_and_route_task(
+                title=f"[Scheduled] {schedule.name}",
+                prompt=prompt,
+                priority=schedule.priority,
+                agent_id=schedule.agent_id,
+                model=schedule.model,
+                metadata={"schedule_id": schedule.id},
+            )
+        finally:
+            if lock_token:
+                await self.redis.release_dispatch_lock(schedule.agent_id, lock_token)
 
         # Plan-Block: der Kalender soll zeigen, dass er LAEUFT — sonst steht dort ewig
         # "geplant", obwohl die Arbeit schon vorbei ist.

--- a/orchestrator/tests/test_dispatch_lock_race.py
+++ b/orchestrator/tests/test_dispatch_lock_race.py
@@ -1,0 +1,116 @@
+"""Race-simulation tests for RedisService's atomic per-agent dispatch lock (#548).
+
+The bug: two schedules due for the SAME agent in the same/overlapping scheduler
+ticks could both read "queue empty, agent idle" and both push a task, so the
+agent ran two unrelated jobs concurrently against the same shared /workspace
+checkout (confirmed 3rd+ occurrence, see issue #548). This tests the lock
+primitive in isolation (no live Redis needed) with a minimal fake client that
+reproduces the semantics that matter: SET NX for mutual exclusion, and a
+Lua-script compare-and-delete for release so a stale/expired holder can't
+release a lock someone else has since acquired.
+"""
+
+import asyncio
+import unittest
+
+from app.services.redis_service import RedisService
+
+
+class _FakeAsyncRedis:
+    """Minimal fake reproducing just the SET NX / Lua-eval semantics we use."""
+
+    def __init__(self):
+        self._store: dict[str, str] = {}
+        self._lock = asyncio.Lock()
+
+    async def set(self, key, value, nx=False, ex=None):
+        async with self._lock:
+            if nx and key in self._store:
+                return None
+            self._store[key] = value
+            return True
+
+    async def get(self, key):
+        return self._store.get(key)
+
+    async def eval(self, script, numkeys, key, arg):
+        # Only the exact CAS-release script used by RedisService is supported.
+        async with self._lock:
+            if self._store.get(key) == arg:
+                del self._store[key]
+                return 1
+            return 0
+
+
+def _service_with_fake_client() -> tuple[RedisService, _FakeAsyncRedis]:
+    svc = RedisService(redis_url="redis://fake")
+    fake = _FakeAsyncRedis()
+    svc.client = fake
+    return svc, fake
+
+
+class DispatchLockTests(unittest.IsolatedAsyncioTestCase):
+    async def test_second_concurrent_acquire_is_rejected(self):
+        """Two 'simultaneous' dispatchers for the same agent must not both win."""
+        svc, _ = _service_with_fake_client()
+        token_a = await svc.acquire_dispatch_lock("agent-1")
+        token_b = await svc.acquire_dispatch_lock("agent-1")
+        self.assertIsNotNone(token_a)
+        self.assertIsNone(token_b, "a second dispatcher must NOT acquire the lock")
+
+    async def test_lock_is_per_agent(self):
+        """A lock held for one agent must not block dispatch for another."""
+        svc, _ = _service_with_fake_client()
+        token_a = await svc.acquire_dispatch_lock("agent-1")
+        token_other = await svc.acquire_dispatch_lock("agent-2")
+        self.assertIsNotNone(token_a)
+        self.assertIsNotNone(token_other)
+
+    async def test_release_then_reacquire_succeeds(self):
+        """After the holder releases, the next dispatcher must be able to proceed
+        (this is what lets a schedule fire on the very next tick once the agent
+        frees up, instead of getting stuck)."""
+        svc, _ = _service_with_fake_client()
+        token_a = await svc.acquire_dispatch_lock("agent-1")
+        await svc.release_dispatch_lock("agent-1", token_a)
+        token_b = await svc.acquire_dispatch_lock("agent-1")
+        self.assertIsNotNone(token_b, "lock must be re-acquirable after release")
+
+    async def test_release_with_wrong_token_is_a_noop(self):
+        """A stale/expired holder (e.g. after its TTL lapsed and someone else
+        already grabbed the lock) must NOT be able to delete the new holder's
+        lock — that would reopen the exact race this fix closes."""
+        svc, fake = _service_with_fake_client()
+        token_a = await svc.acquire_dispatch_lock("agent-1")
+        self.assertIsNotNone(token_a)
+        # Simulate: token_a's dispatcher is delayed and tries to release with a
+        # token that no longer matches the current holder (e.g. because the key
+        # expired and someone else re-acquired it in the meantime).
+        await svc.release_dispatch_lock("agent-1", "some-other-stale-token")
+        # The real lock must still be held (by token_a) — a third dispatcher
+        # must still be rejected.
+        token_c = await svc.acquire_dispatch_lock("agent-1")
+        self.assertIsNone(token_c, "a mismatched token must not release someone else's lock")
+
+    async def test_concurrent_acquire_race_only_one_winner(self):
+        """Fire N concurrent acquire attempts for the same agent (simulating
+        overlapping scheduler ticks); exactly one must win."""
+        svc, _ = _service_with_fake_client()
+        results = await asyncio.gather(
+            *(svc.acquire_dispatch_lock("agent-race") for _ in range(10))
+        )
+        winners = [r for r in results if r is not None]
+        self.assertEqual(len(winners), 1, "exactly one of N racing dispatchers must win the lock")
+
+    async def test_no_client_is_safe_noop(self):
+        """Without a live Redis connection, acquiring must fail closed (None,
+        never a false 'lock acquired') and releasing must not raise."""
+        svc = RedisService(redis_url="redis://fake")
+        svc.client = None
+        token = await svc.acquire_dispatch_lock("agent-1")
+        self.assertIsNone(token)
+        await svc.release_dispatch_lock("agent-1", "whatever")  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orchestrator/tests/test_scheduler_dispatch_lock_guard.py
+++ b/orchestrator/tests/test_scheduler_dispatch_lock_guard.py
@@ -1,0 +1,85 @@
+"""Guard test: dispatch to ANY schedule type must go through the atomic
+per-agent dispatch lock (#548) — not just [Proactive] schedules, and not as a
+non-atomic read-then-push.
+
+Root cause (see issue #548 root-cause comment, 2026-08-10): the busy-check that
+already existed only ever ran for schedules whose name starts with
+"[Proactive]", built from two separate Redis reads with no lock in between, and
+regular/[Plan] schedules had no busy-check at all. Two schedules due for the
+same agent in the same tick (or overlapping ticks) could both dispatch,
+producing two concurrent `claude -p` processes racing on the same shared
+/workspace checkout — confirmed 3rd+ occurrence.
+
+Source-level guard (same style as test_scheduler_skips_stopped_agents.py) so it
+runs without pulling in fastapi/sqlalchemy/croniter in the agent container.
+"""
+
+import unittest
+from pathlib import Path
+
+SRC = (Path(__file__).resolve().parents[1] / "app/services/scheduler_service.py").read_text()
+FIRE = SRC.split("Create a task from a schedule and advance next_run_at", 1)[1].split(
+    "async def _proactive_config", 1
+)[0]
+
+# The final, unconditional dispatch call — must be guarded, not free-standing.
+_DISPATCH_CALL = "router.create_and_route_task("
+
+
+class DispatchLockGuardTests(unittest.TestCase):
+    def test_lock_is_acquired_before_the_final_busy_check(self):
+        self.assertIn("acquire_dispatch_lock(schedule.agent_id)", FIRE)
+        # "is_busy_with_task" also appears in the earlier [Proactive]-only
+        # fast-path check — we need the occurrence tied to OUR lock, i.e. the
+        # last one, which sits right after the acquire call.
+        self.assertLess(
+            FIRE.index("acquire_dispatch_lock("), FIRE.rindex("is_busy_with_task"),
+            "the lock must be held BEFORE re-reading queue_depth/status, "
+            "otherwise the read-then-push window is still racy",
+        )
+
+    def test_final_check_is_not_restricted_to_proactive_schedules(self):
+        """The [Proactive]-only early check is fine to keep as a fast-path
+        filter, but the FINAL check right before dispatch (the one under the
+        lock) must apply to every schedule type — that's what closes the gap
+        for [Plan] blocks, which previously had no guard at all."""
+        # Locate the final lock-guarded block specifically (the one that wraps
+        # the dispatch call), not the earlier [Proactive]-only fast path.
+        pre_dispatch = FIRE.split(_DISPATCH_CALL, 1)[0]
+        guard_section = pre_dispatch.rsplit("acquire_dispatch_lock(schedule.agent_id)", 1)[0]
+        # The guard must be gated on schedule.agent_id alone, not on the
+        # schedule name — i.e. no "startswith(\"[Proactive]\")" between the
+        # lock acquisition and the dispatch call.
+        lock_to_dispatch = pre_dispatch[len(guard_section):]
+        self.assertNotIn('schedule.name.startswith("[Proactive]")', lock_to_dispatch)
+
+    def test_dispatch_call_is_inside_a_try_finally_that_releases_the_lock(self):
+        segment = FIRE.split(_DISPATCH_CALL, 1)
+        self.assertEqual(len(segment), 2, "expected exactly one dispatch call site")
+        before, after = segment
+        self.assertIn("try:", before[-200:])
+        self.assertIn("finally:", after[:400])
+        self.assertIn("release_dispatch_lock(schedule.agent_id, lock_token)", after[:600])
+
+    def test_busy_dispatcher_releases_the_lock_before_returning(self):
+        """If the atomic re-check finds the agent busy, the lock must be
+        released explicitly (the schedule returns immediately, never reaching
+        the try/finally around the dispatch call)."""
+        pre_dispatch = FIRE.split(_DISPATCH_CALL, 1)[0]
+        busy_branch = pre_dispatch.split("is_busy_with_task:", 1)[1]
+        self.assertIn("release_dispatch_lock(schedule.agent_id, lock_token)", busy_branch)
+
+    def test_lock_held_dispatcher_retries_next_tick_without_reading_status(self):
+        """When acquire_dispatch_lock returns None (another dispatch for this
+        agent is already in flight), we must NOT proceed to read queue depth /
+        agent status at all — just back off and let the next tick decide."""
+        pre_dispatch = FIRE.split(_DISPATCH_CALL, 1)[0]
+        lock_rejected_branch = pre_dispatch.split("lock_token is None:", 1)[1].split(
+            "queue_depth = await self.redis.get_queue_depth", 1
+        )[0]
+        self.assertIn("schedule.next_run_at = _calc_next_run(schedule, now)", lock_rejected_branch)
+        self.assertIn("return", lock_rejected_branch)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Two schedules due for the same agent in the same/overlapping scheduler ticks could both see "agent idle" and both dispatch, running two concurrent `claude -p` processes against the same shared `/workspace` checkout (confirmed 3rd+ occurrence — see #548).
- The pre-existing busy-check only ran for `[Proactive]` schedules and was two non-atomic Redis reads with no lock between them, so `[Plan]` blocks and regular schedules had no guard at all.
- Adds `RedisService.acquire_dispatch_lock` / `release_dispatch_lock` (SET NX EX for acquire, Lua compare-and-delete for release so a TTL-expired stale holder can't clobber a new holder's lock) and wraps the final busy-check + dispatch call in `scheduler_service._execute_schedule` with it, for every schedule type.
- The old `[Proactive]`-only check is left in place as a cheap fast-path filter; the new lock-guarded check is what actually closes the race.
- Scoped intentionally to the scheduler-dispatch path only (not `TaskRouter.create_and_route_task` broadly used by chat/delegation) to match the two actually-reported incident patterns without a larger same-session refactor.

## Test plan
- [x] `tests/test_dispatch_lock_race.py` — 6 new unit tests against `RedisService` with a fake async Redis client (mutual exclusion, per-agent isolation, release/reacquire, CAS-protected release against stale tokens, true concurrent race via `asyncio.gather`, no-client no-op)
- [x] `tests/test_scheduler_dispatch_lock_guard.py` — 5 new source-level guard tests confirming the lock is acquired before the final busy-check, the check applies to every schedule type (not just `[Proactive]`), the dispatch call is inside try/finally releasing the lock, the busy branch releases the lock before returning, and the lock-held branch backs off without reading queue/status
- [x] Full relevant suite (`test_dispatch_lock_race.py` + `test_scheduler_dispatch_lock_guard.py` + pre-existing `test_scheduler_skips_stopped_agents.py`) — 17/17 passed, no regressions
- [x] Checked other tests referencing `RedisService` (`test_agent_recreate_reconcile.py`, `test_proactive_checkin_cooldown.py`, `test_oauth_reauth.py`) — none assert on a closed method set, safe with the new methods

Fixes #548