### PR TITLE
Git-host: support GitHub Enterprise Server (base_url) — #532 phase 2

### DIFF
--- a/frontend/src/app/integrations/page.tsx
+++ b/frontend/src/app/integrations/page.tsx
@@ -247,6 +247,8 @@ export default function IntegrationsPage() {
   const [disconnecting, setDisconnecting] = useState<string | null>(null);
   const [toast, setToast] = useState<{ type: "success" | "error"; message: string } | null>(null);
   const [patToken, setPatToken] = useState("");
+  const [patBaseUrl, setPatBaseUrl] = useState("");
+  const [patSelfHosted, setPatSelfHosted] = useState(false);
   const [patSaving, setPatSaving] = useState<string | null>(null);
   const [patVisible, setPatVisible] = useState(false);
   const [setupExpanded, setSetupExpanded] = useState<string | null>(null);
@@ -330,9 +332,12 @@ export default function IntegrationsPage() {
     if (!patToken.trim()) return;
     setPatSaving(provider);
     try {
-      const result = await api.savePatToken(provider, patToken.trim());
+      const baseUrl = patSelfHosted ? patBaseUrl.trim() : "";
+      const result = await api.savePatToken(provider, patToken.trim(), baseUrl);
       setToast({ type: "success", message: `Connected to ${provider} as ${result.account_label || "unknown"}` });
       setPatToken("");
+      setPatBaseUrl("");
+      setPatSelfHosted(false);
       setPatVisible(false);
       await loadIntegrations();
     } catch (e) {
@@ -569,6 +574,29 @@ export default function IntegrationsPage() {
                         <p className="text-[10px] text-muted-foreground/50 mt-1.5">
                           Create a token at github.com/settings/tokens with repo, workflow, and read:org scopes
                         </p>
+
+                        {integration.provider === "github" && (
+                          <div className="mt-3">
+                            <label className="flex items-center gap-1.5 text-[11px] text-muted-foreground cursor-pointer select-none">
+                              <input
+                                type="checkbox"
+                                checked={patSelfHosted}
+                                onChange={(e) => setPatSelfHosted(e.target.checked)}
+                                className="h-3 w-3"
+                              />
+                              Self-hosted (GitHub Enterprise Server)
+                            </label>
+                            {patSelfHosted && (
+                              <input
+                                type="text"
+                                value={patBaseUrl}
+                                onChange={(e) => setPatBaseUrl(e.target.value)}
+                                placeholder="https://ghe.example.com"
+                                className="mt-1.5 w-full rounded-lg border border-foreground/[0.08] bg-background/50 px-3 py-2 text-sm outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all"
+                              />
+                            )}
+                          </div>
+                        )}
                       </div>
                     )}
                   </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1198,11 +1198,12 @@ export async function exchangeOAuthCode(
   });
 }
 
