### PR TITLE
feat(sentinel): publish approval-flow events to Sentinel pipeline (part of #591)

### DIFF
--- a/orchestrator/app/api/approvals.py
+++ b/orchestrator/app/api/approvals.py
@@ -27,6 +27,47 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/approvals", tags=["approvals"])
 
+# Sentinel epic #588, issue #591: feed this endpoint's already-server-side
+# decision points (a command was submitted for approval; a human approved,
+# denied or cancelled it) into the Sentinel's event pipeline (#590) as a
+# second, orchestrator-generated telemetry source alongside `agent:*:logs`.
+#
+# CAVEAT (found while wiring this up, not yet resolved — see the PR/issue
+# comment this points at): `agents:logs:all` is not exclusively orchestrator-
+# generated today. `agent/app/log_publisher.py` — code that runs INSIDE the
+# agent container — already publishes every tool-call/chat event straight to
+# this same channel, and #589's Redis-ACL design explicitly keeps it on the
+# agent-writable global channel list (it has to: it's the live activity feed
+# the admin UI streams from). So a compromised agent can already publish a
+# forged message on this channel today, `agent_id` field included. Marking
+# `source: "orchestrator"` below lets a future #592 scan rule tell the two
+# apart; it is NOT a security boundary by itself (nothing here is signed) —
+# only real per-channel Redis ACLs (excluding this one) would be.
+_SENTINEL_PIPELINE_CHANNEL = "agents:logs:all"
+
+
+async def _publish_sentinel_event(
+    redis: "RedisService | None", agent_id: str, event_type: str, data: dict
+) -> None:
+    """Emit one orchestrator-generated event for the Sentinel pipeline (#591).
+
+    Best-effort like `_publish_notification` — a missing/unavailable Redis
+    client must never break the approval flow itself.
+    """
+    if not redis or not redis.client:
+        return
+    try:
+        event = json.dumps({
+            "agent_id": agent_id,
+            "task_id": "",
+            "type": event_type,
+            "data": {**data, "source": "orchestrator"},
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        })
+        await redis.client.publish(_SENTINEL_PIPELINE_CHANNEL, event)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"[Sentinel] Failed to publish {event_type} event for {scrub_log(agent_id)}: {e}")
+
 
 def _get_redis() -> RedisService | None:
     from app.api.ws import _redis
