### PR TITLE
fix: Web Push 403 als 'gone' behandeln, nicht nur 404/410

### DIFF
--- a/orchestrator/app/core/webpush.py
+++ b/orchestrator/app/core/webpush.py
@@ -159,9 +159,10 @@ async def send(
 ) -> int:
     """Eine Meldung zustellen. Gibt den HTTP-Status zurueck.
 
-    404/410 heisst: diese Anmeldung ist erloschen (Browser deinstalliert, Rechte
-    entzogen). Der Aufrufer soll sie dann loeschen, sonst waechst die Tabelle mit
-    Karteileichen, die bei jeder Meldung erneut angefragt werden.
+    403/404/410 (siehe is_gone) heisst: diese Anmeldung ist erloschen (Browser
+    deinstalliert, Rechte entzogen). Der Aufrufer soll sie dann loeschen, sonst
+    waechst die Tabelle mit Karteileichen, die bei jeder Meldung erneut angefragt
+    werden.
     """
     body = encrypt_payload(payload, p256dh, auth)
     headers = {
@@ -177,5 +178,11 @@ async def send(
 
 
 def is_gone(status: int) -> bool:
-    """Anmeldung endgueltig weg — aufraeumen statt weiter anzufragen."""
-    return status in (404, 410)
+    """Anmeldung endgueltig weg — aufraeumen statt weiter anzufragen.
+
+    404/410 sind die im RFC 8030 vorgesehenen Codes dafuer. Apples Push-Dienst
+    liefert fuer abgelaufene/widerrufene Anmeldungen in der Praxis oft 403 statt
+    410 — ohne das haengt so eine Anmeldung fuer immer in der Tabelle und wird bei
+    jeder Meldung erneut (erfolglos) angefragt.
+    """
+    return status in (403, 404, 410)

--- a/orchestrator/tests/test_webpush.py
+++ b/orchestrator/tests/test_webpush.py
@@ -147,7 +147,10 @@ class VapidTests(unittest.TestCase):
 
 
 class GoneTests(unittest.TestCase):
-    def test_only_404_and_410_mean_gone(self):
+    def test_403_404_410_mean_gone(self):
+        """Apples Push-Dienst meldet abgelaufene Anmeldungen oft als 403, nicht 410 —
+        ohne das bleibt die tote Anmeldung fuer immer in der Tabelle."""
+        self.assertTrue(webpush.is_gone(403))
         self.assertTrue(webpush.is_gone(404))
         self.assertTrue(webpush.is_gone(410))
         for status in (201, 429, 500, 503):


### PR DESCRIPTION
Fixes #586

## Problem
`is_gone()` in `orchestrator/app/core/webpush.py` behandelte nur HTTP 404/410 als "Anmeldung erloschen". Apples Web-Push-Dienst liefert für abgelaufene/widerrufene Anmeldungen in der Praxis aber oft 403. Ergebnis laut `/shared/platform-errors.log`: dieselbe tote Subscription wurde seit mindestens 2026-08-11 alle 15-90 Min erneut angefragt (>150x), nie aufgeräumt — reiner Log-Spam UND ein stiller Funktionsausfall (falls dies die einzige Subscription eines Nutzers ist, bekommt er seitdem keine Push-Benachrichtigungen mehr, ohne dass das irgendwo sichtbar wird).

## Fix
- `is_gone()` erweitert um 403 (403/404/410 = "gone", 429/5xx bleiben "später erneut versuchen").
- Bestehender Test `test_only_404_and_410_mean_gone` umbenannt zu `test_403_404_410_mean_gone` und um die 403-Assertion ergänzt.

## Test plan
- [x] `pytest tests/test_webpush.py -v` — 21 passed (inkl. angepasstem GoneTests)
- [x] Kein Aufrufer-Code geändert — `_push_web()` nutzt `is_gone()` bereits korrekt, profitiert automatisch vom erweiterten Filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)