### PR TITLE
feat(bridge): microphone capture for Voice-on-Desktop, part of #478

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         working-directory: orchestrator
         run: |
           pip install --no-cache-dir -e .
-          pip install --no-cache-dir pytest pytest-asyncio aiosqlite ruff
+          pip install --no-cache-dir pytest pytest-asyncio aiosqlite ruff numpy
       # Undefinierte Namen sind zur Laufzeit ein NameError, aber beim Import
       # unsichtbar. Genau so lief das Anlegen eines Agenten fuenf Tage lang in
       # einen 500 ("cannot access local variable 'config'"), waehrend die Tests

--- a/computer-use-bridge/bridge.py
+++ b/computer-use-bridge/bridge.py
@@ -277,6 +277,80 @@ class InputRecorder:
         return {"ok": True}
 
 
+class VoiceCapture:
+    """Capture microphone audio from the human at the keyboard, chunked and
+    streamed upstream — the desktop counterpart to the browser's getUserMedia()
+    capture (issue #478 phase 1). Server-side wiring (feeding chunks into a
+    RealtimeVoiceSession) is a later phase; here the bridge only records and
+    forwards, same lifecycle discipline as InputRecorder: only between an
+    explicit start/stop, never buffered to disk, logs loudly at both ends.
+    """
+
+    SAMPLE_RATE = 16000  # matches what the STT providers already expect
+    CHANNELS = 1
+    CHUNK_MS = 100  # small enough for low latency, large enough not to flood the WS
+
+    def __init__(self, emit) -> None:
+        self._emit = emit          # called with one {chunk_b64, ...} dict per chunk
+        self._stream = None
+        self.active = False
+
+    def _on_audio(self, indata, frames, time_info, status) -> None:
+        if status:
+            log.debug("Voice capture status: %s", status)
+        import numpy as np
+
+        pcm16 = (indata[:, 0] * 32767.0).astype(np.int16).tobytes()
+        self._emit({
+            "chunk_b64": base64.b64encode(pcm16).decode("ascii"),
+            "sample_rate": self.SAMPLE_RATE,
+            "channels": self.CHANNELS,
+            "ts": time.time(),
+        })
+
+    def start(self) -> dict:
+        if self.active:
+            return {"ok": True, "already_active": True}
+        try:
+            import sounddevice as sd
+        except ImportError:
+            return {
+                "ok": False,
+                "error": "sounddevice is not installed — voice capture unavailable. "
+                         "Install it with: pip install sounddevice",
+            }
+        try:
+            stream = sd.InputStream(
+                samplerate=self.SAMPLE_RATE,
+                channels=self.CHANNELS,
+                blocksize=int(self.SAMPLE_RATE * self.CHUNK_MS / 1000),
+                callback=self._on_audio,
+            )
+            stream.start()
+        except Exception as e:  # noqa: BLE001 — no mic, permission denied, device busy, ...
+            return {"ok": False, "error": f"Mikrofon liess sich nicht oeffnen: {e}"}
+        self._stream = stream
+        log.warning(
+            "VOICE CAPTURE STARTED — microphone audio is being streamed until you stop it."
+        )
+        self.active = True
+        return {"ok": True}
+
+    def stop(self) -> dict:
+        if not self.active:
+            return {"ok": True, "already_stopped": True}
+        if self._stream is not None:
+            try:
+                self._stream.stop()
+                self._stream.close()
+            except Exception:  # noqa: BLE001
+                pass
+            self._stream = None
+        self.active = False
+        log.warning("VOICE CAPTURE STOPPED — no longer streaming microphone audio.")
+        return {"ok": True}
+
+
 def _applescript_string_literal(value: str) -> str:
     """Escape a value for safe interpolation into a double-quoted AppleScript
     string literal. Without this, an app name containing '"' can break out of
@@ -578,6 +652,8 @@ class CommandDispatcher:
         self._ctrl = InputController()
         # Set by the WS client so human-capture events can be pushed upstream.
         self.input_recorder: InputRecorder | None = None
+        # Set by the WS client so microphone chunks can be pushed upstream.
+        self.voice_capture: VoiceCapture | None = None
 
     def dispatch(self, command: dict) -> dict:
         action = command.get("action", "")
@@ -593,6 +669,16 @@ class CommandDispatcher:
                 if not self.input_recorder:
                     return {"ok": False, "error": "input capture not wired up"}
                 return self.input_recorder.stop()
+
+            elif action == "start_voice_capture":
+                if not self.voice_capture:
+                    return {"ok": False, "error": "voice capture not wired up"}
+                return self.voice_capture.start()
+
+            elif action == "stop_voice_capture":
+                if not self.voice_capture:
+                    return {"ok": False, "error": "voice capture not wired up"}
+                return self.voice_capture.stop()
 
             elif action == "screenshot":
                 # Fehlende Freigabe ist KEIN Screenshot — lieber ein klarer Fehler als
@@ -797,12 +883,16 @@ class Bridge:
         # land in a thread-safe queue and are drained by an asyncio task that
         # owns the WebSocket (never send from the listener thread directly).
         self._input_events: queue.Queue = queue.Queue(maxsize=1000)
+        # Same pattern for microphone chunks — sounddevice calls back on its
+        # own audio thread, never from the asyncio loop.
+        self._voice_events: queue.Queue = queue.Queue(maxsize=1000)
 
     def _ensure_dispatcher(self) -> CommandDispatcher:
         if self.dispatcher is None:
             log.info("Initializing desktop control")
             self.dispatcher = CommandDispatcher()
             self.dispatcher.input_recorder = InputRecorder(self._queue_input_event)
+            self.dispatcher.voice_capture = VoiceCapture(self._queue_voice_event)
             log.info("Desktop control ready")
         return self.dispatcher
 
@@ -812,6 +902,13 @@ class Bridge:
             self._input_events.put_nowait(event)
         except queue.Full:
             log.warning("Input-capture queue full — dropping event")
+
+    def _queue_voice_event(self, event: dict) -> None:
+        """Called from the sounddevice audio thread — must not block or send."""
+        try:
+            self._voice_events.put_nowait(event)
+        except queue.Full:
+            log.warning("Voice-capture queue full — dropping chunk")
 
     async def _drain_input_events(self, ws) -> None:
         """Forward queued human-capture events to the orchestrator."""
@@ -826,6 +923,22 @@ class Bridge:
                 return
             try:
                 await ws.send(json.dumps({"type": "input_event", "event": event}))
+            except Exception:  # noqa: BLE001 — connection gone; reconnect loop handles it
+                return
+
+    async def _drain_voice_events(self, ws) -> None:
+        """Forward queued microphone chunks to the orchestrator."""
+        while self._running:
+            try:
+                event = await asyncio.get_event_loop().run_in_executor(
+                    None, self._voice_events.get, True, 0.5
+                )
+            except queue.Empty:
+                continue
+            except Exception:  # noqa: BLE001 — loop shutting down
+                return
+            try:
+                await ws.send(json.dumps({"type": "voice_chunk", "event": event}))
             except Exception:  # noqa: BLE001 — connection gone; reconnect loop handles it
                 return
 
@@ -875,7 +988,8 @@ class Bridge:
                     # falsche Zusage verlaesst, verspricht dem Nutzer etwas.
                     "capabilities": ["screenshot", "click", "type", "key", "scroll", "move", "drag",
                                      "open_app", "open_url", "close_app", "get_clipboard",
-                                     "set_clipboard", "start_input_capture", "stop_input_capture"]
+                                     "set_clipboard", "start_input_capture", "stop_input_capture",
+                                     "start_voice_capture", "stop_voice_capture"]
                                     + (["ax_tree", "find_element", "wait_for_element"]
                                        if ax_tree_available() else []),
                     "ax_tree_available": ax_tree_available(),
@@ -893,14 +1007,19 @@ class Bridge:
                     }))
 
                 drain_task = asyncio.create_task(self._drain_input_events(ws))
+                voice_drain_task = asyncio.create_task(self._drain_voice_events(ws))
                 try:
                     async for raw in ws:
                         await self._handle_message(ws, raw)
                 finally:
                     drain_task.cancel()
+                    voice_drain_task.cancel()
                     if self.dispatcher and self.dispatcher.input_recorder:
                         # Never leave a keylogger running past the connection.
                         self.dispatcher.input_recorder.stop()
+                    if self.dispatcher and self.dispatcher.voice_capture:
+                        # Never leave the microphone open past the connection.
+                        self.dispatcher.voice_capture.stop()
 
             except websockets.ConnectionClosed as e:
                 # 1008 = the server REJECTED us (session expired/unknown, wrong

--- a/computer-use-bridge/requirements.txt
+++ b/computer-use-bridge/requirements.txt
@@ -5,6 +5,10 @@ Pillow>=10.0.0
 # Replay-Modus: observe the human's own clicks/keystrokes to demonstrate a
 # workflow once. Only listens between an explicit start/stop (see InputRecorder).
 pynput>=1.7.6
+# Voice-on-Desktop Phase 1 (#478): capture the human's microphone, chunked and
+# streamed upstream. Only listens between an explicit start/stop (see VoiceCapture).
+sounddevice>=0.4.6
+numpy>=1.26.0
 # System tray app
 rumps>=0.4.0; sys_platform == "darwin"
 pystray>=0.19.0; sys_platform != "darwin"

--- a/orchestrator/tests/test_bridge_voice_capture.py
+++ b/orchestrator/tests/test_bridge_voice_capture.py
@@ -1,0 +1,145 @@
+"""Voice-on-Desktop Phase 1 (#478): bridge-side microphone capture.
+
+The bridge already has an InputRecorder for replay-mode ("observe what the human
+just did"). VoiceCapture is the same lifecycle discipline applied to the
+microphone: only listens between an explicit start/stop, never buffers to disk,
+chunks go straight out. This is phase 1 only — there is deliberately no server
+side yet (RealtimeVoiceSession wiring is a later phase, see issue #478), so
+these tests stay entirely inside the bridge process.
+
+The bridge has no CI suite of its own, so this runs in the orchestrator pytest
+job, same pattern as test_bridge_extra_headers.py: a dynamic import of bridge.py
+with the optional native dependencies stubbed, plus source-level guards for the
+wiring that can't be exercised without real audio hardware.
+"""
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+_BRIDGE_SRC_PATH = Path(__file__).resolve().parents[2] / "computer-use-bridge" / "bridge.py"
+
+
+def _load_bridge_module():
+    """Import bridge.py, stubbing optional native deps (websockets, pyautogui)."""
+    for name in ("websockets", "pyautogui"):
+        if name not in sys.modules:
+            try:
+                __import__(name)
+            except ImportError:
+                sys.modules[name] = types.ModuleType(name)
+    spec = importlib.util.spec_from_file_location("bridge_under_test_voice", _BRIDGE_SRC_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class VoiceCaptureSourceGuard(unittest.TestCase):
+    """Wiring that isn't exercisable without a real microphone / websocket."""
+
+    def setUp(self):
+        self.src = _BRIDGE_SRC_PATH.read_text()
+
+    def test_capabilities_announce_voice_capture(self):
+        self.assertIn('"start_voice_capture", "stop_voice_capture"', self.src)
+
+    def test_dispatcher_wires_voice_capture_actions(self):
+        self.assertIn('action == "start_voice_capture"', self.src)
+        self.assertIn('action == "stop_voice_capture"', self.src)
+
+    def test_voice_capture_is_stopped_on_disconnect(self):
+        # Same discipline as input_recorder: never leave the mic open past the
+        # connection that started it.
+        self.assertIn("self.dispatcher.voice_capture.stop()", self.src)
+
+    def test_voice_chunks_use_own_queue_not_input_queue(self):
+        # Audio and click/keystroke events must not share a queue — different
+        # producers, different consumers, different message types on the wire.
+        self.assertIn("self._voice_events: queue.Queue", self.src)
+        self.assertIn('"type": "voice_chunk"', self.src)
+
+    def test_import_is_lazy_like_pynput(self):
+        # sounddevice must not be imported at module load time — the bridge
+        # has to start fine on a machine without it, same as pynput.
+        self.assertIn("import sounddevice as sd", self.src)
+        self.assertNotIn("import sounddevice\n", self.src.split("class VoiceCapture")[0])
+
+
+class VoiceCaptureBehaviourTests(unittest.TestCase):
+    def setUp(self):
+        self.m = _load_bridge_module()
+
+    def test_missing_sounddevice_reports_actionable_error(self):
+        # This container has no sounddevice installed — exercises the real
+        # ImportError branch, not a mock.
+        vc = self.m.VoiceCapture(emit=lambda e: None)
+        result = vc.start()
+        self.assertFalse(result["ok"])
+        self.assertIn("sounddevice", result["error"])
+        self.assertIn("pip install sounddevice", result["error"])
+        self.assertFalse(vc.active)
+
+    def test_stop_before_start_is_a_no_op(self):
+        vc = self.m.VoiceCapture(emit=lambda e: None)
+        result = vc.stop()
+        self.assertTrue(result["ok"])
+        self.assertTrue(result["already_stopped"])
+
+    def test_on_audio_encodes_pcm16_and_emits(self):
+        import base64
+        import numpy as np
+
+        events = []
+        vc = self.m.VoiceCapture(emit=events.append)
+        indata = np.array([[0.5], [-0.5], [0.0]], dtype=np.float32)
+        vc._on_audio(indata, 3, None, None)
+
+        self.assertEqual(len(events), 1)
+        event = events[0]
+        self.assertEqual(event["sample_rate"], self.m.VoiceCapture.SAMPLE_RATE)
+        self.assertEqual(event["channels"], 1)
+        self.assertIn("ts", event)
+
+        decoded = np.frombuffer(base64.b64decode(event["chunk_b64"]), dtype=np.int16)
+        expected = (indata[:, 0] * 32767.0).astype(np.int16)
+        np.testing.assert_array_equal(decoded, expected)
+
+    def test_dispatcher_routes_start_stop_to_voice_capture(self):
+        dispatcher = self.m.CommandDispatcher.__new__(self.m.CommandDispatcher)
+        dispatcher._ctrl = None
+        dispatcher.input_recorder = None
+        dispatcher.voice_capture = None
+
+        result = dispatcher.dispatch({"action": "start_voice_capture"})
+        self.assertEqual(result, {"ok": False, "error": "voice capture not wired up"})
+
+        result = dispatcher.dispatch({"action": "stop_voice_capture"})
+        self.assertEqual(result, {"ok": False, "error": "voice capture not wired up"})
+
+        calls = []
+
+        class _FakeVoiceCapture:
+            def start(self):
+                calls.append("start")
+                return {"ok": True}
+
+            def stop(self):
+                calls.append("stop")
+                return {"ok": True}
+
+        dispatcher.voice_capture = _FakeVoiceCapture()
+        self.assertEqual(dispatcher.dispatch({"action": "start_voice_capture"}), {"ok": True})
+        self.assertEqual(dispatcher.dispatch({"action": "stop_voice_capture"}), {"ok": True})
+        self.assertEqual(calls, ["start", "stop"])
+
+    def test_bridge_wires_voice_capture_into_new_dispatcher(self):
+        bridge = self.m.Bridge("wss://x", "TOK", "sess")
+        dispatcher = bridge._ensure_dispatcher()
+        self.assertIsInstance(dispatcher.voice_capture, self.m.VoiceCapture)
+        self.assertEqual(dispatcher.voice_capture._emit, bridge._queue_voice_event)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `VoiceCapture` to the bridge, mirroring `InputRecorder`'s lifecycle discipline: explicit start/stop only, no disk buffering, chunks streamed straight out.
- Wires `start_voice_capture` / `stop_voice_capture` into `CommandDispatcher.dispatch()`, announces both in the hello-message capabilities list, and stops capture on disconnect (same cleanup pattern as `input_recorder.stop()`).
- Audio chunks go out on their own `_voice_events` queue (`"type": "voice_chunk"`) — never share the click/keystroke input queue, since these are different producers/consumers/wire messages.
- `sounddevice` is imported lazily (same pattern as `pynput`) so the bridge still starts fine on a machine without it; missing-dependency errors are actionable (`pip install sounddevice`).
- 16kHz mono, 100ms chunks, float32→PCM16, base64-encoded for JSON transport.

This is **Phase 1 only** of #478 (bridge-side capture). Confirmed no server-side change is required for this phase — the orchestrator's bridge WS endpoint silently ignores unknown message types, so `"voice_chunk"` is safe to add ahead of the Phase 2 `RealtimeVoiceSession` server wiring. Issue #478 stays open for Phases 2 (server transport) and 3 (tray UI).

## Test plan
- [x] `python3 -m py_compile computer-use-bridge/bridge.py` — clean
- [x] New `orchestrator/tests/test_bridge_voice_capture.py` (10 tests: source guards + dynamic-import behaviour tests, including the real `ImportError` path since this container has no `sounddevice` installed) — 10/10 pass
- [x] Combined with existing bridge test files (`test_bridge_extra_headers.py`, `test_bridge_screenshot_inprocess.py`, `test_bridge_open_url_hardening.py`) — 36/36 pass, no regressions