### PR TITLE
fix(chat): Race zwischen zwei gleichzeitigen Schreibern verliert keinen Inhalt mehr

### DIFF
--- a/orchestrator/app/services/chat_persistence.py
+++ b/orchestrator/app/services/chat_persistence.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import logging
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 
 from app.db.session import async_session_factory
 from app.models.chat_message import ChatMessage
@@ -60,72 +61,88 @@ async def upsert_chat_message(
     Wiedereinstieg nach einem Verbindungsabbruch: da hing der Zwischenstand ohne
     Antwort in der Ablage, und der Nutzer war weg. Ihn deshalb NICHT zu
     benachrichtigen wäre die falsche Sparsamkeit.
+
+    Zwei Schreiber heisst auch: beide koennen das SELECT oben gleichzeitig mit
+    "gibt es noch nicht" beantworten und beide ein INSERT versuchen. Der zweite
+    Commit verletzt dann den Unique-Index — ohne Retry waere GENAU das der
+    Rueckfall in den Fehler, den dieses Modul beheben soll: der Inhalt dieses
+    Aufrufs (content/tool_calls/meta) ginge kommentarlos verloren. Deshalb bei
+    diesem einen Konflikt einmal neu lesen: die Zeile existiert jetzt, also wird
+    aus dem INSERT ein normales Merge-UPDATE.
     """
     if not (agent_id and session_id and message_id):
         return False
-    created = False
-    filled = False
     try:
-        async with async_session_factory() as db:
-            existing = await db.scalar(
-                select(ChatMessage)
-                .where(ChatMessage.agent_id == agent_id)
-                .where(ChatMessage.session_id == session_id)
-                .where(ChatMessage.message_id == message_id)
-                .where(ChatMessage.role == role)
-                .order_by(ChatMessage.id.asc())
-                .limit(1)
-            )
-            if existing:
-                filled = not (existing.content or "").strip() and bool((content or "").strip())
-                existing.content = content or existing.content
-                existing.tool_calls = tool_calls or existing.tool_calls
-                merged_meta = dict(existing.meta or {})
-                for key, value in (meta or {}).items():
-                    if value is None:
-                        continue
-                    if key == "presented_files":
-                        merged_meta[key] = _merge_files(merged_meta.get(key), value)
-                    else:
-                        merged_meta[key] = value
-                existing.meta = merged_meta or None
-                existing.cost_usd = cost_usd if cost_usd is not None else existing.cost_usd
-                existing.input_tokens = (
-                    input_tokens if input_tokens is not None else existing.input_tokens
+        for attempt in range(2):
+            created = False
+            filled = False
+            async with async_session_factory() as db:
+                existing = await db.scalar(
+                    select(ChatMessage)
+                    .where(ChatMessage.agent_id == agent_id)
+                    .where(ChatMessage.session_id == session_id)
+                    .where(ChatMessage.message_id == message_id)
+                    .where(ChatMessage.role == role)
+                    .order_by(ChatMessage.id.asc())
+                    .limit(1)
                 )
-                existing.output_tokens = (
-                    output_tokens if output_tokens is not None else existing.output_tokens
-                )
-            else:
-                created = True
-                db.add(ChatMessage(
-                    agent_id=agent_id,
-                    session_id=session_id,
-                    message_id=message_id,
-                    role=role,
-                    content=content,
-                    tool_calls=tool_calls,
-                    meta=meta,
-                    cost_usd=cost_usd,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                ))
-            await db.commit()
-
-            # Titel aus dem ersten Austausch (#538) — nur bei der ERSTEN
-            # Nutzernachricht, und ein selbst vergebener Titel bleibt stehen.
-            if role == "user":
+                if existing:
+                    filled = not (existing.content or "").strip() and bool((content or "").strip())
+                    existing.content = content or existing.content
+                    existing.tool_calls = tool_calls or existing.tool_calls
+                    merged_meta = dict(existing.meta or {})
+                    for key, value in (meta or {}).items():
+                        if value is None:
+                            continue
+                        if key == "presented_files":
+                            merged_meta[key] = _merge_files(merged_meta.get(key), value)
+                        else:
+                            merged_meta[key] = value
+                    existing.meta = merged_meta or None
+                    existing.cost_usd = cost_usd if cost_usd is not None else existing.cost_usd
+                    existing.input_tokens = (
+                        input_tokens if input_tokens is not None else existing.input_tokens
+                    )
+                    existing.output_tokens = (
+                        output_tokens if output_tokens is not None else existing.output_tokens
+                    )
+                else:
+                    created = True
+                    db.add(ChatMessage(
+                        agent_id=agent_id,
+                        session_id=session_id,
+                        message_id=message_id,
+                        role=role,
+                        content=content,
+                        tool_calls=tool_calls,
+                        meta=meta,
+                        cost_usd=cost_usd,
+                        input_tokens=input_tokens,
+                        output_tokens=output_tokens,
+                    ))
                 try:
-                    from app.core.chat_history import ensure_title
-                    await ensure_title(db, agent_id, session_id)
                     await db.commit()
-                except Exception:  # noqa: BLE001 — ein Titel stoert keinen Chat
-                    logger.debug("[Chat] Titel nicht ableitbar", exc_info=True)
+                except IntegrityError:
+                    await db.rollback()
+                    if attempt == 0:
+                        continue
+                    raise
+
+                # Titel aus dem ersten Austausch (#538) — nur bei der ERSTEN
+                # Nutzernachricht, und ein selbst vergebener Titel bleibt stehen.
+                if role == "user":
+                    try:
+                        from app.core.chat_history import ensure_title
+                        await ensure_title(db, agent_id, session_id)
+                        await db.commit()
+                    except Exception:  # noqa: BLE001 — ein Titel stoert keinen Chat
+                        logger.debug("[Chat] Titel nicht ableitbar", exc_info=True)
+            return created or filled
     except Exception:  # noqa: BLE001
         logger.warning("[Chat] Zeile nicht speicherbar (%s/%s)", agent_id, message_id,
                        exc_info=True)
         return False
-    return created or filled
+    return False
 
 
 def _merge_files(existing, incoming) -> list:

--- a/orchestrator/tests/test_chat_persistence.py
+++ b/orchestrator/tests/test_chat_persistence.py
@@ -19,6 +19,8 @@ Gegen echtes SQL, weil beides an Abfragen hängt: „gibt es die Zeile schon" un
 „zu welcher Sitzung gehört diese Nachricht".
 """
 
+import os
+import tempfile
 import unittest
 
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -32,7 +34,18 @@ SESSION_B = "sess-kodierung"
 
 class ChatPersistenceTests(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
-        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        # Echte Datei statt ":memory:": ":memory:" ist pro Verbindung eine
+        # EIGENE Datenbank (SQLite-Eigenheit) — zwei "gleichzeitige" Schreiber
+        # (test_a_true_write_race_does_not_drop_the_loser) braeuchten dafuer
+        # dieselbe physische Verbindung, und die teilt sich in SQLAlchemy nicht
+        # nebenlaeufig: eine zweite Transaktion auf derselben Verbindung stoert
+        # die erste (Rollback der einen reisst die andere mit). Eine Datei
+        # dagegen bekommt aus dem Pool ganz normal getrennte Verbindungen, so
+        # wie Postgres auch — genau das macht die Nebenlaeufigkeit im Race-Test
+        # erst echt.
+        fd, self._db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.engine = create_async_engine(f"sqlite+aiosqlite:///{self._db_path}")
         async with self.engine.begin() as conn:
             await conn.run_sync(ChatMessage.metadata.create_all,
                                 tables=[ChatMessage.__table__])
@@ -46,6 +59,7 @@ class ChatPersistenceTests(unittest.IsolatedAsyncioTestCase):
     async def asyncTearDown(self):
         self._cp.async_session_factory = self._orig
         await self.engine.dispose()
+        os.unlink(self._db_path)
 
     async def _rows(self, **where):
         from sqlalchemy import select
@@ -107,6 +121,31 @@ class ChatPersistenceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(rows[0].meta.get("partial"), True)
         self.assertEqual(rows[0].meta.get("num_turns"), 3)
         self.assertAlmostEqual(rows[0].cost_usd, 0.42)
+
+    async def test_a_true_write_race_does_not_drop_the_loser(self):
+        """Zwei Schreiber legen dieselbe NEUE Zeile echt gleichzeitig an (nicht
+        nacheinander). Vor dem Fix verletzte der zweite Commit den Unique-Index,
+        das wurde nur geloggt — der komplette Inhalt dieses Aufrufs (Text ODER
+        Werkzeugaufrufe, je nachdem wer verlor) ging kommentarlos verloren."""
+        import asyncio
+
+        await asyncio.gather(
+            self._cp.upsert_chat_message(
+                AGENT, SESSION_A, "race", "assistant",
+                content="Die fertige Antwort.",
+            ),
+            self._cp.upsert_chat_message(
+                AGENT, SESSION_A, "race", "assistant",
+                content="", tool_calls=[{"tool": "read_file", "input": "{}"}],
+            ),
+        )
+        rows = await self._rows(message_id="race")
+        self.assertEqual(len(rows), 1, "Unique-Index erzwingt genau eine Zeile")
+        self.assertEqual(rows[0].content, "Die fertige Antwort.",
+                          "Der Text darf nicht verloren gehen")
+        self.assertEqual(rows[0].tool_calls, [{"tool": "read_file", "input": "{}"}],
+                          "Die Werkzeugaufrufe des zweiten Schreibers duerfen nicht "
+                          "stillschweigend verworfen werden")
 
     async def test_nothing_is_written_without_a_session(self):
         created = await self._cp.upsert_chat_message(AGENT, "", "m1", "assistant", content="x")


### PR DESCRIPTION
## Zusammenfassung

Fixes #567

WebSocket-Handler und Redis-Hintergrundlauscher schreiben dieselbe Chat-Zeile
unabhaengig voneinander (Absicht, siehe Modul-Docstring). Bisher konnten beide
das SELECT gleichzeitig mit "existiert noch nicht" beantworten und beide ein
INSERT versuchen — der zweite Commit verletzte den Unique-Index
(`uq_chat_messages_agent_session_message_role`), wurde nur geloggt, und sein
kompletter Inhalt (Text oder Werkzeugaufrufe, je nachdem wer verlor) ging
kommentarlos verloren. Produktions-Logs zeigten das 6x in
`/shared/platform-errors.log`.

**Fix:** `upsert_chat_message()` faengt den `IntegrityError` beim Commit ab,
macht ein Rollback und liest einmal neu — die Zeile existiert dann bereits,
also wird aus dem gescheiterten INSERT ein normales Merge-UPDATE mit dem
Inhalt dieses Aufrufs. Alle bestehenden Merge-Regeln (`content or
existing.content`, `presented_files`-Dedup etc.) bleiben unveraendert.

## Testplan
- [x] Neuer Regressionstest `test_a_true_write_race_does_not_drop_the_loser`:
  zwei Schreiber legen per `asyncio.gather` dieselbe neue Zeile echt
  gleichzeitig an — beide Inhalte (Text + Werkzeugaufrufe) muessen in der
  einen resultierenden Zeile landen.
  - Braucht eine datei-basierte SQLite-DB statt `:memory:` + `StaticPool`,
    damit die zwei Schreiber wirklich getrennte Verbindungen benutzen
    (`:memory:` ist sonst pro Verbindung eine eigene DB, `StaticPool` teilt
    umgekehrt eine einzige Verbindung und verhindert damit echte
    Nebenlaeufigkeit) — betrifft `asyncSetUp` fuer die ganze Testklasse.
- [x] Alle 12 Tests in `tests/test_chat_persistence.py` gruen
  (`/tmp/testenv/bin/python -m unittest tests.test_chat_persistence -v`)
- [x] Race-Test 5x wiederholt lauffaehig (keine Flakiness)
- [x] Verifiziert per `git stash`: derselbe Test reproduziert den Bug
  zuverlaessig gegen den alten Code (`tool_calls` wird `None` statt der
  Werkzeugaufrufe des zweiten Schreibers)

## Selbst-Review
CodeReview-Agent aktuell nicht erreichbar — dies ist ein Selbst-Review, kein
unabhaengiges. Schmaler, gut getesteter Fix; Merge-Semantik unveraendert,
nur die Fehlerbehandlung bei einem echten Nebenlaeufigkeits-Konflikt neu.
Kernpfad (Chat-Persistenz) — 24h-Selbstmerge-Fenster wird eingehalten.