### PR TITLE
fix(agent): repair present_file test broken by workspace jail

### DIFF
--- a/agent/tests/test_present_file_marker.py
+++ b/agent/tests/test_present_file_marker.py
@@ -6,6 +6,7 @@ import json
 import pytest
 
 from app.agent_runner import AgentRunner
+from app.config import settings
 
 
 def test_parse_present_file_marker_from_string():
@@ -87,7 +88,8 @@ class _FakeLogPublisher:
 
 
 @pytest.mark.anyio
-async def test_present_file_delivered_via_telegram(tmp_path):
+async def test_present_file_delivered_via_telegram(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "workspace_dir", str(tmp_path))
     f = tmp_path / "podcast.mp3"
     f.write_bytes(b"ID3 fake audio bytes")
     redis = _FakeRedis()


### PR DESCRIPTION
## Summary
- `main`'s CI has been red since commit c063a9a (present_file Workspace-Jail security fix, 2026-07-02): `test_present_file_delivered_via_telegram` writes its fixture file under pytest's `tmp_path` (`/tmp/...`), which the new realpath-jail correctly refuses because it's outside `settings.workspace_dir`.
- This blocks the pending self-merge of PR #580 (Issue #548 fix), which shows the same CI failure even though its diff never touches this code path.
- Fix: monkeypatch `settings.workspace_dir` to `tmp_path` in the test, matching the existing pattern in `test_mcp_auth_headers.py`. No production code changed — the jail itself is untouched.

## Test plan
- [x] `pytest tests/test_present_file_marker.py` — 9 passed (was 2 failed before)
- [x] Full `pytest` suite in `agent/` — 255 passed, 80 subtests passed, no regressions