### PR TITLE
Fix #571: Make Microsoft OAuth prompt=consent opt-in

### DIFF
--- a/orchestrator/app/config.py
+++ b/orchestrator/app/config.py
@@ -232,6 +232,14 @@ class Settings(BaseSettings):
     oauth_github_scopes: str = ""
     oauth_anthropic_scopes: str = ""
 
+    # Opt-in "prompt" value for the Microsoft authorize URL (env: OAUTH_MICROSOFT_PROMPT).
+    # Empty by default = no forced prompt, so a tenant-wide admin consent grant is
+    # honored on connect. Tenants with end-user consent disabled can never satisfy a
+    # forced "prompt=consent" dialog — Entra re-forces it on every attempt even after
+    # the grant exists (#571). Set to "consent" to restore the old forced-reconsent
+    # behaviour where that is actually wanted.
+    oauth_microsoft_prompt: str = ""
+
     # Skill file attachments — stored on shared Docker volume
     skill_files_root: str = "/shared/skill-files"
 

--- a/orchestrator/app/core/oauth_providers.py
+++ b/orchestrator/app/core/oauth_providers.py
@@ -110,7 +110,13 @@ PROVIDERS: dict[str, OAuthProviderConfig] = {
             "Contacts.ReadWrite",
             "People.Read",
         ],
-        auth_extra_params={"prompt": "consent"},
+        # No forced prompt by default (#571): tenants with end-user consent disabled
+        # can never satisfy a forced "prompt=consent" dialog, even after an admin
+        # grants tenant-wide consent — Entra re-forces the dialog on every attempt.
+        # Unlike Google, Microsoft returns a refresh token whenever offline_access is
+        # granted, so no prompt override is needed for that. Opt back in per-deployment
+        # via oauth_microsoft_prompt (see get_provider_extra_params below).
+        auth_extra_params={},
         client_id_setting="oauth_microsoft_client_id",
         client_secret_setting="oauth_microsoft_client_secret",
     ),
@@ -212,6 +218,22 @@ def get_provider_scopes(provider: OAuthProviderConfig) -> list[str]:
     if override.strip():
         return [s.strip() for s in override.split(",") if s.strip()]
     return list(provider.scopes)
+
+
+def get_provider_extra_params(provider: OAuthProviderConfig) -> dict[str, str]:
+    """Return the effective authorize-URL extra params for a provider.
+
+    Same override pattern as get_provider_scopes: static config from PROVIDERS,
+    plus a per-deployment opt-in. Currently only Microsoft's "prompt" is
+    configurable (oauth_microsoft_prompt, empty by default) — see #571.
+    """
+    from app.config import settings
+    params = dict(provider.auth_extra_params)
+    if provider.name == "microsoft":
+        prompt = getattr(settings, "oauth_microsoft_prompt", "").strip()
+        if prompt:
+            params["prompt"] = prompt
+    return params
 
 
 def is_provider_available(provider: OAuthProviderConfig) -> bool:

--- a/orchestrator/app/services/oauth_service.py
+++ b/orchestrator/app/services/oauth_service.py
@@ -21,6 +21,7 @@ from app.core.oauth_providers import (
     get_provider,
     get_provider_client_id,
     get_provider_client_secret,
+    get_provider_extra_params,
     get_provider_scopes,
     is_provider_available,
 )
@@ -89,7 +90,7 @@ class OAuthService:
                 "response_type": "code",
                 "scope": " ".join(get_provider_scopes(provider)),
                 "state": state,
-                **provider.auth_extra_params,
+                **get_provider_extra_params(provider),
             }
 
         return f"{apply_tenant(provider.authorization_url)}?{urlencode(params)}"