@@ -336,6 +377,28 @@ async def request_approval(
     db.add(audit_entry)
     await db.commit()
 
+    # Sentinel event (#591): command submitted + policy verdict + approval
+    # requested collapse into one server-observed moment here — `risk_level`
+    # already IS the policy verdict (computed client-side against the policies
+    # `command_policies.py` served, then reported back in this same request).
+    #
+    # `reasoning` is agent-supplied free text and can carry secrets or real
+    # names (see PR #596 review) — `scrub_log()` only strips control chars for
+    # log-injection safety, it does not redact content. Rather than trust a
+    # regex-based redactor to catch every credential/PII shape, the Sentinel
+    # payload is kept to structured, non-sensitive fields only; a full-text
+    # audit trail of `reasoning` already exists in AuditLog above for anyone
+    # with DB access, which is a narrower trust boundary than this pub/sub
+    # channel.
+    await _publish_sentinel_event(
+        redis, agent_id, "approval_requested",
+        {
+            "approval_id": str(approval.id),
+            "tool": approval_tool,
+            "risk_level": body.risk_level,
+        },
+    )
+
     logger.info(
         f"Approval {approval.id} created for agent {scrub_log(agent_id)} - "
         f"{scrub_log(body.tool)} (risk: {scrub_log(body.risk_level)})"
@@ -633,6 +696,16 @@ async def approve_request(
             json.dumps({"status": "approved", "approval_id": str(approval.id)}),
         )
 
+    # Sentinel event (#591): approval result. Emitted here — the single moment
+    # the decision is actually written — rather than at the agent-facing
+    # `/check/{id}` poll endpoint the issue originally pointed at, which fires
+    # every ~2s while pending and would otherwise re-publish the same result
+    # on every poll after resolution.
+    await _publish_sentinel_event(
+        redis, approval.agent_id, "approval_resolved",
+        {"approval_id": approval_id, "status": "approved", "risk_level": approval.risk_level},
+    )
+
     logger.info(f"Approval {approval.id} approved by user {user.id}")
     return {
         "approval_id": approval_id,
@@ -683,6 +756,17 @@ async def deny_request(
             json.dumps({"status": "denied", "approval_id": str(approval.id), "reason": decision.reason}),
         )
 
+    # Sentinel event (#591): approval result, see approve_request for why this
+    # is emitted at the resolution endpoint rather than the polling one.
+    # `decision.reason` is human-supplied free text with the same secret/PII
+    # risk as `reasoning` above (PR #596 review) — deliberately left out of
+    # the Sentinel payload for the same reason; the full reason is still
+    # recorded in `approval.user_response` / AuditLog.
+    await _publish_sentinel_event(
+        redis, approval.agent_id, "approval_resolved",
+        {"approval_id": approval_id, "status": "denied", "risk_level": approval.risk_level},
+    )
+
     logger.info(f"Approval {approval.id} denied by user {user.id}")
     return {"approval_id": approval_id, "status": "denied", "reason": decision.reason, "message": "Command denied."}
 
@@ -706,5 +790,13 @@ async def cancel_approval_request(
     approval.resolved_at = datetime.now(timezone.utc)
     approval.user_response = "Cancelled by user"
     await db.commit()
+
+    # Sentinel event (#591): a cancel is also a resolution outcome — a Sentinel
+    # rule tracking "was this risky command ever actually approved?" needs to
+    # see it too, not just approve/deny.
+    await _publish_sentinel_event(
+        _get_redis(), approval.agent_id, "approval_resolved",
+        {"approval_id": approval_id, "status": "cancelled", "risk_level": approval.risk_level},
+    )
 
     return {"message": "Approval request cancelled"}

--- a/orchestrator/app/api/command_policies.py
+++ b/orchestrator/app/api/command_policies.py
@@ -204,7 +204,20 @@ async def get_policies_for_agent(
     agent_auth: dict = Depends(verify_agent_token),
     db: AsyncSession = Depends(get_db),
 ):
-    """Agent-only endpoint returning active global + agent-specific policies."""
+    """Agent-only endpoint returning active global + agent-specific policies.
+
+    Deliberately NOT a Sentinel event source (#591 scope decision): this only
+    hands over the policy *set* on a ~10s cache refresh — it doesn't see which
+    command the agent is about to run or what verdict it gets, since that
+    matching happens client-side in `bash-approval-server.mjs`. The one place
+    a specific command + its risk verdict does reach the orchestrator is
+    `POST /api/v1/approvals/request` (medium/high risk only), which is where
+    `_publish_sentinel_event` is actually wired up (see `approvals.py`).
+    A per-command policy-verdict signal — including "low"/"allow" commands
+    that execute silently, and "blocked" ones that never leave the container —
+    would need a change to `bash-approval-server.mjs` itself, which is
+    explicitly out of scope for #591.
+    """
     if agent_auth["agent_id"] != agent_id:
         raise HTTPException(status_code=403, detail="Agent token does not match requested agent")
 

--- a/orchestrator/tests/test_approvals_sentinel_events.py
+++ b/orchestrator/tests/test_approvals_sentinel_events.py
@@ -1,0 +1,186 @@
+"""Sentinel epic #588, issue #591: approval-flow events reach the Sentinel pipeline.
+
+`orchestrator/app/api/approvals.py` is one of two server-side decision points
+(`command_policies.py` deliberately isn't, see the docstring on
+`get_policies_for_agent`) where a specific command's fate is known to the
+orchestrator, not just self-reported by the agent. This pins that:
+  - `request_approval` publishes one "approval_requested" event carrying the
+    command, its policy verdict (risk_level) and the reasoning.
+  - `approve_request` / `deny_request` / `cancel_approval_request` each
+    publish exactly one "approval_resolved" event with the outcome — once,
+    at the actual resolution, not on every `/check/{id}` poll.
+  - every published event is marked `source: "orchestrator"` so a future
+    #592 scan rule can tell it apart from the agent-self-reported traffic
+    that already shares this same `agents:logs:all` channel via
+    `agent/app/log_publisher.py`.
+No live Redis needed — a minimal fake stands in for RedisService, same
+pattern as test_approval_flood.py.
+"""
+
+import json
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.ext.compiler import compiles
+
+from app.api import approvals as api
+from app.models.agent import Agent, AgentState
+from app.models.audit_log import AuditLog
+from app.models.command_approval import ApprovalStatus, CommandApproval
+from app.models.notification import Notification
+from app.models.user import UserRole
+
+
+@compiles(JSONB, "sqlite")
+def _jsonb_as_json(type_, compiler, **kw):  # noqa: ANN001
+    return "JSON"
+
+
+def _admin():
+    return SimpleNamespace(id="u1", role=UserRole.ADMIN, email="admin@example.test")
+
+
+def _fake_redis():
+    redis = AsyncMock()
+    redis.client = AsyncMock()
+    return redis
+
+
+class ApprovalsSentinelEventTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        async with self.engine.begin() as conn:
+            for model in (Agent, CommandApproval, Notification, AuditLog):
+                await conn.run_sync(model.metadata.create_all, tables=[model.__table__])
+        self.Session = async_sessionmaker(self.engine, expire_on_commit=False)
+        async with self.Session() as db:
+            db.add(Agent(id="a1", name="Buchhaltung", state=AgentState.RUNNING,
+                         user_id="u1", config={}))
+            await db.commit()
+        self.redis = _fake_redis()
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+
+    def _sentinel_calls(self):
+        """Every publish() call aimed at the Sentinel pipeline channel, decoded."""
+        out = []
+        for call in self.redis.client.publish.await_args_list:
+            channel, payload = call.args
+            if channel == api._SENTINEL_PIPELINE_CHANNEL:
+                out.append(json.loads(payload))
+        return out
+
+    async def _request(self, db, **kw):
+        body = api.ApprovalRequest(
+            tool=kw.pop("tool", "bash"),
+            reasoning=kw.pop("reasoning", "rm -rf /tmp/x"),
+            risk_level=kw.pop("risk_level", "high"),
+            **kw,
+        )
+        with patch.object(api, "_get_redis", return_value=self.redis), \
+             patch.object(api, "_push_ios_for_agent", new=AsyncMock()):
+            return await api.request_approval(body, agent_auth={"agent_id": "a1"}, db=db)
+
+    async def test_request_approval_publishes_one_approval_requested_event(self):
+        async with self.Session() as db:
+            await self._request(db)
+
+        events = self._sentinel_calls()
+        self.assertEqual(len(events), 1)
+        event = events[0]
+        self.assertEqual(event["agent_id"], "a1")
+        self.assertEqual(event["type"], "approval_requested")
+        self.assertEqual(event["data"]["source"], "orchestrator")
+        self.assertEqual(event["data"]["risk_level"], "high")
+        self.assertEqual(event["data"]["tool"], "bash")
+
+    async def test_repeated_identical_question_does_not_republish(self):
+        # The dedupe path in request_approval returns early for a repeated
+        # identical question — it must not double-publish either.
+        async with self.Session() as db:
+            await self._request(db, tool=None, question="Darf ich X?", reasoning="ctx")
+            await self._request(db, tool=None, question="Darf ich X?", reasoning="ctx")
+
+        events = [e for e in self._sentinel_calls() if e["type"] == "approval_requested"]
+        self.assertEqual(len(events), 1)
+
+    async def test_approve_publishes_one_resolved_event(self):
+        async with self.Session() as db:
+            await self._request(db)
+            approval_id = (await db.execute(
+                __import__("sqlalchemy").select(CommandApproval)
+            )).scalars().first().id
+
+            with patch.object(api, "_get_redis", return_value=self.redis):
+                await api.approve_request(str(approval_id), user=_admin(), db=db)
+
+        resolved = [e for e in self._sentinel_calls() if e["type"] == "approval_resolved"]
+        self.assertEqual(len(resolved), 1)
+        self.assertEqual(resolved[0]["data"]["status"], "approved")
+        self.assertEqual(resolved[0]["data"]["source"], "orchestrator")
+
+    async def test_deny_publishes_one_resolved_event_without_free_text_reason(self):
+        # PR #596 review: `decision.reason` is human-supplied free text that can
+        # carry secrets/PII and was only `scrub_log()`-ed (control chars only,
+        # not real redaction) before reaching the Sentinel pipeline. It must be
+        # excluded from the Sentinel payload entirely, not merely scrubbed.
+        async with self.Session() as db:
+            await self._request(db)
+            approval_id = (await db.execute(
+                __import__("sqlalchemy").select(CommandApproval)
+            )).scalars().first().id
+
+            with patch.object(api, "_get_redis", return_value=self.redis):
+                await api.deny_request(
+                    str(approval_id),
+                    decision=api.ApprovalDecision(decision="deny", reason="zu riskant, api_key=sk-abc123"),
+                    user=_admin(), db=db,
+                )
+
+        resolved = [e for e in self._sentinel_calls() if e["type"] == "approval_resolved"]
+        self.assertEqual(len(resolved), 1)
+        self.assertEqual(resolved[0]["data"]["status"], "denied")
+        self.assertNotIn("reason", resolved[0]["data"])
+
+    async def test_request_approval_event_excludes_free_text_reasoning(self):
+        # Same rationale as above, for the approval_requested side.
+        async with self.Session() as db:
+            await self._request(db, reasoning="rm -rf /tmp/x, token=ghp_abcdefghijklmnopqrstuvwxyz0123456789")
+
+        events = [e for e in self._sentinel_calls() if e["type"] == "approval_requested"]
+        self.assertEqual(len(events), 1)
+        self.assertNotIn("reasoning", events[0]["data"])
+
+    async def test_cancel_publishes_one_resolved_event(self):
+        async with self.Session() as db:
+            await self._request(db)
+            approval_id = (await db.execute(
+                __import__("sqlalchemy").select(CommandApproval)
+            )).scalars().first().id
+
+            with patch.object(api, "_get_redis", return_value=self.redis):
+                await api.cancel_approval_request(str(approval_id), user=_admin(), db=db)
+
+        resolved = [e for e in self._sentinel_calls() if e["type"] == "approval_resolved"]
+        self.assertEqual(len(resolved), 1)
+        self.assertEqual(resolved[0]["data"]["status"], "cancelled")
+
+    async def test_no_redis_client_does_not_raise(self):
+        # Best-effort like _publish_notification: a dead/absent Redis must
+        # never break the approval flow itself.
+        async with self.Session() as db:
+            with patch.object(api, "_get_redis", return_value=None), \
+                 patch.object(api, "_push_ios_for_agent", new=AsyncMock()):
+                result = await api.request_approval(
+                    api.ApprovalRequest(tool="bash", reasoning="ls", risk_level="medium"),
+                    agent_auth={"agent_id": "a1"}, db=db,
+                )
+        self.assertEqual(result["status"], "pending")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Rebases PR #596 onto main. #596's base branch chain (feat/issue-590-sentinel-credential-scheme
via feat/issue-590-sentinel-service-skeleton) got superseded as earlier Sentinel PRs merged,
so it could not be cleanly retargeted — same content, replayed onto current main with the
resulting config.py conflict resolved.

Part of #591 (Sentinel epic #588): wires the approval-flow endpoints
(orchestrator/app/api/approvals.py, command_policies.py) to publish events into the
Sentinel pipeline (agents:logs:all), the same server-mediated, manipulation-proof channel
SentinelService (#590) already subscribes to.

Closes #596 (superseded).