### PR TITLE
feat(sentinel): third credential scheme exclusive to Sentinel process (part of #590)

### DIFF
--- a/orchestrator/app/dependencies.py
+++ b/orchestrator/app/dependencies.py
@@ -352,6 +352,86 @@ async def verify_agent_token(request: Request) -> dict:
     return {"agent_id": agent_id}
 
 
+# --- Sentinel Credential (exclusive to the in-process Sentinel supervisor, #590) ---
+
+
+_SENTINEL_TOKEN_DOMAIN = b"sentinel:internal-credential:v1"
+
+
+def get_sentinel_token() -> str:
+    """Derive the Sentinel-exclusive credential deterministically from api_secret_key.
+
+    Same domain-separated-HMAC pattern already used for make_agent_token() above,
+    the per-agent Redis ACL password (redis_service.py) and the MCP OAuth client
+    secret (mcp_oauth.py): no extra secret to generate, store in the DB, or rotate
+    independently of api_secret_key.
+
+    Unlike make_agent_token(), the domain string here is a *fixed constant*, not an
+    agent_id — this is intentionally one single, non-agent-scoped credential, because
+    it identifies the Sentinel *process* (there is exactly one, per #590), not any
+    individual agent.
+
+    Why this is safe to derive from the same master secret agent tokens also come
+    from: agent containers only ever receive their own per-agent AGENT_TOKEN (a
+    *different* HMAC domain, keyed by agent_id) — never api_secret_key itself
+    (verified: no API_SECRET_KEY/api_secret_key entry appears anywhere in the
+    environment dict AgentManager builds for a container). HMAC is a PRF: knowing
+    any number of (agent_id, make_agent_token(agent_id)) pairs does not let a
+    compromised agent recover api_secret_key or forge a value for a *different*
+    domain string such as this one. That is the concrete guarantee behind #590's
+    requirement that "das Credential verlässt den Orchestrator-Prozess nie und
+    gelangt nie in einen Agent-Container" — it is computed fresh on every check,
+    never persisted anywhere, and structurally unreachable from agent code.
+    """
+    return hmac.new(
+        settings.api_secret_key.encode(),
+        _SENTINEL_TOKEN_DOMAIN,
+        hashlib.sha256,
+    ).hexdigest()
+
+
+class SentinelPrincipal(SimpleNamespace):
+    """Authenticated Sentinel-process caller — see require_sentinel().
+
+    Kept attribute-compatible with AgentPrincipal/User (a `role` attribute) so
+    call sites that only branch on ``role``/``principal_type`` do not need a
+    third special case, while still being unambiguously distinguishable via
+    ``is_sentinel_principal()``.
+    """
+
+    principal_type = "sentinel"
+    role = "sentinel"
+
+
+def is_sentinel_principal(principal) -> bool:
+    """Return True when the authenticated caller is the Sentinel process."""
+    return getattr(principal, "principal_type", None) == "sentinel"
+
+
+async def require_sentinel(request: Request) -> SentinelPrincipal:
+    """FastAPI Depends() wrapper: third credential scheme, exclusive to the Sentinel process.
+
+    Neither ``require_auth``/``require_admin`` (human JWT — Sentinel is not a logged-in
+    user) nor ``verify_agent_token`` (per-agent HMAC — the very actor Sentinel may need
+    to act against, and therefore must never be able to impersonate it) fit here. See
+    #588's manipulation-proof analysis and #590 scope point 3.
+
+    Checks the Authorization header against ``get_sentinel_token()`` with a
+    constant-time comparison (``hmac.compare_digest``), same as ``verify_agent_token``,
+    to avoid a timing side-channel. Endpoints that accept this alongside
+    ``require_auth`` should use an explicit combinator (see ``require_auth_or_agent``
+    for the analogous pattern) rather than silently widening an existing
+    human-only dependency — left to the call site that actually wires Sentinel's
+    privileged action to a route (#590 scope point 4), so the accepted-caller set of
+    any given endpoint stays an explicit, reviewable decision.
+    """
+    auth = request.headers.get("Authorization", "")
+    token = auth.removeprefix("Bearer ").strip()
+    if not token or not hmac.compare_digest(token, get_sentinel_token()):
+        raise HTTPException(status_code=403, detail="Sentinel credential required")
+    return SentinelPrincipal()
+
+
 async def require_auth_or_agent(
     request: Request,
     db: AsyncSession = Depends(get_db),

--- a/orchestrator/app/services/sentinel_service.py
+++ b/orchestrator/app/services/sentinel_service.py
@@ -13,15 +13,20 @@ agent's own process can write, only something the orchestrator generates at the
 point it actually performs an action. `agents:logs:all` already satisfies that
 today; nothing here reads any per-agent-writable stream.
 
-This is the Grundgerüst only (Teil 2/4, #590 scope point 1). The three hook
+This is the Grundgerüst only (Teil 2/4, #590 scope points 1+3). The three hook
 points below exist so the wiring is in place end to end, but carry no
 production logic yet:
   - `_scan`       always returns None (no detection rules — that's #592,
                    the DLP #525/#564/#575 scan logic).
-  - `_stop_agent` logs only (the privileged credential schema + the real
-                   AgentManager.stop_agent() call land in #591).
+  - `_stop_agent` logs only. The Sentinel-exclusive credential itself now
+                   exists (`app.dependencies.require_sentinel`/`get_sentinel_token`,
+                   #590 scope point 3, held on `self._sentinel_token`) — what is
+                   still missing is the actual privileged call it gets presented
+                   to (#590 scope point 4: wiring this to a real
+                   `AgentManager.stop_agent()` invocation, `asyncio.gather`'d with
+                   `_notify`).
   - `_notify`     logs only (wiring to notify_user/send_telegram and the
-                   audit-log table land alongside #591/#592).
+                   audit-log table land alongside scope point 4/#592).
 Because `sentinel_enabled` defaults to False and `_scan` never triggers even
 when on, none of this has any observable effect until those follow-ups land.
 """
@@ -70,6 +75,14 @@ class SentinelService:
     def __init__(self, redis: RedisService):
         self.redis = redis
         self._running = False
+        # The Sentinel-exclusive credential (#590 scope point 3, dependencies.py
+        # require_sentinel/get_sentinel_token). Held here so _stop_agent can present
+        # it once it is wired to a real privileged call (#590 scope point 4) — not
+        # used yet, computing it eagerly just proves the derivation succeeds at
+        # startup (a misconfigured/missing api_secret_key would fail loudly here
+        # instead of silently at the first real stop attempt).
+        from app.dependencies import get_sentinel_token
+        self._sentinel_token = get_sentinel_token()
 
     async def run(self) -> None:
         """Main loop: (re)subscribe to agents:logs:all and react to each event.
@@ -159,13 +172,16 @@ class SentinelService:
     async def _stop_agent(self, agent_id: str, reason: str) -> None:
         """Hook point for the privileged stop path.
 
-        Not wired to AgentManager.stop_agent() yet: that call needs the new
-        Sentinel-exclusive credential schema from #591 (a third scheme, neither
-        the human JWT nor the agent HMAC token — see #590's "Bereits vorhandene
-        Bausteine"). Logs only until then.
+        The Sentinel-exclusive credential (`self._sentinel_token`, see __init__)
+        exists now, but the actual call site it authorises is still undecided —
+        AgentManager.stop_agent() can be reached either as a direct in-process call
+        (like scheduler_service.py already does today, no HTTP/credential involved)
+        or by presenting `self._sentinel_token` to a dedicated endpoint alongside
+        `require_auth` on `/api/v1/agents/{id}/stop`. That call-path decision plus
+        the audit-log write land together in #590 scope point 4. Logs only until then.
         """
         logger.warning(
-            "[Sentinel] stop_agent hook called for %s (reason=%s) — not yet wired, see #591",
+            "[Sentinel] stop_agent hook called for %s (reason=%s) — not yet wired, see #590 scope point 4",
             agent_id, reason,
         )
 

--- a/orchestrator/tests/test_dependencies_sentinel_credential.py
+++ b/orchestrator/tests/test_dependencies_sentinel_credential.py
@@ -1,0 +1,91 @@
+"""Tests for the Sentinel-exclusive credential scheme (issue #590 scope point 3).
+
+Pins the properties the design in #590/#588 depends on:
+  - deterministic across calls/restarts (derived from api_secret_key, not random)
+  - a valid Sentinel token is accepted; missing/empty/wrong tokens are rejected
+  - it lives in its own HMAC domain, separate from per-agent tokens (make_agent_token) —
+    an agent's own token must never satisfy require_sentinel, and vice versa
+  - SentinelPrincipal is distinguishable from AgentPrincipal via principal_type/role,
+    same shape as the existing is_agent_principal() check
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import pytest
+
+from app.dependencies import (
+    SentinelPrincipal,
+    get_sentinel_token,
+    is_sentinel_principal,
+    make_agent_token,
+    require_sentinel,
+)
+from fastapi import HTTPException
+
+
+def _request(auth_header: str | None) -> SimpleNamespace:
+    """Minimal stand-in for a Starlette Request — require_sentinel only reads .headers."""
+    headers = {"Authorization": auth_header} if auth_header else {}
+    return SimpleNamespace(headers=headers)
+
+
+class TestGetSentinelToken(unittest.TestCase):
+    def test_deterministic_across_calls(self):
+        self.assertEqual(get_sentinel_token(), get_sentinel_token())
+
+    def test_distinct_from_an_agent_token(self):
+        # Different HMAC domain (fixed constant vs. agent_id) must never collide.
+        self.assertNotEqual(get_sentinel_token(), make_agent_token("some-agent-id"))
+
+    def test_is_a_non_trivial_hex_digest(self):
+        token = get_sentinel_token()
+        self.assertEqual(len(token), 64)  # full SHA-256 hex digest
+        int(token, 16)  # raises ValueError if not hex
+
+
+class TestRequireSentinel(unittest.IsolatedAsyncioTestCase):
+    async def test_accepts_valid_token(self):
+        request = _request(f"Bearer {get_sentinel_token()}")
+        principal = await require_sentinel(request)
+        self.assertIsInstance(principal, SentinelPrincipal)
+        self.assertTrue(is_sentinel_principal(principal))
+
+    async def test_rejects_missing_authorization_header(self):
+        request = _request(None)
+        with pytest.raises(HTTPException) as exc_info:
+            await require_sentinel(request)
+        self.assertEqual(exc_info.value.status_code, 403)
+
+    async def test_rejects_empty_token(self):
+        request = _request("Bearer ")
+        with pytest.raises(HTTPException) as exc_info:
+            await require_sentinel(request)
+        self.assertEqual(exc_info.value.status_code, 403)
+
+    async def test_rejects_wrong_token(self):
+        request = _request("Bearer not-the-sentinel-token")
+        with pytest.raises(HTTPException):
+            await require_sentinel(request)
+
+    async def test_rejects_an_agent_token_presented_as_sentinel_credential(self):
+        """The actor Sentinel may need to stop must never be able to impersonate it."""
+        agent_token = make_agent_token("agent-1")
+        request = _request(f"Bearer {agent_token}")
+        with pytest.raises(HTTPException):
+            await require_sentinel(request)
+
+
+class TestIsSentinelPrincipal(unittest.TestCase):
+    def test_true_for_sentinel_principal(self):
+        self.assertTrue(is_sentinel_principal(SentinelPrincipal()))
+
+    def test_false_for_plain_namespace(self):
+        self.assertFalse(is_sentinel_principal(SimpleNamespace(role="agent")))
+
+    def test_false_for_none(self):
+        self.assertFalse(is_sentinel_principal(None))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Stacked on #594 (Sentinel skeleton, unmerged) — implements #590 scope point 3: "Neues drittes Credential-Schema (`orchestrator/app/dependencies.py`, analog `require_admin`) exklusiv für den Sentinel-Prozess, zum Aufruf von `stop_agent`."

- `orchestrator/app/dependencies.py`: new `require_sentinel` FastAPI dependency + `get_sentinel_token()` + `SentinelPrincipal`/`is_sentinel_principal()`, structurally analogous to `require_admin`/`verify_agent_token`/`AgentPrincipal`/`is_agent_principal`.
- Token derivation: fixed-domain `HMAC-SHA256(api_secret_key, "sentinel:internal-credential:v1")` — same domain-separated-HMAC pattern already used for `make_agent_token()`, the per-agent Redis ACL password (#589), and the MCP OAuth client secret. No new secret to generate, persist, or rotate independently of `api_secret_key`.
- Verified agent containers never receive `api_secret_key` itself (only their own per-agent `AGENT_TOKEN`, a different HMAC domain) — so this satisfies #590's "das Credential verlässt den Orchestrator-Prozess nie und gelangt nie in einen Agent-Container" by construction, not just by convention.
- `SentinelService.__init__` now computes and holds `self._sentinel_token` (fails loudly at startup if `api_secret_key` is misconfigured, instead of silently at the first real stop attempt).

## Explicitly NOT in this PR (deferred to #590 scope point 4)
The credential exists but is **not yet presented to any privileged call**. `_stop_agent` still only logs. The actual call-path decision — direct in-process `AgentManager.stop_agent()` (the pattern `scheduler_service.py` already uses today, no HTTP/credential needed) vs. presenting `self._sentinel_token` to a dedicated endpoint alongside `require_auth` on `/api/v1/agents/{id}/stop` — is left open on purpose: `_check_owner`/`require_agent_access` (`orchestrator/app/api/agents.py`) currently assume a real `User` ORM object with `.role`/`.id`, and widening that shared, heavily-used authz path to accept a `SentinelPrincipal` is a separate, reviewable decision, not a side effect of adding the credential primitive. Documented in `sentinel_service.py`'s module docstring and `_stop_agent` docstring.

Also fixed a stale cross-reference: the previous skeleton PR (#594) pointed to "#591" for the credential schema — the real #591 is "Anbindung an bash-approval-server.mjs/command-policies" (a different sub-step). References now correctly point at #590 scope point 3/4.

## Test plan
- [x] `python3 -m py_compile` on all changed/new files
- [x] `pytest tests/test_dependencies_sentinel_credential.py tests/test_sentinel_service_skeleton.py -v` — 19/19 passed (11 new: deterministic derivation, valid/missing/empty/wrong token rejection, cross-scheme rejection — an agent's own HMAC token must not satisfy `require_sentinel` and vice versa — plus the 8 pre-existing skeleton tests, unaffected by the constructor change)
- [x] Direct import + `SentinelService(fake_redis)` construction smoke-tested outside pytest
- [x] `test_api/test_security_hardening.py` (existing dependency-adjacent suite) still passes at the same rate as on the base branch (1 pre-existing failure, `ModuleNotFoundError: yaml`, unrelated sandbox environment gap, not caused by this change)