### PR TITLE
feat(sentinel): SentinelService skeleton, event-driven, no rules yet (part of #590)

### DIFF
--- a/orchestrator/app/config.py
+++ b/orchestrator/app/config.py
@@ -151,6 +151,13 @@ class Settings(BaseSettings):
     # Security
     encryption_key: str = ""
     api_secret_key: str = "change-me-in-production"  # Used for agent HMAC tokens + JWT signing
+    # When True, SentinelService (orchestrator/app/services/sentinel_service.py,
+    # Sentinel epic #588 sub-issue #590) subscribes to agents:logs:all and reacts
+    # to events. Default off: as of #590 this is a skeleton only — _scan always
+    # returns None (no detection rules yet, see #592) and _stop_agent/_notify are
+    # unwired stubs (see #591), so enabling it today has no observable effect
+    # beyond an idle Redis subscription.
+    sentinel_enabled: bool = False
     registration_open: bool = True  # Allow new user registration
     # When True, new self-registered users (SSO or password) land in "pending approval"
     # (approved=False) and must be unlocked by an admin before they can use the app

--- a/orchestrator/app/main.py
+++ b/orchestrator/app/main.py
@@ -1973,6 +1973,17 @@ clean Markdown; you don't need to commit.
     scheduler = SchedulerService(app.state.redis, docker_service=app.state.docker)
     scheduler_task = asyncio.create_task(scheduler.run())
 
+    # Start Sentinel service (Sentinel epic #588, skeleton per #590). Off by
+    # default via settings.sentinel_enabled — see sentinel_service.py docstring:
+    # _scan never triggers yet, so this has no observable effect even when on.
+    sentinel_task = None
+    if settings.sentinel_enabled:
+        from app.services.sentinel_service import SentinelService
+
+        sentinel = SentinelService(app.state.redis)
+        app.state.sentinel = sentinel
+        sentinel_task = asyncio.create_task(sentinel.run())
+
     # Start skill catalog crawler (weekly GitHub crawl)
     from app.services.skill_crawler import SkillCrawlerService
 
@@ -2050,6 +2061,9 @@ clean Markdown; you don't need to commit.
     mcp_oauth_refresh_task.cancel()
     claude_token_task.cancel()
     scheduler_task.cancel()
+    if sentinel_task:
+        sentinel.stop()
+        sentinel_task.cancel()
     skill_crawler_task.cancel()
     improvement_task.cancel()
     self_test_task.cancel()

--- a/orchestrator/app/services/sentinel_service.py
+++ b/orchestrator/app/services/sentinel_service.py
@@ -1,0 +1,181 @@
+"""Sentinel core service skeleton (issue #590, part of Sentinel epic #588).
+
+Event-driven counterpart to watchdog.py's poll-driven checks: instead of
+scanning the DB on a timer like SchedulerService.run() does, SentinelService
+subscribes to the orchestrator's own `agents:logs:all` Redis channel — the
+same channel StreamManager.stream_all_logs() already streams to the admin UI,
+populated by AgentManager._publish_event() (orchestrator/app/core/agent_manager.py)
+as it executes/passes through each agent lifecycle event.
+
+That channel choice is load-bearing, not incidental: per #588's manipulation-proof
+analysis, a telemetry source the Sentinel acts on must never be something an
+agent's own process can write, only something the orchestrator generates at the
+point it actually performs an action. `agents:logs:all` already satisfies that
+today; nothing here reads any per-agent-writable stream.
+
+This is the Grundgerüst only (Teil 2/4, #590 scope point 1). The three hook
+points below exist so the wiring is in place end to end, but carry no
+production logic yet:
+  - `_scan`       always returns None (no detection rules — that's #592,
+                   the DLP #525/#564/#575 scan logic).
+  - `_stop_agent` logs only (the privileged credential schema + the real
+                   AgentManager.stop_agent() call land in #591).
+  - `_notify`     logs only (wiring to notify_user/send_telegram and the
+                   audit-log table land alongside #591/#592).
+Because `sentinel_enabled` defaults to False and `_scan` never triggers even
+when on, none of this has any observable effect until those follow-ups land.
+"""
+
+import asyncio
+import json
+import logging
+
+from app.services.redis_service import RedisService
+
+logger = logging.getLogger(__name__)
+
+_AGENTS_LOGS_ALL_CHANNEL = "agents:logs:all"
+# Pubsub reconnect backoff after an unexpected error (Redis restart, network
+# blip). Short enough that a real incident isn't missed for long, long enough
+# not to hot-loop against a Redis that is still down.
+_RECONNECT_DELAY_SECONDS = 2
+
+
+class SentinelVerdict:
+    """Result of scanning one agent event.
+
+    `triggered=False` is the only outcome this skeleton ever produces — real
+    rules (secret/PII leakage, destructive commands, policy violations, ...)
+    are #592's job. The shape exists now so #592 can fill in `_scan` without
+    touching the dispatch path in `_handle_event`.
+    """
+
+    def __init__(self, triggered: bool, reason: str | None = None, excerpt: str | None = None):
+        self.triggered = triggered
+        self.reason = reason
+        self.excerpt = excerpt
+
+
+class SentinelService:
+    """Central, privileged supervisor over all agents (Sentinel epic #588).
+
+    Runs exactly once, inside the orchestrator process — never inside an
+    agent container, unlike a per-agent self-check, which an agent under an
+    injection attack could simply skip. See SchedulerService for the sibling
+    "one background service per orchestrator process" pattern; the difference
+    here is event-driven consumption instead of a 30s poll loop, because a
+    harmful action needs to be caught as it happens, not up to 30s later.
+    """
+
+    def __init__(self, redis: RedisService):
+        self.redis = redis
+        self._running = False
+
+    async def run(self) -> None:
+        """Main loop: (re)subscribe to agents:logs:all and react to each event.
+
+        Never lets a pubsub error kill the loop — same resilience contract as
+        StreamManager.stream_all_logs(): log, back off, reconnect. A Sentinel
+        that silently stops watching is worse than one that logs a warning and
+        keeps trying; watchdog.py is expected to grow a liveness check on this
+        service itself (#590 scope point 6) so a stuck Sentinel is its own alert
+        rather than a silent gap.
+        """
+        logger.info("[Sentinel] Service started")
+        self._running = True
+        while self._running:
+            try:
+                await self._consume()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.warning(
+                    "[Sentinel] pubsub consume error, reconnecting in %ss: %s",
+                    _RECONNECT_DELAY_SECONDS, e,
+                )
+                await asyncio.sleep(_RECONNECT_DELAY_SECONDS)
+
+    def stop(self) -> None:
+        """Signal run() to exit after the current message (graceful shutdown)."""
+        self._running = False
+
+    async def _consume(self) -> None:
+        """Hold one pubsub subscription open and hand each message to _handle_message."""
+        if not self.redis.client:
+            await asyncio.sleep(_RECONNECT_DELAY_SECONDS)
+            return
+        pubsub = await self.redis.subscribe(_AGENTS_LOGS_ALL_CHANNEL)
+        try:
+            while self._running:
+                message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0)
+                if message and message["type"] == "message":
+                    await self._handle_message(message["data"])
+                else:
+                    await asyncio.sleep(0.01)
+        finally:
+            await pubsub.unsubscribe(_AGENTS_LOGS_ALL_CHANNEL)
+            await pubsub.aclose()
+
+    async def _handle_message(self, raw: bytes | str) -> None:
+        """Decode one raw pubsub payload and route it, tolerating malformed events."""
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        try:
+            event = json.loads(raw)
+        except (ValueError, TypeError) as e:
+            logger.warning("[Sentinel] Could not decode event, skipping: %s", e)
+            return
+        if not isinstance(event, dict):
+            return
+        await self._handle_event(event)
+
+    async def _handle_event(self, event: dict) -> None:
+        """Scan one decoded event; on a trigger, stop the agent and notify in parallel.
+
+        `asyncio.gather` (not sequential awaits) per #590 scope point 4: a
+        blocking stop_agent() call must never delay the human-facing alert.
+        """
+        agent_id = event.get("agent_id")
+        if not agent_id:
+            return
+        verdict = await self._scan(agent_id, event)
+        if verdict is None or not verdict.triggered:
+            return
+        reason = verdict.reason or "sentinel_triggered"
+        await asyncio.gather(
+            self._stop_agent(agent_id, reason),
+            self._notify(agent_id, reason, verdict.excerpt),
+            return_exceptions=True,
+        )
+
+    async def _scan(self, agent_id: str, event: dict) -> SentinelVerdict | None:
+        """Hook point for detection logic. Skeleton: no rules yet, never triggers.
+
+        Real implementation lands in #592 (DLP-style secret/PII/policy checks,
+        building on #525/#564/#575) — this signature is the contract #592 fills in.
+        """
+        return None
+
+    async def _stop_agent(self, agent_id: str, reason: str) -> None:
+        """Hook point for the privileged stop path.
+
+        Not wired to AgentManager.stop_agent() yet: that call needs the new
+        Sentinel-exclusive credential schema from #591 (a third scheme, neither
+        the human JWT nor the agent HMAC token — see #590's "Bereits vorhandene
+        Bausteine"). Logs only until then.
+        """
+        logger.warning(
+            "[Sentinel] stop_agent hook called for %s (reason=%s) — not yet wired, see #591",
+            agent_id, reason,
+        )
+
+    async def _notify(self, agent_id: str, reason: str, excerpt: str | None) -> None:
+        """Hook point for human escalation.
+
+        Not wired to notify_user/send_telegram or the audit-log table yet
+        (#591/#592). Logs only until then.
+        """
+        logger.warning(
+            "[Sentinel] notify hook called for %s (reason=%s, excerpt=%r)",
+            agent_id, reason, excerpt,
+        )

