### PR TITLE
feat(memory): task-conditioned, evidence-backed preload slice

### DIFF
--- a/agent/app/llm_chat_handler.py
+++ b/agent/app/llm_chat_handler.py
@@ -425,7 +425,7 @@ class LLMChatHandler:
             # CLI runtimes read both from disk, this runtime has to be handed them. Without
             # it the agent answers "ich habe keinen eigenen Namen" and forgets across
             # sessions what the user told it, although it saved it.
-            system_prompt = system_prompt + get_identity_context() + get_memory_preload()
+            system_prompt = system_prompt + get_identity_context() + get_memory_preload(text[:500])
             system_prompt = system_prompt + MULTIMODAL_CAPABILITY_NOTE
             system_prompt = system_prompt + (
                 "\n\n## Werkzeuge bei Bedarf nachladen\n"

--- a/agent/app/llm_runner.py
+++ b/agent/app/llm_runner.py
@@ -230,14 +230,14 @@ class LLMRunner:
             # preferences (how to address them, what they decided) live in memory, and a
             # quick reply that ignores them is exactly what feels like amnesia.
             system_prompt = (
-                base_system + "\n\n" + TOOL_USAGE_RULES + mounts_ctx + get_memory_preload()
+                base_system + "\n\n" + TOOL_USAGE_RULES + mounts_ctx + get_memory_preload(prompt[:500])
             )
             if skills_ctx:
                 system_prompt += "\n" + skills_ctx
             marketplace_suggestions = get_marketplace_skill_suggestions(prompt[:200])
             enhanced_prompt = CHAT_STARTUP_PREFIX + marketplace_suggestions + prompt
         else:
-            memory_preload = get_memory_preload()
+            memory_preload = get_memory_preload(prompt[:500])
             approval_rules = get_approval_rules_prefix()
             improvement_ctx = get_improvement_context()
             system_prompt = (

--- a/agent/app/runner_hooks.py
+++ b/agent/app/runner_hooks.py
@@ -8,6 +8,7 @@ import asyncio
 import json as _json
 import logging
 import os
+import urllib.parse
 import urllib.request
 
 from app.config import settings
@@ -429,14 +430,22 @@ def get_onboarding_context() -> str:
     )
 
 
-def get_memory_preload() -> str:
+def get_memory_preload(task_context: str | None = None) -> str:
     """Fetch critical memories for prompt injection.
 
     Agents often forget API keys and user preferences after session reset. This ensures
     every task starts with the agent's most important long-term knowledge already loaded.
+
+    ``task_context`` (issue #547): the task title/prompt, truncated. When given, the
+    orchestrator adds a semantically-ranked "task_relevant" slice on top of the static
+    critical set — memories that were never important=5 but happen to match THIS task.
+    Best-effort: on any failure (including embeddings disabled) it's silently empty,
+    same as the rest of this function.
     """
     try:
         url = f"{settings.orchestrator_url}/api/v1/memory/preload/{settings.agent_id}"
+        if task_context:
+            url += "?" + urllib.parse.urlencode({"task_context": task_context[:500]})
         req = urllib.request.Request(url, headers={
             "Authorization": f"Bearer {settings.agent_token}",
             "X-Agent-ID": settings.agent_id,
@@ -447,8 +456,9 @@ def get_memory_preload() -> str:
         critical = data.get("critical", [])
         credentials = data.get("credentials", [])
         learnings = data.get("recent_learnings", [])
+        task_relevant = data.get("task_relevant", [])
 
-        if not (critical or credentials or learnings):
+        if not (critical or credentials or learnings or task_relevant):
             return ""
 
         lines = [
@@ -467,6 +477,10 @@ def get_memory_preload() -> str:
                 if m["category"] in ("credentials", "api_key", "secret", "auth"):
                     continue  # already listed above
                 lines.append(f"  - [{m['category']}] {m['key']}: {m['content']}")
+        if task_relevant:
+            lines.append("\n## Relevant to this task (evidence-backed, semantic match):")
+            for m in task_relevant:
+                lines.append(f"  - [{m['category']}] {m['key']} ({m['source']}): {m['content']}")
         if learnings:
             lines.append("\n## Recent Learnings:")
             for m in learnings[:5]:
@@ -748,11 +762,12 @@ def compose_prompt_bundle(prompt: str, lightweight: bool) -> str:
     """
     mounts = get_mounts_context()
     marketplace = get_marketplace_skill_suggestions(prompt[:200])
+    task_context = prompt[:500]
     if lightweight:
         return (
             CHAT_STARTUP_PREFIX
             + get_onboarding_context()
-            + get_memory_preload()
+            + get_memory_preload(task_context)
             + get_skill_preload()
             + get_skills_context()
             + mounts
@@ -761,7 +776,7 @@ def compose_prompt_bundle(prompt: str, lightweight: bool) -> str:
     return (
         TASK_STARTUP_PREFIX
         + get_onboarding_context()
-        + get_memory_preload()
+        + get_memory_preload(task_context)
         + get_user_feedback()
         + get_skill_preload()
         + get_skills_context()

--- a/agent/tests/test_identity_and_recall.py
+++ b/agent/tests/test_identity_and_recall.py
@@ -72,14 +72,16 @@ class EveryEntryPointUsesItTests(unittest.TestCase):
     def test_chat_path(self):
         src = self._src("app/llm_chat_handler.py")
         self.assertIn("get_identity_context()", src)
-        self.assertIn("get_memory_preload()", src)
+        # get_memory_preload( statt exaktem "()" — Issue #547 gibt ihr optional den
+        # Task-/Chat-Text als task_context mit, der Aufruf selbst darf nicht fehlen.
+        self.assertIn("get_memory_preload(", src)
 
     def test_task_path_including_lightweight(self):
         src = self._src("app/llm_runner.py")
         self.assertIn("get_identity_context()", src)
         # Der leichte Zweig (Chat/Telegram) hatte KEINEN Preload — genau das war die Luecke.
         light = src.split("if lightweight:", 1)[1].split("else:", 1)[0]
-        self.assertIn("get_memory_preload()", light)
+        self.assertIn("get_memory_preload(", light)
 
     def test_agent_to_agent_path(self):
         self.assertIn("get_identity_context()", self._src("app/message_consumer.py"))

--- a/orchestrator/app/api/memory.py
+++ b/orchestrator/app/api/memory.py
@@ -623,6 +623,11 @@ async def search_memories(
 @router.get("/preload/{agent_id}")
 async def preload_critical_memories(
     agent_id: str,
+    task_context: str | None = Query(
+        None, max_length=500,
+        description="Task title/description — adds a semantically-ranked 'task_relevant' slice (issue #547)",
+    ),
+    room: str | None = Query(None, description="Restrict the task_relevant slice to this room / sub-rooms"),
     user=Depends(require_auth_or_agent),
     db: AsyncSession = Depends(get_db),
 ):
@@ -632,6 +637,8 @@ async def preload_critical_memories(
     - importance >= 4 (user corrections, key decisions, credentials)
     - categories: credentials, preference, procedure
     - recent learnings (last 10)
+    - task_relevant: top-N memories semantically close to ``task_context``, if given
+      (empty list if omitted or embeddings are disabled — best-effort, never blocks)
 
     Requires user or agent auth. This response includes credential-category
     memories in clear text, so it must never be unauthenticated: an agent
@@ -650,7 +657,7 @@ async def preload_critical_memories(
     # Selection + grouping live in app.core.memory_preload so the voice front uses
     # exactly the same definition of "what this agent must always know".
     from app.core.memory_preload import collect_preload
-    return await collect_preload(db, agent_id)
+    return await collect_preload(db, agent_id, task_context=task_context, room=room)
 
 
 @router.get("/agents/{agent_id}")

--- a/orchestrator/app/core/memory_preload.py
+++ b/orchestrator/app/core/memory_preload.py
@@ -8,24 +8,115 @@ Ohne das schrieb der Sprachweg seine Erinnerungen brav weg und las sie nie zurue
 Nutzer taufte den Agenten „Luna" und einen Anruf spaeter hatte er keinen Namen mehr.
 """
 
-from sqlalchemy import select
+from datetime import datetime, timezone
+
+from sqlalchemy import select, text as sa_text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 # Das Modell liegt in app/models/memory.py — ein Import aus app.models.agent_memory
 # ist seit 6e635f8 (2026-08-07) fehlgeschlagen und hat den Gedaechtnis-Preload
 # unbenutzbar gemacht. Der Fehler faellt erst beim Aufruf auf, nicht beim Start.
 from app.models.memory import AgentMemory
+from app.core.memory_scoring import ScoringInputs, final_score
 
 # Kategorien, die Zugangsdaten enthalten — im Klartext, deshalb nie in einen Kontext,
 # der nach draussen geht (der Sprach-Prompt laesst sie weg, siehe as_prompt_block).
 CREDENTIAL_CATEGORIES = ["credentials", "api_key", "secret", "auth"]
 
+# Issue #547: wie viele semantisch zum aktuellen Task passende Erinnerungen zusaetzlich
+# zum statischen Kritisch-Set injiziert werden — hart begrenzt gegen Prompt-Bloat.
+TASK_RELEVANT_LIMIT = 5
 
-async def collect_preload(db: AsyncSession, agent_id: str) -> dict:
+
+def _rank_task_relevant(rows: list[dict], seen: set[int], *, query_room: str | None,
+                         limit: int = TASK_RELEVANT_LIMIT, now: datetime | None = None) -> list[dict]:
+    """Re-rank semantic-search rows and cap to the top-N not already selected.
+
+    Pure function (no I/O) so it can be unit-tested without a DB/embedding stub —
+    ``rows`` are the raw dict rows a cosine-similarity query would return.
+    """
+    now = now or datetime.now(timezone.utc)
+    scored: list[tuple[float, dict]] = []
+    for r in rows:
+        if r["id"] in seen:
+            continue
+        inp = ScoringInputs(
+            semantic_sim=float(r["similarity"]),
+            query_room=query_room,
+            memory_room=r.get("room"),
+            memory_tag_type=r.get("tag_type") or "permanent",
+            last_accessed_at=r.get("last_accessed_at"),
+            created_at=r["created_at"],
+            access_count=int(r.get("access_count") or 0),
+            importance=int(r.get("importance") or 3),
+        )
+        s = final_score(inp, now=now)
+        scored.append((s, r))
+    scored.sort(key=lambda t: t[0], reverse=True)
+
+    out = []
+    for score, r in scored[:limit]:
+        seen.add(r["id"])
+        out.append({
+            "key": r["key"],
+            "category": r["category"],
+            "content": r["content"],
+            "importance": r["importance"],
+            "room": r.get("room"),
+            "score": round(score, 4),
+            "source": f"memory:{r['id']}",  # evidence-backed — traceable back to the row
+        })
+    return out
+
+
+async def _task_relevant_rows(db: AsyncSession, agent_id: str, task_context: str,
+                               room: str | None, candidate_limit: int) -> list[dict]:
+    """Fetch semantic-search candidate rows for ``task_context`` (empty if embeddings off)."""
+    from app.services.embedding_service import get_embedding_service
+
+    svc = get_embedding_service()
+    if not svc.enabled:
+        return []
+    query_embedding = await svc.embed(task_context)
+    if query_embedding is None:
+        return []
+
+    room_clause = "AND (room = :room OR room LIKE :room_prefix)" if room else ""
+    sql = sa_text(
+        f"""
+        SELECT id, category, key, content, importance, access_count,
+               created_at, room, tag_type, last_accessed_at,
+               1 - (embedding <=> CAST(:query_vec AS vector)) AS similarity
+        FROM agent_memories
+        WHERE agent_id = :agent_id
+          AND embedding IS NOT NULL
+          AND superseded_by IS NULL
+          {room_clause}
+        ORDER BY embedding <=> CAST(:query_vec AS vector)
+        LIMIT :limit
+        """
+    )
+    params = {"query_vec": str(query_embedding), "agent_id": agent_id, "limit": candidate_limit}
+    if room:
+        params["room"] = room
+        params["room_prefix"] = f"{room}/%"
+    result = await db.execute(sql, params)
+    return [dict(r) for r in result.mappings().all()]
+
+
+async def collect_preload(
+    db: AsyncSession, agent_id: str, task_context: str | None = None, room: str | None = None,
+) -> dict:
     """Die kritischen Erinnerungen eines Agenten, gruppiert.
 
-    Rueckgabe: ``{"critical": [...], "credentials": [...], "recent_learnings": [...]}``,
-    jeder Eintrag ``{key, category, content, importance}``, ohne Dubletten.
+    Rueckgabe: ``{"critical": [...], "credentials": [...], "recent_learnings": [...],
+    "task_relevant": [...]}``, jeder Eintrag ``{key, category, content, importance}``,
+    ohne Dubletten.
+
+    ``task_relevant`` ist NUR gefuellt wenn ``task_context`` (Task-Titel/-Beschreibung)
+    mitgegeben wird UND Embeddings aktiv sind — sonst leere Liste, kein Fehler (Issue #547:
+    der statische Preload kennt den aktuellen Task nicht; dieser Slice holt semantisch
+    passende Erinnerungen zusaetzlich, mit Quellenangabe je Eintrag).
     """
     async def _rows(stmt):
         return list((await db.execute(stmt)).scalars().all())
@@ -64,11 +155,23 @@ async def collect_preload(db: AsyncSession, agent_id: str) -> dict:
             })
         return out
 
-    return {
+    result = {
         "critical": _dedupe(high_imp),
         "credentials": _dedupe(creds),
         "recent_learnings": _dedupe(learnings),
+        "task_relevant": [],
     }
+
+    if task_context:
+        try:
+            rows = await _task_relevant_rows(
+                db, agent_id, task_context, room, candidate_limit=max(TASK_RELEVANT_LIMIT * 4, 20)
+            )
+            result["task_relevant"] = _rank_task_relevant(rows, seen, query_room=room)
+        except Exception:  # noqa: BLE001 — evidence slice is best-effort, never blocks preload
+            result["task_relevant"] = []
+
+    return result
 
 
 async def as_prompt_block(db: AsyncSession, agent_id: str, limit: int = 12) -> str:

--- a/orchestrator/tests/test_memory_preload_task_context.py
+++ b/orchestrator/tests/test_memory_preload_task_context.py
@@ -1,0 +1,108 @@
+"""Issue #547: collect_preload gets a task-conditioned, evidence-backed slice.
+
+The static preload (importance>=5, recent learnings, ...) doesn't know what the
+current task is about. These tests cover the pure re-ranking/dedup helper
+(``_rank_task_relevant``) without a DB, and ``collect_preload`` end-to-end with a
+stubbed AsyncSession so no Postgres/pgvector is needed.
+"""
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.memory_preload import (
+    TASK_RELEVANT_LIMIT,
+    _rank_task_relevant,
+    collect_preload,
+)
+
+
+def _row(id_, similarity, importance=3, room=None, days_old=1):
+    now = datetime.now(timezone.utc)
+    return {
+        "id": id_,
+        "category": "learning",
+        "key": f"mem-{id_}",
+        "content": f"content-{id_}",
+        "importance": importance,
+        "access_count": 0,
+        "created_at": now - timedelta(days=days_old),
+        "room": room,
+        "tag_type": "permanent",
+        "last_accessed_at": None,
+        "similarity": similarity,
+    }
+
+
+def test_rank_orders_by_score_descending():
+    rows = [_row(1, similarity=0.5), _row(2, similarity=0.95), _row(3, similarity=0.7)]
+    out = _rank_task_relevant(rows, seen=set(), query_room=None)
+    assert [m["key"] for m in out] == ["mem-2", "mem-3", "mem-1"]
+
+
+def test_rank_skips_already_seen_ids():
+    rows = [_row(1, similarity=0.9), _row(2, similarity=0.8)]
+    out = _rank_task_relevant(rows, seen={1}, query_room=None)
+    assert [m["key"] for m in out] == ["mem-2"]
+
+
+def test_rank_caps_to_limit():
+    rows = [_row(i, similarity=0.5 + i * 0.001) for i in range(TASK_RELEVANT_LIMIT + 10)]
+    out = _rank_task_relevant(rows, seen=set(), query_room=None)
+    assert len(out) == TASK_RELEVANT_LIMIT
+
+
+def test_rank_entry_carries_evidence_source():
+    rows = [_row(42, similarity=0.9)]
+    out = _rank_task_relevant(rows, seen=set(), query_room=None)
+    assert out[0]["source"] == "memory:42"
+
+
+def test_rank_adds_returned_ids_to_seen():
+    seen: set = set()
+    rows = [_row(7, similarity=0.9)]
+    _rank_task_relevant(rows, seen, query_room=None)
+    assert 7 in seen
+
+
+def _db_with(high_imp=None, creds=None, learnings=None):
+    db = MagicMock()
+    queue = [high_imp or [], [], creds or [], learnings or []]
+
+    async def execute(stmt, *a, **kw):
+        result = MagicMock()
+        items = queue.pop(0) if queue else []
+        result.scalars.return_value.all.return_value = items
+        return result
+
+    db.execute = AsyncMock(side_effect=execute)
+    return db
+
+
+@pytest.mark.asyncio
+async def test_task_relevant_empty_without_task_context():
+    db = _db_with()
+    out = await collect_preload(db, "agent-1")
+    assert out["task_relevant"] == []
+
+
+@pytest.mark.asyncio
+async def test_task_relevant_empty_when_embeddings_disabled():
+    db = _db_with()
+    fake_svc = MagicMock(enabled=False)
+    with patch("app.services.embedding_service.get_embedding_service", return_value=fake_svc):
+        out = await collect_preload(db, "agent-1", task_context="fix the login bug")
+    assert out["task_relevant"] == []
+
+
+@pytest.mark.asyncio
+async def test_task_relevant_never_raises_on_embedding_failure():
+    db = _db_with()
+    fake_svc = MagicMock(enabled=True)
+    fake_svc.embed = AsyncMock(side_effect=RuntimeError("boom"))
+    with patch("app.services.embedding_service.get_embedding_service", return_value=fake_svc):
+        out = await collect_preload(db, "agent-1", task_context="fix the login bug")
+    assert out["task_relevant"] == []
+    # Static buckets must still come back — a broken embedding call must not
+    # take down the whole preload.
+    assert "critical" in out and "credentials" in out and "recent_learnings" in out


### PR DESCRIPTION
## Summary
- `collect_preload` (orchestrator) gains an optional `task_context` (+ `room`) parameter: it embeds the task/chat text, runs a pgvector semantic search over `agent_memories`, and re-ranks candidates with the existing multi-strategy scoring (`memory_scoring.final_score`) — capped at `TASK_RELEVANT_LIMIT=5`, deduped against the static critical/credentials/learnings buckets, each entry tagged with a `source` (`memory:<id>`) for evidence/traceability.
- Best-effort by design: disabled embedding service or any exception during the semantic lookup falls back to an empty `task_relevant` list — never breaks the existing critical/credentials/recent_learnings preload that every task/chat/voice session depends on.
- `/memory/preload/{agent_id}` gets optional `task_context` / `room` query params, fully backward compatible (no params → identical behavior to before).
- Threaded the task/chat text through every `custom_llm` entry point via `runner_hooks.get_memory_preload(task_context)`: `llm_runner.py` (task + lightweight branches) and `llm_chat_handler.py`. Updated the source-scan test (`test_identity_and_recall.py`) that enforces "every entry point must call memory preload" to allow the new optional-arg call signature.

Verdict from issue #547: **ADAPT** — reuse existing embedding service + scoring module, no new infra.

Closes #547

## Test plan
- [x] `pytest orchestrator/tests/test_memory_preload_task_context.py -v` — 8/8 passed (pure ranking/dedup logic + `collect_preload` with a stubbed AsyncSession, no Postgres needed)
- [x] `pytest orchestrator/tests/test_api/test_security_hardening.py -v -k preload` — `test_memory_preload_requires_auth` still passes (no auth regression)
- [x] `python3 -m unittest tests.test_identity_and_recall -v` (agent) — 7/7 passed
- [x] `py_compile` on all 7 touched files
- [ ] Full orchestrator/agent test suites not run in full (heavy/absent deps in this container) — targeted suites above cover the changed surface

## Review note
This touches the core memory-preload path used by every agent task/chat/voice session. CodeReview agent is currently unreachable, so I'm self-reviewing transparently here rather than self-merging silently — flagging to the user for a sanity check before merge given the blast radius, even though the change is additive/backward-compatible and fails open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)