-// PAT-based integrations (GitHub)
-export async function savePatToken(provider: string, token: string): Promise<{ status: string; provider: string; account_label?: string }> {
+// PAT-based integrations (GitHub). base_url points at a self-hosted instance
+// (GitHub Enterprise Server) instead of github.com — #532 phase 2.
+export async function savePatToken(provider: string, token: string, baseUrl?: string): Promise<{ status: string; provider: string; account_label?: string }> {
   return fetchJSON(`${getBase()}/integrations/${provider}/pat`, {
     method: "POST",
-    body: JSON.stringify({ token }),
+    body: JSON.stringify({ token, base_url: baseUrl || undefined }),
   });
 }
 

--- a/orchestrator/alembic/versions/b532p2h1o2s3_oauth_integration_host_type.py
+++ b/orchestrator/alembic/versions/b532p2h1o2s3_oauth_integration_host_type.py
@@ -1,0 +1,35 @@
+"""oauth_integrations: add host_type + base_url (#532 phase 2)
+
+Lets a Git-host integration describe a self-hosted instance (GitHub
+Enterprise Server today, Forgejo/Gitea in a later phase) instead of the host
+being implied by the fixed OAuthProvider enum value. Both columns are
+nullable and unused by existing rows, so current behaviour (public GitHub,
+public Google/Microsoft/...) is unchanged.
+
+Revision ID: b532p2h1o2s3
+Revises: v7h1b2r3d4s5
+Create Date: 2026-08-12
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "b532p2h1o2s3"
+down_revision = "v7h1b2r3d4s5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "oauth_integrations",
+        sa.Column("host_type", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "oauth_integrations",
+        sa.Column("base_url", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("oauth_integrations", "base_url")
+    op.drop_column("oauth_integrations", "host_type")

--- a/orchestrator/app/api/integrations.py
+++ b/orchestrator/app/api/integrations.py
@@ -190,6 +190,9 @@ async def exchange_code_manual(
 
 class PatRequest(BaseModel):
     token: str
+    # Self-hosted instance, e.g. "https://ghe.example.com" (#532 phase 2).
+    # Only meaningful for provider="github" (GitHub Enterprise Server) today.
+    base_url: str | None = None
 
 
 @router.post("/{provider}/pat")
@@ -201,7 +204,7 @@ async def store_pat(
 ):
     """Store a Personal Access Token for a provider (e.g., GitHub PAT)."""
     try:
-        integration = await service.store_pat(provider, body.token)
+        integration = await service.store_pat(provider, body.token, base_url=body.base_url)
         return {
             "status": "connected",
             "provider": provider,

--- a/orchestrator/app/core/agent_manager.py
+++ b/orchestrator/app/core/agent_manager.py
@@ -1097,7 +1097,10 @@ class AgentManager:
             integration = result.scalar_one_or_none()
             if integration:
                 token = decrypt_token(integration.access_token_encrypted)
-                env.update(get_git_host_provider("github").get_agent_env(token))
+                provider = get_git_host_provider(
+                    integration.host_type or "github", integration.base_url
+                )
+                env.update(provider.get_agent_env(token))
         if "microsoft" in agent_integrations and user_id:
             from sqlalchemy import and_ as _sqland
             result = await self.db.execute(

--- a/orchestrator/app/core/githost/github.py
+++ b/orchestrator/app/core/githost/github.py
@@ -11,10 +11,17 @@ from app.core.githost.base import GitHostProvider
 
 
 class GitHubHostProvider(GitHostProvider):
-    api_base = "https://api.github.com"
+    def __init__(self, api_base: str = "https://api.github.com", host: str | None = None):
+        self.api_base = api_base
+        # `gh` needs GH_HOST (bare hostname, no scheme) to target a GitHub
+        # Enterprise Server instance instead of github.com.
+        self.host = host
 
     def get_agent_env(self, token: str) -> dict[str, str]:
-        return {"GITHUB_TOKEN": token, "GH_TOKEN": token}
+        env = {"GITHUB_TOKEN": token, "GH_TOKEN": token}
+        if self.host:
+            env["GH_HOST"] = self.host
+        return env
 
     async def search_open_issue(
         self, client: httpx.AsyncClient, token: str, repo: str, title: str

--- a/orchestrator/app/core/githost/registry.py
+++ b/orchestrator/app/core/githost/registry.py
@@ -2,16 +2,27 @@
 
 Only "github" exists today (#532 phase 1). An unknown/unset host_type falls
 back to GitHub — this preserves current behaviour, where GitHub was the only
-option, for every existing caller.
+option, for every existing caller. Forgejo/Gitea adapters land in phase 3;
+until then a non-github host_type with a base_url still gets routed through
+GitHubHostProvider, which is wrong for those hosts but no worse than today
+(no adapter existed at all).
+
+`base_url` (#532 phase 2) lets a "github" integration point at a GitHub
+Enterprise Server instance instead of the public API — GHES exposes the
+same REST API under `<base_url>/api/v3`.
 """
 
 from app.core.githost.base import GitHostProvider
 from app.core.githost.github import GitHubHostProvider
 
+_DEFAULT_GITHUB = GitHubHostProvider()
 _PROVIDERS: dict[str, GitHostProvider] = {
-    "github": GitHubHostProvider(),
+    "github": _DEFAULT_GITHUB,
 }
 
 
-def get_git_host_provider(host_type: str = "github") -> GitHostProvider:
-    return _PROVIDERS.get(host_type, _PROVIDERS["github"])
+def get_git_host_provider(host_type: str = "github", base_url: str | None = None) -> GitHostProvider:
+    if not base_url:
+        return _PROVIDERS.get(host_type, _DEFAULT_GITHUB)
+    host = base_url.rstrip("/").split("://", 1)[-1]
+    return GitHubHostProvider(api_base=f"{base_url.rstrip('/')}/api/v3", host=host)

--- a/orchestrator/app/models/oauth_integration.py
+++ b/orchestrator/app/models/oauth_integration.py
@@ -49,3 +49,9 @@ class OAuthIntegration(Base, TimestampMixin):
     account_label: Mapped[str | None] = mapped_column(String, nullable=True)
     # For Apple: stores extra data (id_token, user info) - encrypted
     extra_data_encrypted: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Self-hosted Git-host support (#532 phase 2). NULL = the provider's public
+    # host (e.g. github.com). Set on GITHUB rows to point at a GitHub Enterprise
+    # Server instance instead; host_type distinguishes the API dialect
+    # ("github" today, "forgejo"/"gitea" in a later phase) once base_url is set.
+    host_type: Mapped[str | None] = mapped_column(String, nullable=True)
+    base_url: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/orchestrator/app/services/oauth_service.py
+++ b/orchestrator/app/services/oauth_service.py
@@ -371,7 +371,7 @@ class OAuthService:
         account_label = None
         if userinfo_url:
             async with httpx.AsyncClient() as client:
-                resp = await client.get(
+                resp = await client.get(  # codeql[py/partial-ssrf]: userinfo_url is validated by check_outbound_url above.
                     userinfo_url,
                     headers={
                         "Authorization": f"Bearer {token}" if not token.startswith("ghp_") else f"token {token}",

--- a/orchestrator/app/services/oauth_service.py
+++ b/orchestrator/app/services/oauth_service.py
@@ -371,8 +371,8 @@ class OAuthService:
         account_label = None
         if userinfo_url:
             async with httpx.AsyncClient() as client:
-                resp = await client.get(  # codeql[py/partial-ssrf]: userinfo_url is validated by check_outbound_url above.
-                    userinfo_url,
+                resp = await client.get(
+                    userinfo_url,  # codeql[py/partial-ssrf]: userinfo_url is validated by check_outbound_url above.
                     headers={
                         "Authorization": f"Bearer {token}" if not token.startswith("ghp_") else f"token {token}",
                         "Accept": "application/json",

--- a/orchestrator/app/services/oauth_service.py
+++ b/orchestrator/app/services/oauth_service.py
@@ -340,17 +340,32 @@ class OAuthService:
         logger.info("Refreshed token for %s (user=%s)", integration.provider.value, integration.user_id)
         return integration
 
-    async def store_pat(self, provider_name: str, token: str, user_id: str | None = None) -> OAuthIntegration:
-        """Store a Personal Access Token (e.g., GitHub PAT)."""
+    async def store_pat(
+        self,
+        provider_name: str,
+        token: str,
+        user_id: str | None = None,
+        base_url: str | None = None,
+    ) -> OAuthIntegration:
+        """Store a Personal Access Token (e.g., GitHub PAT).
+
+        `base_url` (#532 phase 2) points the token at a self-hosted instance —
+        currently only meaningful for provider="github" (GitHub Enterprise
+        Server). Ignored for providers without a self-hosted variant.
+        """
         provider_enum = OAuthProvider(provider_name)
         if not _is_per_user(provider_name):
             user_id = None
         provider = get_provider(provider_name)
+        host_type = "github" if (base_url and provider_name == "github") else None
+        userinfo_url = provider.userinfo_url
+        if host_type == "github" and base_url:
+            userinfo_url = f"{base_url.rstrip('/')}/api/v3/user"
         account_label = None
-        if provider.userinfo_url:
+        if userinfo_url:
             async with httpx.AsyncClient() as client:
                 resp = await client.get(
-                    provider.userinfo_url,
+                    userinfo_url,
                     headers={
                         "Authorization": f"Bearer {token}" if not token.startswith("ghp_") else f"token {token}",
                         "Accept": "application/json",
@@ -372,6 +387,8 @@ class OAuthService:
             integration.expires_at = None
             integration.scopes = " ".join(get_provider_scopes(provider))
             integration.account_label = account_label
+            integration.host_type = host_type
+            integration.base_url = base_url if host_type else None
         else:
             integration = OAuthIntegration(
                 provider=provider_enum,
@@ -380,6 +397,8 @@ class OAuthService:
                 token_type="token",
                 scopes=" ".join(get_provider_scopes(provider)),
                 account_label=account_label,
+                host_type=host_type,
+                base_url=base_url if host_type else None,
             )
             self.db.add(integration)
 

--- a/orchestrator/app/services/oauth_service.py
+++ b/orchestrator/app/services/oauth_service.py
@@ -371,8 +371,9 @@ class OAuthService:
         account_label = None
         if userinfo_url:
             async with httpx.AsyncClient() as client:
+                # codeql[py/partial-ssrf]: userinfo_url is validated by check_outbound_url above.
                 resp = await client.get(
-                    userinfo_url,  # codeql[py/partial-ssrf]: userinfo_url is validated by check_outbound_url above.
+                    userinfo_url,
                     headers={
                         "Authorization": f"Bearer {token}" if not token.startswith("ghp_") else f"token {token}",
                         "Accept": "application/json",

--- a/orchestrator/app/services/oauth_service.py
+++ b/orchestrator/app/services/oauth_service.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import settings
 from app.core.encryption import decrypt_token, encrypt_token
 from app.core.log_redaction import scrub_log
+from app.core.url_guard import check_outbound_url
 from app.core.oauth_providers import (
     PROVIDERS,
     apply_tenant,
@@ -361,6 +362,12 @@ class OAuthService:
         userinfo_url = provider.userinfo_url
         if host_type == "github" and base_url:
             userinfo_url = f"{base_url.rstrip('/')}/api/v3/user"
+            # base_url is user-supplied (self-hosted GHES) — without this check a
+            # caller could point it at an internal service or the cloud metadata
+            # endpoint and use this server to probe it (SSRF).
+            allowed, reason = check_outbound_url(userinfo_url)
+            if not allowed:
+                raise ValueError(f"Invalid base_url: {reason}")
         account_label = None
         if userinfo_url:
             async with httpx.AsyncClient() as client:

--- a/orchestrator/tests/test_agent_manager_githost_env.py
+++ b/orchestrator/tests/test_agent_manager_githost_env.py
@@ -21,6 +21,8 @@ def _db_with_integration(integration):
 async def test_github_integration_env_via_provider():
     integration = MagicMock()
     integration.access_token_encrypted = "encrypted-blob"
+    integration.host_type = None
+    integration.base_url = None
     db = _db_with_integration(integration)
     manager = AgentManager(db=db, docker=MagicMock(), redis=MagicMock())
 
@@ -38,3 +40,24 @@ async def test_no_github_integration_row_yields_empty_env():
     env = await manager._get_integration_env(["github"])
 
     assert env == {}
+
+
+@pytest.mark.asyncio
+async def test_ghes_integration_env_routes_via_base_url():
+    """#532 phase 2: an integration row with host_type/base_url set (GitHub
+    Enterprise Server) must inject GH_HOST so `gh` targets that instance."""
+    integration = MagicMock()
+    integration.access_token_encrypted = "encrypted-blob"
+    integration.host_type = "github"
+    integration.base_url = "https://ghe.example.com"
+    db = _db_with_integration(integration)
+    manager = AgentManager(db=db, docker=MagicMock(), redis=MagicMock())
+
+    with patch("app.core.agent_manager.decrypt_token", return_value="test_pat_decrypted"):
+        env = await manager._get_integration_env(["github"])
+
+    assert env == {
+        "GITHUB_TOKEN": "test_pat_decrypted",
+        "GH_TOKEN": "test_pat_decrypted",
+        "GH_HOST": "ghe.example.com",
+    }

--- a/orchestrator/tests/test_githost_provider.py
+++ b/orchestrator/tests/test_githost_provider.py
@@ -27,6 +27,45 @@ def test_get_agent_env_sets_both_token_vars():
     assert env == {"GITHUB_TOKEN": "test_pat_abc123", "GH_TOKEN": "test_pat_abc123"}
 
 
+# --- #532 phase 2: base_url (GitHub Enterprise Server) ---
+
+
+def test_registry_with_base_url_routes_to_ghes_api():
+    provider = get_git_host_provider("github", "https://ghe.example.com")
+    assert isinstance(provider, GitHubHostProvider)
+    assert provider.api_base == "https://ghe.example.com/api/v3"
+    assert provider.host == "ghe.example.com"
+
+
+def test_registry_without_base_url_still_uses_public_github():
+    provider = get_git_host_provider("github", None)
+    assert provider.api_base == "https://api.github.com"
+    assert provider.host is None
+
+
+def test_registry_base_url_trailing_slash_stripped():
+    provider = get_git_host_provider("github", "https://ghe.example.com/")
+    assert provider.api_base == "https://ghe.example.com/api/v3"
+
+
+def test_get_agent_env_sets_gh_host_for_ghes():
+    provider = GitHubHostProvider(api_base="https://ghe.example.com/api/v3", host="ghe.example.com")
+    env = provider.get_agent_env("tok")
+    assert env == {"GITHUB_TOKEN": "tok", "GH_TOKEN": "tok", "GH_HOST": "ghe.example.com"}
+
+
+@pytest.mark.asyncio
+async def test_ghes_provider_hits_enterprise_api_base():
+    client = _client(get_resp=_resp(200, {"items": [{"number": 5}]}))
+    provider = GitHubHostProvider(api_base="https://ghe.example.com/api/v3", host="ghe.example.com")
+
+    result = await provider.search_open_issue(client, "tok", "org/repo", "x")
+
+    assert result == 5
+    args, _ = client.get.call_args
+    assert args[0] == "https://ghe.example.com/api/v3/search/issues"
+
+
 def _client(get_resp=None, post_resp=None, patch_resp=None):
     client = AsyncMock()
     if get_resp is not None:

--- a/orchestrator/tests/test_oauth_service_pat_base_url.py
+++ b/orchestrator/tests/test_oauth_service_pat_base_url.py
@@ -41,9 +41,15 @@ def _mock_encrypt(token):
     return f"enc:{token}"
 
 
+# GHES base_url is a self-hosted, user-supplied host — store_pat runs it through
+# the SSRF guard (app.core.url_guard.check_outbound_url) before requesting it.
+# "ghe.example.com" doesn't resolve in the test sandbox, so the guard would
+# reject it as "internal" (fail-closed on unresolvable hosts); mock it allowed
+# here to test store_pat's own routing logic in isolation.
 @pytest.mark.asyncio
+@patch("app.services.oauth_service.check_outbound_url", return_value=(True, ""))
 @patch("app.services.oauth_service.encrypt_token", side_effect=_mock_encrypt)
-async def test_store_pat_with_base_url_hits_ghes_userinfo_endpoint(_enc):
+async def test_store_pat_with_base_url_hits_ghes_userinfo_endpoint(_enc, _guard):
     db = _db_with_integration(None)
     service = OAuthService(db=db, redis=MagicMock())
     resp = _userinfo_resp(login="enterprise-user")
@@ -80,8 +86,9 @@ async def test_store_pat_without_base_url_hits_public_github_userinfo(_enc):
 
 
 @pytest.mark.asyncio
+@patch("app.services.oauth_service.check_outbound_url", return_value=(True, ""))
 @patch("app.services.oauth_service.encrypt_token", side_effect=_mock_encrypt)
-async def test_store_pat_updates_existing_integration_with_base_url(_enc):
+async def test_store_pat_updates_existing_integration_with_base_url(_enc, _guard):
     existing = OAuthIntegration(
         provider="github",
         access_token_encrypted="old-blob",
@@ -105,7 +112,8 @@ async def test_store_pat_updates_existing_integration_with_base_url(_enc):
 
 
 @pytest.mark.asyncio
-async def test_store_pat_invalid_token_raises_value_error():
+@patch("app.services.oauth_service.check_outbound_url", return_value=(True, ""))
+async def test_store_pat_invalid_token_raises_value_error(_guard):
     db = _db_with_integration(None)
     service = OAuthService(db=db, redis=MagicMock())
     resp = _userinfo_resp(status_code=401)
@@ -114,3 +122,18 @@ async def test_store_pat_invalid_token_raises_value_error():
     with patch("app.services.oauth_service.httpx.AsyncClient", return_value=ctx):
         with pytest.raises(ValueError):
             await service.store_pat("github", "bad_tok", base_url="https://ghe.example.com")
+
+
+@pytest.mark.asyncio
+async def test_store_pat_rejects_base_url_pointing_at_internal_host():
+    """The SSRF guard runs BEFORE any outbound request — an internal/unresolvable
+    base_url must be rejected without ever calling httpx."""
+    db = _db_with_integration(None)
+    service = OAuthService(db=db, redis=MagicMock())
+
+    with patch("app.services.oauth_service.httpx.AsyncClient") as mock_client:
+        with pytest.raises(ValueError):
+            await service.store_pat(
+                "github", "ghp_tok", base_url="http://169.254.169.254"
+            )
+        mock_client.assert_not_called()

--- a/orchestrator/tests/test_oauth_service_pat_base_url.py
+++ b/orchestrator/tests/test_oauth_service_pat_base_url.py
@@ -1,0 +1,109 @@
+"""Regression test: OAuthService.store_pat routes GitHub Enterprise Server
+(base_url) PATs through the GHES userinfo endpoint and persists host_type/
+base_url on the resulting OAuthIntegration row (#532 phase 2).
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.oauth_integration import OAuthIntegration
+from app.services.oauth_service import OAuthService
+
+
+def _db_with_integration(integration=None):
+    db = AsyncMock()
+    exec_result = MagicMock()
+    exec_result.scalar_one_or_none.return_value = integration
+    db.execute = AsyncMock(return_value=exec_result)
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    db.add = MagicMock()
+    return db
+
+
+def _userinfo_resp(status_code=200, login="octocat"):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = {"login": login}
+    return resp
+
+
+def _client_ctx(resp):
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=resp)
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=client)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx, client
+
+
+@pytest.mark.asyncio
+async def test_store_pat_with_base_url_hits_ghes_userinfo_endpoint():
+    db = _db_with_integration(None)
+    service = OAuthService(db=db, redis=MagicMock())
+    resp = _userinfo_resp(login="enterprise-user")
+    ctx, client = _client_ctx(resp)
+
+    with patch("app.services.oauth_service.httpx.AsyncClient", return_value=ctx):
+        integration = await service.store_pat(
+            "github", "ghp_tok", base_url="https://ghe.example.com"
+        )
+
+    args, _ = client.get.call_args
+    assert args[0] == "https://ghe.example.com/api/v3/user"
+    assert integration.host_type == "github"
+    assert integration.base_url == "https://ghe.example.com"
+    assert integration.account_label == "enterprise-user"
+    db.add.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_store_pat_without_base_url_hits_public_github_userinfo():
+    db = _db_with_integration(None)
+    service = OAuthService(db=db, redis=MagicMock())
+    resp = _userinfo_resp(login="octocat")
+    ctx, client = _client_ctx(resp)
+
+    with patch("app.services.oauth_service.httpx.AsyncClient", return_value=ctx):
+        integration = await service.store_pat("github", "ghp_tok")
+
+    args, _ = client.get.call_args
+    assert args[0] == "https://api.github.com/user"
+    assert integration.host_type is None
+    assert integration.base_url is None
+
+
+@pytest.mark.asyncio
+async def test_store_pat_updates_existing_integration_with_base_url():
+    existing = OAuthIntegration(
+        provider="github",
+        access_token_encrypted="old-blob",
+        host_type=None,
+        base_url=None,
+    )
+    db = _db_with_integration(existing)
+    service = OAuthService(db=db, redis=MagicMock())
+    resp = _userinfo_resp(login="enterprise-user")
+    ctx, client = _client_ctx(resp)
+
+    with patch("app.services.oauth_service.httpx.AsyncClient", return_value=ctx):
+        integration = await service.store_pat(
+            "github", "ghp_new", base_url="https://ghe.example.com"
+        )
+
+    assert integration is existing
+    assert integration.host_type == "github"
+    assert integration.base_url == "https://ghe.example.com"
+    db.add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_store_pat_invalid_token_raises_value_error():
+    db = _db_with_integration(None)
+    service = OAuthService(db=db, redis=MagicMock())
+    resp = _userinfo_resp(status_code=401)
+    ctx, client = _client_ctx(resp)
+
+    with patch("app.services.oauth_service.httpx.AsyncClient", return_value=ctx):
+        with pytest.raises(ValueError):
+            await service.store_pat("github", "bad_tok", base_url="https://ghe.example.com")

--- a/orchestrator/tests/test_oauth_service_pat_base_url.py
+++ b/orchestrator/tests/test_oauth_service_pat_base_url.py
@@ -37,8 +37,13 @@ def _client_ctx(resp):
     return ctx, client
 
 
+def _mock_encrypt(token):
+    return f"enc:{token}"
+
+
 @pytest.mark.asyncio
-async def test_store_pat_with_base_url_hits_ghes_userinfo_endpoint():
+@patch("app.services.oauth_service.encrypt_token", side_effect=_mock_encrypt)
+async def test_store_pat_with_base_url_hits_ghes_userinfo_endpoint(_enc):
     db = _db_with_integration(None)
     service = OAuthService(db=db, redis=MagicMock())
     resp = _userinfo_resp(login="enterprise-user")
@@ -58,7 +63,8 @@ async def test_store_pat_with_base_url_hits_ghes_userinfo_endpoint():
 
 
 @pytest.mark.asyncio
-async def test_store_pat_without_base_url_hits_public_github_userinfo():
+@patch("app.services.oauth_service.encrypt_token", side_effect=_mock_encrypt)
+async def test_store_pat_without_base_url_hits_public_github_userinfo(_enc):
     db = _db_with_integration(None)
     service = OAuthService(db=db, redis=MagicMock())
     resp = _userinfo_resp(login="octocat")
@@ -74,7 +80,8 @@ async def test_store_pat_without_base_url_hits_public_github_userinfo():
 
 
 @pytest.mark.asyncio
-async def test_store_pat_updates_existing_integration_with_base_url():
+@patch("app.services.oauth_service.encrypt_token", side_effect=_mock_encrypt)
+async def test_store_pat_updates_existing_integration_with_base_url(_enc):
     existing = OAuthIntegration(
         provider="github",
         access_token_encrypted="old-blob",


### PR DESCRIPTION
## Summary
- Adds `host_type`/`base_url` columns to `oauth_integrations` so a Git-host integration can point at a self-hosted GitHub Enterprise Server instance instead of the public API — the host is now configured, not enum-coded (continues #532 phase 1, PR #563).
- `GitHubHostProvider` takes `api_base`/`host` constructor params; `get_agent_env` now injects `GH_HOST` for a configured GHES instance so the `gh` CLI targets the right host inside agent containers.
- `get_git_host_provider(host_type, base_url)` builds a fresh GHES-pointed provider (`<base_url>/api/v3`) when `base_url` is set, otherwise returns the cached public-GitHub singleton — unchanged default behavior.
- `AgentManager._get_integration_env` and `OAuthService.store_pat` route through `host_type`/`base_url` on the stored integration row (PAT validation now hits the GHES userinfo endpoint when applicable).
- `POST /integrations/{provider}/pat` accepts an optional `base_url`; Integrations UI gets a "Self-hosted (GitHub Enterprise Server)" checkbox + base URL field (GitHub only).
- `self_test_service.py` intentionally untouched — it always targets the fixed public AI-Employee repo, not a per-user host.
- Phase 3 (Forgejo/Gitea provider) remains out of scope; unknown host_types still fall back to `GitHubHostProvider` as before.

## Test plan
- [x] `pytest tests/test_githost_provider.py tests/test_agent_manager_githost_env.py tests/test_oauth_service_pat_base_url.py` — 24 passed (new GHES-routing tests + a new `store_pat` base_url test file)
- [x] `alembic heads` — confirms a single clean head after the new migration (had to resolve a revision-ID collision with an existing migration, `a2b3c4d5e6f7`, by renaming to `b532p2h1o2s3`)
- [x] `python -m py_compile` on all touched Python files
- [ ] Frontend `tsc` type-check (skipped — throwaway clone's `node_modules` lacked a usable `tsc` binary; change mirrors existing PAT-input JSX patterns in the same file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)