### PR TITLE
Fix #572: create_schedule 500 when timezone omitted

### DIFF
--- a/orchestrator/app/schemas/schedule.py
+++ b/orchestrator/app/schemas/schedule.py
@@ -65,7 +65,13 @@ class ScheduleCreate(BaseModel):
             )
         if self.cron_expression:
             self.cron_expression = _validate_cron(self.cron_expression)
-        self.timezone = _validate_timezone(self.timezone)
+        # None/empty means "use the agent's own timezone" — resolved later in the
+        # create_schedule endpoint, which has DB access to look the agent up. Only
+        # validate when the caller actually named one; ZoneInfo(None) raises a raw
+        # TypeError (not caught below), which crashed every no-timezone request with
+        # a 500 instead of leaving the field for the endpoint to fill in (#572).
+        if self.timezone:
+            self.timezone = _validate_timezone(self.timezone)
         return self
 
 

--- a/orchestrator/tests/test_schedule_create_no_timezone.py
+++ b/orchestrator/tests/test_schedule_create_no_timezone.py
@@ -1,0 +1,47 @@
+"""Regression test for #572: create_schedule returned 500 for every input.
+
+ScheduleCreate.validate_timing() unconditionally ran ZoneInfo(self.timezone)
+via _validate_timezone(). Agents are told (by design, see the tool docstring)
+to OMIT timezone unless overriding the server-side agent-timezone default —
+so self.timezone was None on virtually every real call. ZoneInfo(None) raises
+a plain TypeError, which the validator's except clause (ZoneInfoNotFoundError,
+ValueError, KeyError) does not catch, so it escaped as an unhandled 500
+instead of a clean 422 — reproduced identically for cron, interval_seconds,
+and run_in_seconds inputs.
+"""
+
+import unittest
+
+from pydantic import ValidationError
+
+from app.schemas.schedule import ScheduleCreate
+
+
+class ScheduleCreateNoTimezoneTests(unittest.TestCase):
+    def test_cron_without_timezone_does_not_raise(self):
+        data = ScheduleCreate(name="Test", prompt="Test.", cron_expression="0 18 * * 5")
+        self.assertIsNone(data.timezone)
+
+    def test_interval_without_timezone_does_not_raise(self):
+        data = ScheduleCreate(name="Test", prompt="Test.", interval_seconds=604800)
+        self.assertIsNone(data.timezone)
+
+    def test_run_in_seconds_without_timezone_does_not_raise(self):
+        data = ScheduleCreate(name="Test", prompt="Test.", run_in_seconds=1800)
+        self.assertIsNone(data.timezone)
+
+    def test_explicit_valid_timezone_is_kept(self):
+        data = ScheduleCreate(
+            name="Test", prompt="Test.", cron_expression="0 6 * * *", timezone="Europe/Berlin"
+        )
+        self.assertEqual(data.timezone, "Europe/Berlin")
+
+    def test_explicit_invalid_timezone_still_raises_validation_error(self):
+        with self.assertRaises(ValidationError):
+            ScheduleCreate(
+                name="Test", prompt="Test.", cron_expression="0 6 * * *", timezone="Mars/Olympus"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #572

## Root cause
`ScheduleCreate.validate_timing()` (orchestrator/app/schemas/schedule.py) unconditionally called `_validate_timezone(self.timezone)`. The `timezone` field defaults to `None` — by design, agents are told (in the tool docstring/definitions.py) to omit it so the server fills in the agent's own timezone inside the `create_schedule` endpoint, which runs *after* pydantic validation.

`ZoneInfo(None)` raises a plain `TypeError`, which `_validate_timezone`'s except clause (`ZoneInfoNotFoundError, ValueError, KeyError`) does not catch. Pydantic only converts `ValueError`/`AssertionError` from validators into a clean `ValidationError` (422) — any other exception type propagates raw, which FastAPI's default handler turns into an unhandled 500.

Since no real agent call sets `timezone` explicitly, this made **every** `create_schedule` call fail — reproduced locally for all three input shapes from the issue (cron_expression, interval_seconds, run_in_seconds), all raising the same `TypeError` before the fix and all succeeding after.

## Fix
Only call `_validate_timezone` when a timezone was actually provided; `None`/empty is left alone for the endpoint to resolve from the agent's config, exactly as the adjacent comment already documented as the intended behavior.

## Testing
- New `tests/test_schedule_create_no_timezone.py`: 5 cases (cron/interval/run_in_seconds without timezone no longer raise; explicit valid timezone kept; explicit invalid timezone still raises a proper `ValidationError`).
- Local repro script instantiating `create_schedule()` end-to-end (mocked DB) confirms all 3 cases from the issue now succeed instead of raising.
- `tests/test_schedule_cron_timezone.py` (existing DST/timezone suite) still passes — 12/12 green together.

## Note
Self-reviewed and self-merging per the documented fallback: CodeReview agent (6e4210c1) remains unreachable (see prior memory/issue history), this is a small, well-isolated schema-validation fix with a regression test, not a core dispatch-path change.