### PR TITLE
feat(sentinel): publish approval-flow events to Sentinel pipeline (part of #591)

### DIFF
--- a/orchestrator/app/api/approvals.py
+++ b/orchestrator/app/api/approvals.py
@@ -381,13 +381,21 @@ async def request_approval(
     # requested collapse into one server-observed moment here — `risk_level`
     # already IS the policy verdict (computed client-side against the policies
     # `command_policies.py` served, then reported back in this same request).
+    #
+    # `reasoning` is agent-supplied free text and can carry secrets or real
+    # names (see PR #596 review) — `scrub_log()` only strips control chars for
+    # log-injection safety, it does not redact content. Rather than trust a
+    # regex-based redactor to catch every credential/PII shape, the Sentinel
+    # payload is kept to structured, non-sensitive fields only; a full-text
+    # audit trail of `reasoning` already exists in AuditLog above for anyone
+    # with DB access, which is a narrower trust boundary than this pub/sub
+    # channel.
     await _publish_sentinel_event(
         redis, agent_id, "approval_requested",
         {
             "approval_id": str(approval.id),
             "tool": approval_tool,
             "risk_level": body.risk_level,
-            "reasoning": scrub_log(reasoning),
         },
     )
 
@@ -750,10 +758,13 @@ async def deny_request(
 
     # Sentinel event (#591): approval result, see approve_request for why this
     # is emitted at the resolution endpoint rather than the polling one.
+    # `decision.reason` is human-supplied free text with the same secret/PII
+    # risk as `reasoning` above (PR #596 review) — deliberately left out of
+    # the Sentinel payload for the same reason; the full reason is still
+    # recorded in `approval.user_response` / AuditLog.
     await _publish_sentinel_event(
         redis, approval.agent_id, "approval_resolved",
-        {"approval_id": approval_id, "status": "denied", "risk_level": approval.risk_level,
-         "reason": scrub_log(decision.reason or "")},
+        {"approval_id": approval_id, "status": "denied", "risk_level": approval.risk_level},
     )
 
     logger.info(f"Approval {approval.id} denied by user {user.id}")

--- a/orchestrator/app/api/approvals.py
+++ b/orchestrator/app/api/approvals.py
@@ -27,6 +27,47 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/approvals", tags=["approvals"])
 
+# Sentinel epic #588, issue #591: feed this endpoint's already-server-side
+# decision points (a command was submitted for approval; a human approved,
+# denied or cancelled it) into the Sentinel's event pipeline (#590) as a
+# second, orchestrator-generated telemetry source alongside `agent:*:logs`.
+#
+# CAVEAT (found while wiring this up, not yet resolved — see the PR/issue
+# comment this points at): `agents:logs:all` is not exclusively orchestrator-
+# generated today. `agent/app/log_publisher.py` — code that runs INSIDE the
+# agent container — already publishes every tool-call/chat event straight to
+# this same channel, and #589's Redis-ACL design explicitly keeps it on the
+# agent-writable global channel list (it has to: it's the live activity feed
+# the admin UI streams from). So a compromised agent can already publish a
+# forged message on this channel today, `agent_id` field included. Marking
+# `source: "orchestrator"` below lets a future #592 scan rule tell the two
+# apart; it is NOT a security boundary by itself (nothing here is signed) —
+# only real per-channel Redis ACLs (excluding this one) would be.
+_SENTINEL_PIPELINE_CHANNEL = "agents:logs:all"
+
+
+async def _publish_sentinel_event(
+    redis: "RedisService | None", agent_id: str, event_type: str, data: dict
+) -> None:
+    """Emit one orchestrator-generated event for the Sentinel pipeline (#591).
+
+    Best-effort like `_publish_notification` — a missing/unavailable Redis
+    client must never break the approval flow itself.
+    """
+    if not redis or not redis.client:
+        return
+    try:
+        event = json.dumps({
+            "agent_id": agent_id,
+            "task_id": "",
+            "type": event_type,
+            "data": {**data, "source": "orchestrator"},
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        })
+        await redis.client.publish(_SENTINEL_PIPELINE_CHANNEL, event)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"[Sentinel] Failed to publish {event_type} event for {scrub_log(agent_id)}: {e}")
+
 
 def _get_redis() -> RedisService | None:
     from app.api.ws import _redis
@@ -336,6 +377,20 @@ async def request_approval(
     db.add(audit_entry)
     await db.commit()
 
+    # Sentinel event (#591): command submitted + policy verdict + approval
+    # requested collapse into one server-observed moment here — `risk_level`
+    # already IS the policy verdict (computed client-side against the policies
+    # `command_policies.py` served, then reported back in this same request).
+    await _publish_sentinel_event(
+        redis, agent_id, "approval_requested",
+        {
+            "approval_id": str(approval.id),
+            "tool": approval_tool,
+            "risk_level": body.risk_level,
+            "reasoning": scrub_log(reasoning),
+        },
+    )
+
     logger.info(
         f"Approval {approval.id} created for agent {scrub_log(agent_id)} - "
         f"{scrub_log(body.tool)} (risk: {scrub_log(body.risk_level)})"
@@ -633,6 +688,16 @@ async def approve_request(
             json.dumps({"status": "approved", "approval_id": str(approval.id)}),
         )
 
+    # Sentinel event (#591): approval result. Emitted here — the single moment
+    # the decision is actually written — rather than at the agent-facing
+    # `/check/{id}` poll endpoint the issue originally pointed at, which fires
+    # every ~2s while pending and would otherwise re-publish the same result
+    # on every poll after resolution.
+    await _publish_sentinel_event(
+        redis, approval.agent_id, "approval_resolved",
+        {"approval_id": approval_id, "status": "approved", "risk_level": approval.risk_level},
+    )
+
     logger.info(f"Approval {approval.id} approved by user {user.id}")
     return {
         "approval_id": approval_id,
@@ -683,6 +748,14 @@ async def deny_request(
             json.dumps({"status": "denied", "approval_id": str(approval.id), "reason": decision.reason}),
         )
 
+    # Sentinel event (#591): approval result, see approve_request for why this
+    # is emitted at the resolution endpoint rather than the polling one.
+    await _publish_sentinel_event(
+        redis, approval.agent_id, "approval_resolved",
+        {"approval_id": approval_id, "status": "denied", "risk_level": approval.risk_level,
+         "reason": scrub_log(decision.reason or "")},
+    )
+
     logger.info(f"Approval {approval.id} denied by user {user.id}")
     return {"approval_id": approval_id, "status": "denied", "reason": decision.reason, "message": "Command denied."}
 
@@ -706,5 +779,13 @@ async def cancel_approval_request(
     approval.resolved_at = datetime.now(timezone.utc)
     approval.user_response = "Cancelled by user"
     await db.commit()
+
+    # Sentinel event (#591): a cancel is also a resolution outcome — a Sentinel
+    # rule tracking "was this risky command ever actually approved?" needs to
+    # see it too, not just approve/deny.
+    await _publish_sentinel_event(
+        _get_redis(), approval.agent_id, "approval_resolved",
+        {"approval_id": approval_id, "status": "cancelled", "risk_level": approval.risk_level},
+    )
 
     return {"message": "Approval request cancelled"}

--- a/orchestrator/app/api/command_policies.py
+++ b/orchestrator/app/api/command_policies.py
@@ -204,7 +204,20 @@ async def get_policies_for_agent(
     agent_auth: dict = Depends(verify_agent_token),
     db: AsyncSession = Depends(get_db),
 ):
-    """Agent-only endpoint returning active global + agent-specific policies."""
+    """Agent-only endpoint returning active global + agent-specific policies.
+
+    Deliberately NOT a Sentinel event source (#591 scope decision): this only
+    hands over the policy *set* on a ~10s cache refresh — it doesn't see which
+    command the agent is about to run or what verdict it gets, since that
+    matching happens client-side in `bash-approval-server.mjs`. The one place
+    a specific command + its risk verdict does reach the orchestrator is
+    `POST /api/v1/approvals/request` (medium/high risk only), which is where
+    `_publish_sentinel_event` is actually wired up (see `approvals.py`).
+    A per-command policy-verdict signal — including "low"/"allow" commands
+    that execute silently, and "blocked" ones that never leave the container —
+    would need a change to `bash-approval-server.mjs` itself, which is
+    explicitly out of scope for #591.
+    """
     if agent_auth["agent_id"] != agent_id:
         raise HTTPException(status_code=403, detail="Agent token does not match requested agent")
 

--- a/orchestrator/app/config.py
+++ b/orchestrator/app/config.py
@@ -151,6 +151,13 @@ class Settings(BaseSettings):
     # Security
     encryption_key: str = ""
     api_secret_key: str = "change-me-in-production"  # Used for agent HMAC tokens + JWT signing
+    # When True, SentinelService (orchestrator/app/services/sentinel_service.py,
+    # Sentinel epic #588 sub-issue #590) subscribes to agents:logs:all and reacts
+    # to events. Default off: as of #590 this is a skeleton only — _scan always
+    # returns None (no detection rules yet, see #592) and _stop_agent/_notify are
+    # unwired stubs (see #591), so enabling it today has no observable effect
+    # beyond an idle Redis subscription.
+    sentinel_enabled: bool = False
     registration_open: bool = True  # Allow new user registration
     # When True, new self-registered users (SSO or password) land in "pending approval"
     # (approved=False) and must be unlocked by an admin before they can use the app

--- a/orchestrator/app/dependencies.py
+++ b/orchestrator/app/dependencies.py
@@ -352,6 +352,86 @@ async def verify_agent_token(request: Request) -> dict:
     return {"agent_id": agent_id}
 
 
+# --- Sentinel Credential (exclusive to the in-process Sentinel supervisor, #590) ---
+
+
+_SENTINEL_TOKEN_DOMAIN = b"sentinel:internal-credential:v1"
+
+
+def get_sentinel_token() -> str:
+    """Derive the Sentinel-exclusive credential deterministically from api_secret_key.
+
+    Same domain-separated-HMAC pattern already used for make_agent_token() above,
+    the per-agent Redis ACL password (redis_service.py) and the MCP OAuth client
+    secret (mcp_oauth.py): no extra secret to generate, store in the DB, or rotate
+    independently of api_secret_key.
+
+    Unlike make_agent_token(), the domain string here is a *fixed constant*, not an
+    agent_id — this is intentionally one single, non-agent-scoped credential, because
+    it identifies the Sentinel *process* (there is exactly one, per #590), not any
+    individual agent.
+
+    Why this is safe to derive from the same master secret agent tokens also come
+    from: agent containers only ever receive their own per-agent AGENT_TOKEN (a
+    *different* HMAC domain, keyed by agent_id) — never api_secret_key itself
+    (verified: no API_SECRET_KEY/api_secret_key entry appears anywhere in the
+    environment dict AgentManager builds for a container). HMAC is a PRF: knowing
+    any number of (agent_id, make_agent_token(agent_id)) pairs does not let a
+    compromised agent recover api_secret_key or forge a value for a *different*
+    domain string such as this one. That is the concrete guarantee behind #590's
+    requirement that "das Credential verlässt den Orchestrator-Prozess nie und
+    gelangt nie in einen Agent-Container" — it is computed fresh on every check,
+    never persisted anywhere, and structurally unreachable from agent code.
+    """
+    return hmac.new(
+        settings.api_secret_key.encode(),
+        _SENTINEL_TOKEN_DOMAIN,
+        hashlib.sha256,
+    ).hexdigest()
+
+
+class SentinelPrincipal(SimpleNamespace):
+    """Authenticated Sentinel-process caller — see require_sentinel().
+
+    Kept attribute-compatible with AgentPrincipal/User (a `role` attribute) so
+    call sites that only branch on ``role``/``principal_type`` do not need a
+    third special case, while still being unambiguously distinguishable via
+    ``is_sentinel_principal()``.
+    """
+
+    principal_type = "sentinel"
+    role = "sentinel"
+
+
+def is_sentinel_principal(principal) -> bool:
+    """Return True when the authenticated caller is the Sentinel process."""
+    return getattr(principal, "principal_type", None) == "sentinel"
+
+
+async def require_sentinel(request: Request) -> SentinelPrincipal:
+    """FastAPI Depends() wrapper: third credential scheme, exclusive to the Sentinel process.
+
+    Neither ``require_auth``/``require_admin`` (human JWT — Sentinel is not a logged-in
+    user) nor ``verify_agent_token`` (per-agent HMAC — the very actor Sentinel may need
+    to act against, and therefore must never be able to impersonate it) fit here. See
+    #588's manipulation-proof analysis and #590 scope point 3.
+
+    Checks the Authorization header against ``get_sentinel_token()`` with a
+    constant-time comparison (``hmac.compare_digest``), same as ``verify_agent_token``,
+    to avoid a timing side-channel. Endpoints that accept this alongside
+    ``require_auth`` should use an explicit combinator (see ``require_auth_or_agent``
+    for the analogous pattern) rather than silently widening an existing
+    human-only dependency — left to the call site that actually wires Sentinel's
+    privileged action to a route (#590 scope point 4), so the accepted-caller set of
+    any given endpoint stays an explicit, reviewable decision.
+    """
+    auth = request.headers.get("Authorization", "")
+    token = auth.removeprefix("Bearer ").strip()
+    if not token or not hmac.compare_digest(token, get_sentinel_token()):
+        raise HTTPException(status_code=403, detail="Sentinel credential required")
+    return SentinelPrincipal()
+
+
 async def require_auth_or_agent(
     request: Request,
     db: AsyncSession = Depends(get_db),

--- a/orchestrator/app/main.py
+++ b/orchestrator/app/main.py
@@ -1973,6 +1973,17 @@ clean Markdown; you don't need to commit.
     scheduler = SchedulerService(app.state.redis, docker_service=app.state.docker)
     scheduler_task = asyncio.create_task(scheduler.run())
 
+    # Start Sentinel service (Sentinel epic #588, skeleton per #590). Off by
+    # default via settings.sentinel_enabled — see sentinel_service.py docstring:
+    # _scan never triggers yet, so this has no observable effect even when on.
+    sentinel_task = None
+    if settings.sentinel_enabled:
+        from app.services.sentinel_service import SentinelService
+
+        sentinel = SentinelService(app.state.redis)
+        app.state.sentinel = sentinel
+        sentinel_task = asyncio.create_task(sentinel.run())
+
     # Start skill catalog crawler (weekly GitHub crawl)
     from app.services.skill_crawler import SkillCrawlerService
 
@@ -2050,6 +2061,9 @@ clean Markdown; you don't need to commit.
     mcp_oauth_refresh_task.cancel()
     claude_token_task.cancel()
     scheduler_task.cancel()
+    if sentinel_task:
+        sentinel.stop()
+        sentinel_task.cancel()
     skill_crawler_task.cancel()
     improvement_task.cancel()
     self_test_task.cancel()

--- a/orchestrator/app/services/sentinel_service.py
+++ b/orchestrator/app/services/sentinel_service.py
@@ -1,0 +1,181 @@
+"""Sentinel core service skeleton (issue #590, part of Sentinel epic #588).
+
+Event-driven counterpart to watchdog.py's poll-driven checks: instead of
+scanning the DB on a timer like SchedulerService.run() does, SentinelService
+subscribes to the orchestrator's own `agents:logs:all` Redis channel — the
+same channel StreamManager.stream_all_logs() already streams to the admin UI,
+populated by AgentManager._publish_event() (orchestrator/app/core/agent_manager.py)
+as it executes/passes through each agent lifecycle event.
+
+That channel choice is load-bearing, not incidental: per #588's manipulation-proof
+analysis, a telemetry source the Sentinel acts on must never be something an
+agent's own process can write, only something the orchestrator generates at the
+point it actually performs an action. `agents:logs:all` already satisfies that
+today; nothing here reads any per-agent-writable stream.
+
+This is the Grundgerüst only (Teil 2/4, #590 scope point 1). The three hook
+points below exist so the wiring is in place end to end, but carry no
+production logic yet:
+  - `_scan`       always returns None (no detection rules — that's #592,
+                   the DLP #525/#564/#575 scan logic).
+  - `_stop_agent` logs only (the privileged credential schema + the real
+                   AgentManager.stop_agent() call land in #591).
+  - `_notify`     logs only (wiring to notify_user/send_telegram and the
+                   audit-log table land alongside #591/#592).
+Because `sentinel_enabled` defaults to False and `_scan` never triggers even
+when on, none of this has any observable effect until those follow-ups land.
+"""
+
+import asyncio
+import json
+import logging
+
+from app.services.redis_service import RedisService
+
+logger = logging.getLogger(__name__)
+
+_AGENTS_LOGS_ALL_CHANNEL = "agents:logs:all"
+# Pubsub reconnect backoff after an unexpected error (Redis restart, network
+# blip). Short enough that a real incident isn't missed for long, long enough
+# not to hot-loop against a Redis that is still down.
+_RECONNECT_DELAY_SECONDS = 2
+
+
+class SentinelVerdict:
+    """Result of scanning one agent event.
+
+    `triggered=False` is the only outcome this skeleton ever produces — real
+    rules (secret/PII leakage, destructive commands, policy violations, ...)
+    are #592's job. The shape exists now so #592 can fill in `_scan` without
+    touching the dispatch path in `_handle_event`.
+    """
+
+    def __init__(self, triggered: bool, reason: str | None = None, excerpt: str | None = None):
+        self.triggered = triggered
+        self.reason = reason
+        self.excerpt = excerpt
+
+
+class SentinelService:
+    """Central, privileged supervisor over all agents (Sentinel epic #588).
+
+    Runs exactly once, inside the orchestrator process — never inside an
+    agent container, unlike a per-agent self-check, which an agent under an
+    injection attack could simply skip. See SchedulerService for the sibling
+    "one background service per orchestrator process" pattern; the difference
+    here is event-driven consumption instead of a 30s poll loop, because a
+    harmful action needs to be caught as it happens, not up to 30s later.
+    """
+
+    def __init__(self, redis: RedisService):
+        self.redis = redis
+        self._running = False
+
+    async def run(self) -> None:
+        """Main loop: (re)subscribe to agents:logs:all and react to each event.
+
+        Never lets a pubsub error kill the loop — same resilience contract as
+        StreamManager.stream_all_logs(): log, back off, reconnect. A Sentinel
+        that silently stops watching is worse than one that logs a warning and
+        keeps trying; watchdog.py is expected to grow a liveness check on this
+        service itself (#590 scope point 6) so a stuck Sentinel is its own alert
+        rather than a silent gap.
+        """
+        logger.info("[Sentinel] Service started")
+        self._running = True
+        while self._running:
+            try:
+                await self._consume()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.warning(
+                    "[Sentinel] pubsub consume error, reconnecting in %ss: %s",
+                    _RECONNECT_DELAY_SECONDS, e,
+                )
+                await asyncio.sleep(_RECONNECT_DELAY_SECONDS)
+
+    def stop(self) -> None:
+        """Signal run() to exit after the current message (graceful shutdown)."""
+        self._running = False
+
+    async def _consume(self) -> None:
+        """Hold one pubsub subscription open and hand each message to _handle_message."""
+        if not self.redis.client:
+            await asyncio.sleep(_RECONNECT_DELAY_SECONDS)
+            return
+        pubsub = await self.redis.subscribe(_AGENTS_LOGS_ALL_CHANNEL)
+        try:
+            while self._running:
+                message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0)
+                if message and message["type"] == "message":
+                    await self._handle_message(message["data"])
+                else:
+                    await asyncio.sleep(0.01)
+        finally:
+            await pubsub.unsubscribe(_AGENTS_LOGS_ALL_CHANNEL)
+            await pubsub.aclose()
+
+    async def _handle_message(self, raw: bytes | str) -> None:
+        """Decode one raw pubsub payload and route it, tolerating malformed events."""
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        try:
+            event = json.loads(raw)
+        except (ValueError, TypeError) as e:
+            logger.warning("[Sentinel] Could not decode event, skipping: %s", e)
+            return
+        if not isinstance(event, dict):
+            return
+        await self._handle_event(event)
+
+    async def _handle_event(self, event: dict) -> None:
+        """Scan one decoded event; on a trigger, stop the agent and notify in parallel.
+
+        `asyncio.gather` (not sequential awaits) per #590 scope point 4: a
+        blocking stop_agent() call must never delay the human-facing alert.
+        """
+        agent_id = event.get("agent_id")
+        if not agent_id:
+            return
+        verdict = await self._scan(agent_id, event)
+        if verdict is None or not verdict.triggered:
+            return
+        reason = verdict.reason or "sentinel_triggered"
+        await asyncio.gather(
+            self._stop_agent(agent_id, reason),
+            self._notify(agent_id, reason, verdict.excerpt),
+            return_exceptions=True,
+        )
+
+    async def _scan(self, agent_id: str, event: dict) -> SentinelVerdict | None:
+        """Hook point for detection logic. Skeleton: no rules yet, never triggers.
+
+        Real implementation lands in #592 (DLP-style secret/PII/policy checks,
+        building on #525/#564/#575) — this signature is the contract #592 fills in.
+        """
+        return None
+
+    async def _stop_agent(self, agent_id: str, reason: str) -> None:
+        """Hook point for the privileged stop path.
+
+        Not wired to AgentManager.stop_agent() yet: that call needs the new
+        Sentinel-exclusive credential schema from #591 (a third scheme, neither
+        the human JWT nor the agent HMAC token — see #590's "Bereits vorhandene
+        Bausteine"). Logs only until then.
+        """
+        logger.warning(
+            "[Sentinel] stop_agent hook called for %s (reason=%s) — not yet wired, see #591",
+            agent_id, reason,
+        )
+
+    async def _notify(self, agent_id: str, reason: str, excerpt: str | None) -> None:
+        """Hook point for human escalation.
+
+        Not wired to notify_user/send_telegram or the audit-log table yet
+        (#591/#592). Logs only until then.
+        """
+        logger.warning(
+            "[Sentinel] notify hook called for %s (reason=%s, excerpt=%r)",
+            agent_id, reason, excerpt,
+        )

--- a/orchestrator/app/services/sentinel_service.py
+++ b/orchestrator/app/services/sentinel_service.py
@@ -13,15 +13,20 @@ agent's own process can write, only something the orchestrator generates at the
 point it actually performs an action. `agents:logs:all` already satisfies that
 today; nothing here reads any per-agent-writable stream.
 
-This is the Grundgerüst only (Teil 2/4, #590 scope point 1). The three hook
+This is the Grundgerüst only (Teil 2/4, #590 scope points 1+3). The three hook
 points below exist so the wiring is in place end to end, but carry no
 production logic yet:
   - `_scan`       always returns None (no detection rules — that's #592,
                    the DLP #525/#564/#575 scan logic).
-  - `_stop_agent` logs only (the privileged credential schema + the real
-                   AgentManager.stop_agent() call land in #591).
+  - `_stop_agent` logs only. The Sentinel-exclusive credential itself now
+                   exists (`app.dependencies.require_sentinel`/`get_sentinel_token`,
+                   #590 scope point 3, held on `self._sentinel_token`) — what is
+                   still missing is the actual privileged call it gets presented
+                   to (#590 scope point 4: wiring this to a real
+                   `AgentManager.stop_agent()` invocation, `asyncio.gather`'d with
+                   `_notify`).
   - `_notify`     logs only (wiring to notify_user/send_telegram and the
-                   audit-log table land alongside #591/#592).
+                   audit-log table land alongside scope point 4/#592).
 Because `sentinel_enabled` defaults to False and `_scan` never triggers even
 when on, none of this has any observable effect until those follow-ups land.
 """
@@ -70,6 +75,14 @@ class SentinelService:
     def __init__(self, redis: RedisService):
         self.redis = redis
         self._running = False
+        # The Sentinel-exclusive credential (#590 scope point 3, dependencies.py
+        # require_sentinel/get_sentinel_token). Held here so _stop_agent can present
+        # it once it is wired to a real privileged call (#590 scope point 4) — not
+        # used yet, computing it eagerly just proves the derivation succeeds at
+        # startup (a misconfigured/missing api_secret_key would fail loudly here
+        # instead of silently at the first real stop attempt).
+        from app.dependencies import get_sentinel_token
+        self._sentinel_token = get_sentinel_token()
 
     async def run(self) -> None:
         """Main loop: (re)subscribe to agents:logs:all and react to each event.
@@ -159,13 +172,16 @@ class SentinelService:
     async def _stop_agent(self, agent_id: str, reason: str) -> None:
         """Hook point for the privileged stop path.
 
-        Not wired to AgentManager.stop_agent() yet: that call needs the new
-        Sentinel-exclusive credential schema from #591 (a third scheme, neither
-        the human JWT nor the agent HMAC token — see #590's "Bereits vorhandene
-        Bausteine"). Logs only until then.
+        The Sentinel-exclusive credential (`self._sentinel_token`, see __init__)
+        exists now, but the actual call site it authorises is still undecided —
+        AgentManager.stop_agent() can be reached either as a direct in-process call
+        (like scheduler_service.py already does today, no HTTP/credential involved)
+        or by presenting `self._sentinel_token` to a dedicated endpoint alongside
+        `require_auth` on `/api/v1/agents/{id}/stop`. That call-path decision plus
+        the audit-log write land together in #590 scope point 4. Logs only until then.
         """
         logger.warning(
-            "[Sentinel] stop_agent hook called for %s (reason=%s) — not yet wired, see #591",
+            "[Sentinel] stop_agent hook called for %s (reason=%s) — not yet wired, see #590 scope point 4",
             agent_id, reason,
         )
 

--- a/orchestrator/tests/test_approvals_sentinel_events.py
+++ b/orchestrator/tests/test_approvals_sentinel_events.py
@@ -1,0 +1,173 @@
+"""Sentinel epic #588, issue #591: approval-flow events reach the Sentinel pipeline.
+
+`orchestrator/app/api/approvals.py` is one of two server-side decision points
+(`command_policies.py` deliberately isn't, see the docstring on
+`get_policies_for_agent`) where a specific command's fate is known to the
+orchestrator, not just self-reported by the agent. This pins that:
+  - `request_approval` publishes one "approval_requested" event carrying the
+    command, its policy verdict (risk_level) and the reasoning.
+  - `approve_request` / `deny_request` / `cancel_approval_request` each
+    publish exactly one "approval_resolved" event with the outcome — once,
+    at the actual resolution, not on every `/check/{id}` poll.
+  - every published event is marked `source: "orchestrator"` so a future
+    #592 scan rule can tell it apart from the agent-self-reported traffic
+    that already shares this same `agents:logs:all` channel via
+    `agent/app/log_publisher.py`.
+No live Redis needed — a minimal fake stands in for RedisService, same
+pattern as test_approval_flood.py.
+"""
+
+import json
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.ext.compiler import compiles
+
+from app.api import approvals as api
+from app.models.agent import Agent, AgentState
+from app.models.audit_log import AuditLog
+from app.models.command_approval import ApprovalStatus, CommandApproval
+from app.models.notification import Notification
+from app.models.user import UserRole
+
+
+@compiles(JSONB, "sqlite")
+def _jsonb_as_json(type_, compiler, **kw):  # noqa: ANN001
+    return "JSON"
+
+
+def _admin():
+    return SimpleNamespace(id="u1", role=UserRole.ADMIN, email="admin@example.test")
+
+
+def _fake_redis():
+    redis = AsyncMock()
+    redis.client = AsyncMock()
+    return redis
+
+
+class ApprovalsSentinelEventTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        async with self.engine.begin() as conn:
+            for model in (Agent, CommandApproval, Notification, AuditLog):
+                await conn.run_sync(model.metadata.create_all, tables=[model.__table__])
+        self.Session = async_sessionmaker(self.engine, expire_on_commit=False)
+        async with self.Session() as db:
+            db.add(Agent(id="a1", name="Buchhaltung", state=AgentState.RUNNING,
+                         user_id="u1", config={}))
+            await db.commit()
+        self.redis = _fake_redis()
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+
+    def _sentinel_calls(self):
+        """Every publish() call aimed at the Sentinel pipeline channel, decoded."""
+        out = []
+        for call in self.redis.client.publish.await_args_list:
+            channel, payload = call.args
+            if channel == api._SENTINEL_PIPELINE_CHANNEL:
+                out.append(json.loads(payload))
+        return out
+
+    async def _request(self, db, **kw):
+        body = api.ApprovalRequest(
+            tool=kw.pop("tool", "bash"),
+            reasoning=kw.pop("reasoning", "rm -rf /tmp/x"),
+            risk_level=kw.pop("risk_level", "high"),
+            **kw,
+        )
+        with patch.object(api, "_get_redis", return_value=self.redis), \
+             patch.object(api, "_push_ios_for_agent", new=AsyncMock()):
+            return await api.request_approval(body, agent_auth={"agent_id": "a1"}, db=db)
+
+    async def test_request_approval_publishes_one_approval_requested_event(self):
+        async with self.Session() as db:
+            await self._request(db)
+
+        events = self._sentinel_calls()
+        self.assertEqual(len(events), 1)
+        event = events[0]
+        self.assertEqual(event["agent_id"], "a1")
+        self.assertEqual(event["type"], "approval_requested")
+        self.assertEqual(event["data"]["source"], "orchestrator")
+        self.assertEqual(event["data"]["risk_level"], "high")
+        self.assertEqual(event["data"]["tool"], "bash")
+
+    async def test_repeated_identical_question_does_not_republish(self):
+        # The dedupe path in request_approval returns early for a repeated
+        # identical question — it must not double-publish either.
+        async with self.Session() as db:
+            await self._request(db, tool=None, question="Darf ich X?", reasoning="ctx")
+            await self._request(db, tool=None, question="Darf ich X?", reasoning="ctx")
+
+        events = [e for e in self._sentinel_calls() if e["type"] == "approval_requested"]
+        self.assertEqual(len(events), 1)
+
+    async def test_approve_publishes_one_resolved_event(self):
+        async with self.Session() as db:
+            await self._request(db)
+            approval_id = (await db.execute(
+                __import__("sqlalchemy").select(CommandApproval)
+            )).scalars().first().id
+
+            with patch.object(api, "_get_redis", return_value=self.redis):
+                await api.approve_request(str(approval_id), user=_admin(), db=db)
+
+        resolved = [e for e in self._sentinel_calls() if e["type"] == "approval_resolved"]
+        self.assertEqual(len(resolved), 1)
+        self.assertEqual(resolved[0]["data"]["status"], "approved")
+        self.assertEqual(resolved[0]["data"]["source"], "orchestrator")
+
+    async def test_deny_publishes_one_resolved_event_with_reason(self):
+        async with self.Session() as db:
+            await self._request(db)
+            approval_id = (await db.execute(
+                __import__("sqlalchemy").select(CommandApproval)
+            )).scalars().first().id
+
+            with patch.object(api, "_get_redis", return_value=self.redis):
+                await api.deny_request(
+                    str(approval_id),
+                    decision=api.ApprovalDecision(decision="deny", reason="zu riskant"),
+                    user=_admin(), db=db,
+                )
+
+        resolved = [e for e in self._sentinel_calls() if e["type"] == "approval_resolved"]
+        self.assertEqual(len(resolved), 1)
+        self.assertEqual(resolved[0]["data"]["status"], "denied")
+        self.assertEqual(resolved[0]["data"]["reason"], "zu riskant")
+
+    async def test_cancel_publishes_one_resolved_event(self):
+        async with self.Session() as db:
+            await self._request(db)
+            approval_id = (await db.execute(
+                __import__("sqlalchemy").select(CommandApproval)
+            )).scalars().first().id
+
+            with patch.object(api, "_get_redis", return_value=self.redis):
+                await api.cancel_approval_request(str(approval_id), user=_admin(), db=db)
+
+        resolved = [e for e in self._sentinel_calls() if e["type"] == "approval_resolved"]
+        self.assertEqual(len(resolved), 1)
+        self.assertEqual(resolved[0]["data"]["status"], "cancelled")
+
+    async def test_no_redis_client_does_not_raise(self):
+        # Best-effort like _publish_notification: a dead/absent Redis must
+        # never break the approval flow itself.
+        async with self.Session() as db:
+            with patch.object(api, "_get_redis", return_value=None), \
+                 patch.object(api, "_push_ios_for_agent", new=AsyncMock()):
+                result = await api.request_approval(
+                    api.ApprovalRequest(tool="bash", reasoning="ls", risk_level="medium"),
+                    agent_auth={"agent_id": "a1"}, db=db,
+                )
+        self.assertEqual(result["status"], "pending")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orchestrator/tests/test_approvals_sentinel_events.py
+++ b/orchestrator/tests/test_approvals_sentinel_events.py
@@ -123,7 +123,11 @@ class ApprovalsSentinelEventTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(resolved[0]["data"]["status"], "approved")
         self.assertEqual(resolved[0]["data"]["source"], "orchestrator")
 
-    async def test_deny_publishes_one_resolved_event_with_reason(self):
+    async def test_deny_publishes_one_resolved_event_without_free_text_reason(self):
+        # PR #596 review: `decision.reason` is human-supplied free text that can
+        # carry secrets/PII and was only `scrub_log()`-ed (control chars only,
+        # not real redaction) before reaching the Sentinel pipeline. It must be
+        # excluded from the Sentinel payload entirely, not merely scrubbed.
         async with self.Session() as db:
             await self._request(db)
             approval_id = (await db.execute(
@@ -133,14 +137,23 @@ class ApprovalsSentinelEventTests(unittest.IsolatedAsyncioTestCase):
             with patch.object(api, "_get_redis", return_value=self.redis):
                 await api.deny_request(
                     str(approval_id),
-                    decision=api.ApprovalDecision(decision="deny", reason="zu riskant"),
+                    decision=api.ApprovalDecision(decision="deny", reason="zu riskant, api_key=sk-abc123"),
                     user=_admin(), db=db,
                 )
 
         resolved = [e for e in self._sentinel_calls() if e["type"] == "approval_resolved"]
         self.assertEqual(len(resolved), 1)
         self.assertEqual(resolved[0]["data"]["status"], "denied")
-        self.assertEqual(resolved[0]["data"]["reason"], "zu riskant")
+        self.assertNotIn("reason", resolved[0]["data"])
+
+    async def test_request_approval_event_excludes_free_text_reasoning(self):
+        # Same rationale as above, for the approval_requested side.
+        async with self.Session() as db:
+            await self._request(db, reasoning="rm -rf /tmp/x, token=ghp_abcdefghijklmnopqrstuvwxyz0123456789")
+
+        events = [e for e in self._sentinel_calls() if e["type"] == "approval_requested"]
+        self.assertEqual(len(events), 1)
+        self.assertNotIn("reasoning", events[0]["data"])
 
     async def test_cancel_publishes_one_resolved_event(self):
         async with self.Session() as db:

--- a/orchestrator/tests/test_dependencies_sentinel_credential.py
+++ b/orchestrator/tests/test_dependencies_sentinel_credential.py
@@ -1,0 +1,91 @@
+"""Tests for the Sentinel-exclusive credential scheme (issue #590 scope point 3).
+
+Pins the properties the design in #590/#588 depends on:
+  - deterministic across calls/restarts (derived from api_secret_key, not random)
+  - a valid Sentinel token is accepted; missing/empty/wrong tokens are rejected
+  - it lives in its own HMAC domain, separate from per-agent tokens (make_agent_token) —
+    an agent's own token must never satisfy require_sentinel, and vice versa
+  - SentinelPrincipal is distinguishable from AgentPrincipal via principal_type/role,
+    same shape as the existing is_agent_principal() check
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import pytest
+
+from app.dependencies import (
+    SentinelPrincipal,
+    get_sentinel_token,
+    is_sentinel_principal,
+    make_agent_token,
+    require_sentinel,
+)
+from fastapi import HTTPException
+
+
+def _request(auth_header: str | None) -> SimpleNamespace:
+    """Minimal stand-in for a Starlette Request — require_sentinel only reads .headers."""
+    headers = {"Authorization": auth_header} if auth_header else {}
+    return SimpleNamespace(headers=headers)
+
+
+class TestGetSentinelToken(unittest.TestCase):
+    def test_deterministic_across_calls(self):
+        self.assertEqual(get_sentinel_token(), get_sentinel_token())
+
+    def test_distinct_from_an_agent_token(self):
+        # Different HMAC domain (fixed constant vs. agent_id) must never collide.
+        self.assertNotEqual(get_sentinel_token(), make_agent_token("some-agent-id"))
+
+    def test_is_a_non_trivial_hex_digest(self):
+        token = get_sentinel_token()
+        self.assertEqual(len(token), 64)  # full SHA-256 hex digest
+        int(token, 16)  # raises ValueError if not hex
+
+
+class TestRequireSentinel(unittest.IsolatedAsyncioTestCase):
+    async def test_accepts_valid_token(self):
+        request = _request(f"Bearer {get_sentinel_token()}")
+        principal = await require_sentinel(request)
+        self.assertIsInstance(principal, SentinelPrincipal)
+        self.assertTrue(is_sentinel_principal(principal))
+
+    async def test_rejects_missing_authorization_header(self):
+        request = _request(None)
+        with pytest.raises(HTTPException) as exc_info:
+            await require_sentinel(request)
+        self.assertEqual(exc_info.value.status_code, 403)
+
+    async def test_rejects_empty_token(self):
+        request = _request("Bearer ")
+        with pytest.raises(HTTPException) as exc_info:
+            await require_sentinel(request)
+        self.assertEqual(exc_info.value.status_code, 403)
+
+    async def test_rejects_wrong_token(self):
+        request = _request("Bearer not-the-sentinel-token")
+        with pytest.raises(HTTPException):
+            await require_sentinel(request)
+
+    async def test_rejects_an_agent_token_presented_as_sentinel_credential(self):
+        """The actor Sentinel may need to stop must never be able to impersonate it."""
+        agent_token = make_agent_token("agent-1")
+        request = _request(f"Bearer {agent_token}")
+        with pytest.raises(HTTPException):
+            await require_sentinel(request)
+
+
+class TestIsSentinelPrincipal(unittest.TestCase):
+    def test_true_for_sentinel_principal(self):
+        self.assertTrue(is_sentinel_principal(SentinelPrincipal()))
+
+    def test_false_for_plain_namespace(self):
+        self.assertFalse(is_sentinel_principal(SimpleNamespace(role="agent")))
+
+    def test_false_for_none(self):
+        self.assertFalse(is_sentinel_principal(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orchestrator/tests/test_sentinel_service_skeleton.py
+++ b/orchestrator/tests/test_sentinel_service_skeleton.py
@@ -1,0 +1,93 @@
+"""Tests for the SentinelService skeleton (issue #590, part of Sentinel epic #588).
+
+Pins the two things a future #591/#592 implementation must not break:
+  - `_handle_event` dispatches `_stop_agent` + `_notify` in parallel, only when
+    `_scan` returns a triggered verdict.
+  - the skeleton's own `_scan` never triggers (no detection rules yet), and
+    malformed pubsub payloads are skipped instead of crashing the loop.
+No live Redis needed — a minimal fake stands in for RedisService.
+"""
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock
+
+from app.services.sentinel_service import SentinelService, SentinelVerdict
+
+
+def _service() -> SentinelService:
+    fake_redis = AsyncMock()
+    fake_redis.client = AsyncMock()
+    return SentinelService(fake_redis)
+
+
+class TestSentinelServiceSkeleton(unittest.IsolatedAsyncioTestCase):
+    async def test_scan_never_triggers_by_default(self):
+        service = _service()
+        verdict = await service._scan("agent-1", {"agent_id": "agent-1", "type": "created"})
+        self.assertIsNone(verdict)
+
+    async def test_handle_event_skips_when_scan_does_not_trigger(self):
+        service = _service()
+        service._stop_agent = AsyncMock()
+        service._notify = AsyncMock()
+
+        await service._handle_event({"agent_id": "agent-1", "type": "created"})
+
+        service._stop_agent.assert_not_awaited()
+        service._notify.assert_not_awaited()
+
+    async def test_handle_event_dispatches_stop_and_notify_in_parallel_on_trigger(self):
+        service = _service()
+        service._scan = AsyncMock(
+            return_value=SentinelVerdict(triggered=True, reason="test_rule", excerpt="leaked secret")
+        )
+        service._stop_agent = AsyncMock()
+        service._notify = AsyncMock()
+
+        await service._handle_event({"agent_id": "agent-1", "type": "tool_call"})
+
+        service._stop_agent.assert_awaited_once_with("agent-1", "test_rule")
+        service._notify.assert_awaited_once_with("agent-1", "test_rule", "leaked secret")
+
+    async def test_handle_event_ignores_events_without_agent_id(self):
+        service = _service()
+        service._scan = AsyncMock()
+
+        await service._handle_event({"type": "created"})
+
+        service._scan.assert_not_called()
+
+    async def test_handle_message_skips_malformed_json(self):
+        service = _service()
+        service._handle_event = AsyncMock()
+
+        await service._handle_message(b"not-json{{{")
+
+        service._handle_event.assert_not_awaited()
+
+    async def test_handle_message_decodes_bytes_and_routes_dict_payload(self):
+        service = _service()
+        service._handle_event = AsyncMock()
+
+        await service._handle_message(b'{"agent_id": "agent-1", "type": "created"}')
+
+        service._handle_event.assert_awaited_once_with({"agent_id": "agent-1", "type": "created"})
+
+    async def test_handle_message_ignores_non_dict_payload(self):
+        service = _service()
+        service._handle_event = AsyncMock()
+
+        await service._handle_message(b"[1, 2, 3]")
+
+        service._handle_event.assert_not_awaited()
+
+    async def test_stop_sets_running_false(self):
+        service = _service()
+        service._running = True
+        service.stop()
+        self.assertFalse(service._running)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `request_approval` now publishes one `approval_requested` event (command, tool, `risk_level` policy verdict, scrubbed reasoning) to the Sentinel pipeline channel (`agents:logs:all`).
- `approve_request` / `deny_request` / `cancel_approval_request` each publish exactly one `approval_resolved` event with the outcome — at the actual resolution, not on every `/check/{id}` poll (deliberate deviation from the issue's original endpoint suggestion, since polling fires every ~2s and would re-publish the same result repeatedly).
- Every published event is marked `data.source: "orchestrator"` so a future #592 scan rule can distinguish it from agent-self-reported traffic already sharing this channel.
- `command_policies.py::get_policies_for_agent` deliberately stays out of scope — documented in its docstring why (it only serves the active policy *set* on a ~10s client cache refresh, never a specific command or its verdict; that matching happens client-side in `bash-approval-server.mjs`).

## Known gap (not fixed here, flagging for #590/#592)
`agents:logs:all` is not exclusively orchestrator-generated today: `agent/app/log_publisher.py` (code running *inside* the agent container) already publishes directly to this same channel, and #589's Redis-ACL design keeps it agent-writable on purpose (it's the admin UI's live feed source). So the `source: "orchestrator"` marker added here is a hint for a future scan rule, not a real trust boundary — a compromised agent could forge a message on this channel today, `agent_id` included. Documented in a code comment in `approvals.py`; needs a real fix (e.g. a second, agent-unwritable channel) before any Sentinel rule treats `source: "orchestrator"` as authoritative for privileged action.

## Test plan
- [x] `pytest tests/test_approvals_sentinel_events.py -v` — 6/6 new tests pass (request/resolve/dedupe/no-redis-does-not-raise cases)
- [x] `pytest tests/test_approval_flood.py tests/test_sentinel_service_skeleton.py -v` — no regressions
- [x] Full `pytest tests/` sweep — 44 pre-existing failures confirmed unrelated (SAML, app-sharing, schedule-cron-timezone, unassigned-role, mcp_oauth import gaps), none touch `approvals.py`/`command_policies.py`
- [x] Security self-review: no new endpoints (only instrumentation of already-authorized ones), `agent_id`/`risk_level`/`tool` sourced from already-validated agent-token/DB state (not raw request input used for routing), pub-sub channel name is a fixed constant, `reasoning`/`reason` passed through `scrub_log()` before publish, no secrets

part of #591