--- a/orchestrator/tests/test_oauth_extra_params_config.py
+++ b/orchestrator/tests/test_oauth_extra_params_config.py
@@ -1,0 +1,73 @@
+"""Regression test for #571: Microsoft OAuth unconditionally sent prompt=consent,
+which tenants with end-user consent disabled can never satisfy — even after an
+admin grants tenant-wide consent, Entra re-forces the dialog on every attempt.
+
+get_provider_extra_params() now merges an opt-in oauth_microsoft_prompt setting
+into the static auth_extra_params instead of Microsoft's config hardcoding
+"prompt": "consent". Default (unset) means no prompt param is sent at all.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.core.oauth_providers import get_provider, get_provider_extra_params
+
+
+def _mock_settings(**kwargs):
+    m = MagicMock()
+    for k, v in kwargs.items():
+        setattr(m, k, v)
+    return m
+
+
+def test_microsoft_no_prompt_by_default():
+    provider = get_provider("microsoft")
+    with patch("app.config.settings", _mock_settings(oauth_microsoft_prompt="")):
+        params = get_provider_extra_params(provider)
+    assert "prompt" not in params
+
+
+def test_microsoft_prompt_opt_in():
+    provider = get_provider("microsoft")
+    with patch("app.config.settings", _mock_settings(oauth_microsoft_prompt="consent")):
+        params = get_provider_extra_params(provider)
+    assert params["prompt"] == "consent"
+
+
+def test_microsoft_prompt_whitespace_only_is_unset():
+    provider = get_provider("microsoft")
+    with patch("app.config.settings", _mock_settings(oauth_microsoft_prompt="   ")):
+        params = get_provider_extra_params(provider)
+    assert "prompt" not in params
+
+
+def test_google_extra_params_unaffected():
+    """Google keeps access_type=offline + prompt=consent — out of scope for #571."""
+    provider = get_provider("google")
+    with patch("app.config.settings", _mock_settings(oauth_microsoft_prompt="")):
+        params = get_provider_extra_params(provider)
+    assert params == {"access_type": "offline", "prompt": "consent"}
+
+
+def test_oauth_service_uses_get_provider_extra_params():
+    """generate_auth_url must merge extra params through get_provider_extra_params,
+    not read provider.auth_extra_params directly — otherwise the opt-in setting
+    would be silently bypassed for the standard (non-Anthropic) auth flow."""
+    import ast
+    import inspect
+
+    from app.services import oauth_service
+
+    src = inspect.getsource(oauth_service)
+    tree = ast.parse(src)
+    raw = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute)
+        and node.attr == "auth_extra_params"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "provider"
+    ]
+    assert not raw, (
+        "oauth_service still reads provider.auth_extra_params directly; route it "
+        "through get_provider_extra_params(provider) so the prompt override applies"
+    )


### PR DESCRIPTION
## Summary
- Microsoft's authorize URL unconditionally sent `prompt=consent`, which tenants with end-user consent disabled can never satisfy — even after an admin grants tenant-wide consent, Entra re-forces the dialog on every attempt, blocking those tenants from connecting at all.
- Makes the prompt opt-in via `OAUTH_MICROSOFT_PROMPT` (empty by default = no forced prompt, so a tenant-wide admin consent grant is honored). Google's `prompt=consent` (needed there to reliably get a refresh token) is untouched.

## Changes
- `oauth_providers.py`: Microsoft's `auth_extra_params` no longer hardcodes `prompt=consent`; new `get_provider_extra_params()` merges in the per-deployment opt-in.
- `oauth_service.py`: `generate_auth_url` now routes through `get_provider_extra_params()` instead of reading `provider.auth_extra_params` directly.
- `config.py`: new `oauth_microsoft_prompt` setting (env `OAUTH_MICROSOFT_PROMPT`).
- New regression tests (`test_oauth_extra_params_config.py`, 5 tests) covering default/opt-in/whitespace behavior, Google being unaffected, and an AST check that the service can't bypass the override.

Fixes #571

## Test plan
- [x] `pytest tests/test_oauth_extra_params_config.py` — 5/5 passed
- [ ] CI