### PR TITLE
fix: CI has been red on main since c063a9a — present_file test never patched workspace_dir

### DIFF
--- a/agent/tests/test_present_file_marker.py
+++ b/agent/tests/test_present_file_marker.py
@@ -5,6 +5,7 @@ import json
 
 import pytest
 
+from app import agent_runner as agent_runner_module
 from app.agent_runner import AgentRunner
 
 
@@ -87,7 +88,8 @@ class _FakeLogPublisher:
 
 
 @pytest.mark.anyio
-async def test_present_file_delivered_via_telegram(tmp_path):
+async def test_present_file_delivered_via_telegram(tmp_path, monkeypatch):
+    monkeypatch.setattr(agent_runner_module.settings, "workspace_dir", str(tmp_path))
     f = tmp_path / "podcast.mp3"
     f.write_bytes(b"ID3 fake audio bytes")
     redis = _FakeRedis()
@@ -113,8 +115,9 @@ async def test_present_file_delivered_via_telegram(tmp_path):
 
 
 @pytest.mark.anyio
-async def test_telegram_fallback_on_present_file_failure(tmp_path):
+async def test_telegram_fallback_on_present_file_failure(tmp_path, monkeypatch):
     """A missing or oversized file must not raise and must not publish."""
+    monkeypatch.setattr(agent_runner_module.settings, "workspace_dir", str(tmp_path))
     redis = _FakeRedis()
     runner = AgentRunner(log_publisher=_FakeLogPublisher(redis, "agent-1"))
 
@@ -126,4 +129,21 @@ async def test_telegram_fallback_on_present_file_failure(tmp_path):
     big = tmp_path / "big.bin"
     big.write_bytes(b"\0" * (20 * 1024 * 1024 + 1))
     await runner._deliver_present_file_via_telegram({"path": str(big)})
+    assert redis.published == []
+
+
+@pytest.mark.anyio
+async def test_present_file_outside_workspace_refused(tmp_path, monkeypatch):
+    """A path outside the agent's own workspace must be refused, never delivered."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setattr(agent_runner_module.settings, "workspace_dir", str(workspace))
+    outside = tmp_path / "outside" / "secret.mp3"
+    outside.parent.mkdir()
+    outside.write_bytes(b"not yours")
+
+    redis = _FakeRedis()
+    runner = AgentRunner(log_publisher=_FakeLogPublisher(redis, "agent-1"))
+    await runner._deliver_present_file_via_telegram({"path": str(outside)})
+
     assert redis.published == []


### PR DESCRIPTION
## Problem
`Agent pytest` has failed on **every** run on `main` since c063a9a (2026-07-02, the present_file workspace-jail security fix): `test_present_file_delivered_via_telegram` uses pytest's `tmp_path` (under `/tmp`), but `_deliver_present_file_via_telegram` refuses any path outside `settings.workspace_dir` (`/workspace`) — a legitimate security check, just never accounted for in the test. This has been silently red for over a month and is currently blocking clean-CI self-merge on PR #580.

## Fix
Test-only change, no production code touched:
- Monkeypatch `settings.workspace_dir` to `tmp_path` in both existing tests so they exercise the real jail check against a path that is actually "inside the workspace".
- Add `test_present_file_outside_workspace_refused` as an explicit regression test for the security behavior itself (a path outside the configured workspace must be refused).

## Verification
- `pytest agent/tests/test_present_file_marker.py` — 11 passed (was 2 failed / 9 passed)
- Full `pytest agent/tests/` — 257 passed, 80 subtests passed, 0 failures

Fixes the shared CI failure — no issue filed since this was only discovered live during a proactive run.