--- a/orchestrator/tests/test_sentinel_service_skeleton.py
+++ b/orchestrator/tests/test_sentinel_service_skeleton.py
@@ -1,0 +1,93 @@
+"""Tests for the SentinelService skeleton (issue #590, part of Sentinel epic #588).
+
+Pins the two things a future #591/#592 implementation must not break:
+  - `_handle_event` dispatches `_stop_agent` + `_notify` in parallel, only when
+    `_scan` returns a triggered verdict.
+  - the skeleton's own `_scan` never triggers (no detection rules yet), and
+    malformed pubsub payloads are skipped instead of crashing the loop.
+No live Redis needed — a minimal fake stands in for RedisService.
+"""
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock
+
+from app.services.sentinel_service import SentinelService, SentinelVerdict
+
+
+def _service() -> SentinelService:
+    fake_redis = AsyncMock()
+    fake_redis.client = AsyncMock()
+    return SentinelService(fake_redis)
+
+
+class TestSentinelServiceSkeleton(unittest.IsolatedAsyncioTestCase):
+    async def test_scan_never_triggers_by_default(self):
+        service = _service()
+        verdict = await service._scan("agent-1", {"agent_id": "agent-1", "type": "created"})
+        self.assertIsNone(verdict)
+
+    async def test_handle_event_skips_when_scan_does_not_trigger(self):
+        service = _service()
+        service._stop_agent = AsyncMock()
+        service._notify = AsyncMock()
+
+        await service._handle_event({"agent_id": "agent-1", "type": "created"})
+
+        service._stop_agent.assert_not_awaited()
+        service._notify.assert_not_awaited()
+
+    async def test_handle_event_dispatches_stop_and_notify_in_parallel_on_trigger(self):
+        service = _service()
+        service._scan = AsyncMock(
+            return_value=SentinelVerdict(triggered=True, reason="test_rule", excerpt="leaked secret")
+        )
+        service._stop_agent = AsyncMock()
+        service._notify = AsyncMock()
+
+        await service._handle_event({"agent_id": "agent-1", "type": "tool_call"})
+
+        service._stop_agent.assert_awaited_once_with("agent-1", "test_rule")
+        service._notify.assert_awaited_once_with("agent-1", "test_rule", "leaked secret")
+
+    async def test_handle_event_ignores_events_without_agent_id(self):
+        service = _service()
+        service._scan = AsyncMock()
+
+        await service._handle_event({"type": "created"})
+
+        service._scan.assert_not_called()
+
+    async def test_handle_message_skips_malformed_json(self):
+        service = _service()
+        service._handle_event = AsyncMock()
+
+        await service._handle_message(b"not-json{{{")
+
+        service._handle_event.assert_not_awaited()
+
+    async def test_handle_message_decodes_bytes_and_routes_dict_payload(self):
+        service = _service()
+        service._handle_event = AsyncMock()
+
+        await service._handle_message(b'{"agent_id": "agent-1", "type": "created"}')
+
+        service._handle_event.assert_awaited_once_with({"agent_id": "agent-1", "type": "created"})
+
+    async def test_handle_message_ignores_non_dict_payload(self):
+        service = _service()
+        service._handle_event = AsyncMock()
+
+        await service._handle_message(b"[1, 2, 3]")
+
+        service._handle_event.assert_not_awaited()
+
+    async def test_stop_sets_running_false(self):
+        service = _service()
+        service._running = True
+        service.stop()
+        self.assertFalse(service._running)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Teilschritt 2/4 des Sentinel-Epics (#588), konkret Issue #590 Scope-Punkt 1: `orchestrator/app/services/sentinel_service.py`-Grundgerüst, nach Vorbild `watchdog.py`/`scheduler_service.py`, aber **event-getrieben** statt Polling.
- Konsumiert `agents:logs:all` (bereits vorhandener, orchestrator-seitig erzeugter Redis-Channel via `AgentManager._publish_event()`) — laut #588-Manipulationsschutz-Analyse darf die Telemetriequelle nie etwas sein, das der Agent-Prozess selbst schreibt.
- Drei Hook-Punkte ohne produktive Logik: `_scan` (immer `None`, Regeln kommen in #592), `_stop_agent` (loggt nur, echtes Credential-Schema kommt in #591), `_notify` (loggt nur).
- Neuer Feature-Flag `settings.sentinel_enabled` (Default `False`), analog `redis_acl_enabled` aus #589 — auch aktiviert ändert sich nichts, da `_scan` nie triggert.
- Verdrahtet in `main.py` Startup/Shutdown neben `SchedulerService`.

## Test plan
- [x] `python3 -m py_compile` auf allen geänderten/neuen Dateien
- [x] 8 neue Unit-Tests (`tests/test_sentinel_service_skeleton.py`), Fake-Redis, kein Live-Redis nötig — pinnen: `_handle_event` ruft `_stop_agent`+`_notify` nur bei getriggertem Verdict, parallel via `asyncio.gather`; malformte Pubsub-Payloads werden übersprungen; Events ohne `agent_id` werden ignoriert
- [x] Volle Orchestrator-Testsuite gegen sauberen `origin/main`-Worktree gelaufen — 2081 passed, dieselben 196 pre-existing Fehler wie ohne diese Änderung (fehlende `bcrypt`/`telegram`-Module im Sandbox-Environment, nicht durch diesen PR verursacht, verifiziert per Vergleich mit/ohne die Änderung)

Nicht Teil dieses PRs (folgen in #591/#592 laut Issue-Scope): privilegiertes drittes Credential-Schema für `stop_agent`, echte Scan-/Detection-Regeln, Audit-Tabelle, Erweiterung des Event-Streams um feingranulare Events, Sentinel-Liveness-Check in `watchdog.py`.