### PR TITLE
feat: Skill writing-agent-ready-issues (PO-Triage, agent-taugliche Issues/Epics)

### DIFF
--- a/marketplace-skills/README.md
+++ b/marketplace-skills/README.md
@@ -1,0 +1,15 @@
+# Marketplace Skills (SKILL.md sources)
+
+Source directory for SKILL.md-based agent skills served through the skill
+marketplace. Register this repo as a skill source (admin UI, issue #371) with
+subdir `marketplace-skills` — the crawler picks up every `SKILL.md` here and
+installs selected skills into agents at `/workspace/.claude/skills/<name>/`.
+
+Not to be confused with [agent/skills/](../agent/skills/), which contains
+Python tool plugins (`skill.json` + `tools.py`) loaded directly by the agent
+runtime. The top-level `skills/` directory is the gitignored runtime install
+target, never a source location.
+
+| Skill | Purpose |
+|---|---|
+| [writing-agent-ready-issues](writing-agent-ready-issues/SKILL.md) | Product-owner triage: turn raw backlog items and epics into issues an autonomous agent can implement cleanly |

--- a/marketplace-skills/writing-agent-ready-issues/SKILL.md
+++ b/marketplace-skills/writing-agent-ready-issues/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: writing-agent-ready-issues
+description: Use when creating, triaging, or refining issues, epics, or backlog items that an autonomous AI agent will implement — e.g. when an issue is vague ("improve X"), lacks acceptance criteria, mixes several changes, or when a product owner needs to break an epic into agent-sized tasks or decide what to delegate to an agent vs. keep with a human.
+---
+
+# Writing Agent-Ready Issues
+
+## Overview
+
+An autonomous agent has no standup, no hallway conversation, and no chance to ask
+the reporter a follow-up question mid-task. **The issue IS the entire onboarding.**
+Write every issue like a brief for a competent new hire on day one: what is the
+problem, what does "good" look like, what does "bad" look like, and what should
+they do when unsure.
+
+Evidence: concise, well-scoped, self-contained, context-guided issues raise
+agent PR merge rates by up to 30 percentage points.
+
+## When to Use
+
+- Before assigning any issue to an automated agent
+- When a product owner triages an inbox of raw requests, bug reports, or ideas
+- When breaking an epic into implementable slices
+- When an agent's PR missed the point — the issue was probably not agent-ready
+
+**When NOT to use:** quick interactive pairing sessions where a human steers the
+agent turn by turn; there the conversation replaces the brief.
+
+## Triage: Every Issue Gets Exactly One State
+
+Move each incoming item through this state machine. One category label
+(`bug` | `enhancement`) plus one state label — never more, never zero:
+
+| State | Meaning | Exit condition |
+|---|---|---|
+| `needs-triage` | Untouched inbox item | PO decision made |
+| `needs-info` | Cannot be specified yet | Reporter answered the concrete questions asked in a comment |
+| `ready-for-agent` | Passes the Definition of Ready below | Agent assigned |
+| `ready-for-human` | Specified, but needs human judgment (design taste, production risk, manual testing) | Human picks it up |
+| `wontfix` / closed | Duplicate, already implemented, or rejected | Reason recorded in a closing comment |
+
+Decision rules during triage:
+
+1. **Verify before you brief.** Reproduce the bug from the reporter's steps.
+   Search the codebase by *concept*, not just keyword — the feature may already
+   exist. Already implemented → close with a pointer to where. No codebase
+   access at triage time → the issue may be drafted but stays out of
+   `ready-for-agent` until someone verified it against the code.
+2. **Ask, don't guess.** Missing *reporter facts* (repro steps, environment,
+   data volume) → `needs-info` with concrete, answerable questions. Missing
+   *product decisions* ("maybe dark mode?") are the PO's to make — the item
+   stays `needs-triage` until decided; never bounce product questions to the
+   reporter. Never pad either gap with assumptions.
+3. **Split before assigning.** More than one PR needed? Two cases:
+   - Unrelated asks bundled in one item (a grab-bag) → split into independent
+     issues, close the original with a comment linking the children
+   - One coherent goal that spans several PRs → it is an epic, see below
+4. **Category tie-breaker:** a regression from previously working/acceptable
+   behavior is a `bug`; a new capability or a new quality target is an
+   `enhancement`.
+
+## Definition of Ready (for Agents)
+
+An issue is `ready-for-agent` only if ALL of these hold:
+
+- [ ] **One paragraph problem/goal** — what and why, in plain language
+- [ ] **Verifiable acceptance criteria** — each criterion checkable by a
+      command, test, or observable behavior. "Looks good" is not a criterion.
+- [ ] **Explicit scope boundary** — an "Out of scope" list. No boundary =
+      guaranteed scope creep.
+- [ ] **Durable context pointers** — name modules, symbols, domain concepts,
+      and behavioral contracts ("`TaskScheduler` must keep firing for stopped
+      agents"). NOT file paths + line numbers — those rot within weeks.
+- [ ] **Verification recipe** — the exact commands to run (tests, build, lint)
+      and what output counts as success. Cannot name the commands? Look them up
+      (README, CI config) — placeholders like `<test command>` fail this check.
+- [ ] **Escalation rule** — what the agent should do when unsure. Default:
+      touches security or data visibility → stop and comment with the concrete
+      question; anything else → take the conservative option and flag the
+      decision in the PR description.
+- [ ] **One-PR sized** — result reviewable in one sitting
+
+Use the full section layout from [templates/issue-template.md](templates/issue-template.md).
+
+## Epics: Vertical Slices, Not Layers
+
+The PO keeps the intent at epic level; agents never work "on the epic".
+
+1. Write the epic as **goal + slice list** — see
+   [templates/epic-template.md](templates/epic-template.md)
+2. Slice **vertically** (each slice delivers observable user value and is
+   independently mergeable), not horizontally (DB ticket, API ticket, UI
+   ticket — those force agents to integrate blind)
+3. Make **dependency order explicit** ("slice 3 requires slice 1 merged")
+4. State **shared constraints once** in the epic (stack, security rules,
+   conventions) and link every slice back to it — do not copy-paste them
+5. Each slice becomes a normal issue that must pass the Definition of Ready
+
+## Delegate to Agent vs. Keep Human
+
+| Delegate to agent | Keep with a human |
+|---|---|
+| Bug fixes with reproduction steps | Production incidents, hotfixes under pressure |
+| Test coverage, documentation, accessibility passes | Security- and auth-critical changes (agent may draft, human must own) |
+| Mechanical refactors, dependency bumps | Cross-repo or deep-domain redesigns |
+| Well-specified feature slices | Ambiguous, exploratory, or taste-driven work |
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---|---|
+| "Improve performance of X" | Measure the baseline first, then name the target: "list endpoint p95 < 300ms at 10k rows (baseline: 1.4s)" — never invent numbers |
+| Acceptance criteria only a human can judge | Rewrite as command + expected output |
+| File paths and line numbers as context | Name symbols and behavioral contracts instead |
+| Feature + refactor in one issue | Two issues; refactor first, feature depends on it |
+| Requirements hidden in comment threads | Fold decisions back into the issue body before assigning |
+| No "Out of scope" section | Agent "helpfully" rewrites neighboring code — add the boundary |
+| No verification recipe | Agent declares success without proof — list the commands |
+| Assigning the epic itself | Slice first; agents get slices only |
+
+## Quick Reference — Issue Skeleton
+
+```
+Title: <verb + object, one outcome>
+1. Context      — why this exists, links to epic/constraints
+2. Problem/Goal — one paragraph
+3. Scope        — In / Out (explicit non-goals)
+4. Acceptance criteria — verifiable, checkbox list
+5. Context pointers    — modules, symbols, contracts, docs
+6. Verification        — exact commands + expected result
+7. Constraints         — security, style, compatibility
+8. When unsure         — escalation rule
+```

--- a/marketplace-skills/writing-agent-ready-issues/templates/epic-template.md
+++ b/marketplace-skills/writing-agent-ready-issues/templates/epic-template.md
@@ -1,0 +1,45 @@
+# Epic Template — Agent-Sliced
+
+```markdown
+# Epic: <outcome-oriented name, e.g. "Self-service password reset">
+
+Labels: epic
+
+## Goal
+What user-visible outcome this epic delivers and why it matters.
+The epic itself is NEVER assigned to an agent — only its slices are.
+
+## Shared Constraints (stated once, linked from every slice)
+- Stack / architecture rules: ...
+- Security rules: ...
+- Conventions: ...
+
+## Slices (vertical — each independently mergeable and verifiable)
+Order = dependency order. Each slice becomes one agent-ready issue
+that passes the Definition of Ready.
+
+| # | Slice (user-observable value) | Depends on | Issue |
+|---|---|---|---|
+| 1 | <e.g. request-reset endpoint sends tokenized mail> | — | #... |
+| 2 | <e.g. reset form consumes token, sets password> | 1 | #... |
+| 3 | <e.g. rate limiting + audit log on both endpoints> | 1, 2 | #... |
+
+## Done When
+- [ ] All slices merged
+- [ ] End-to-end verification: <command or manual walkthrough>
+- [ ] Docs/changelog updated
+
+## Explicitly Not in This Epic
+- ...
+```
+
+## Slicing Rules
+
+1. **Vertical, not horizontal.** A slice crosses all layers (DB → API → UI)
+   and delivers observable value. "DB ticket + API ticket + UI ticket"
+   forces agents to integrate blind against unwritten code.
+2. **One PR per slice.** If a slice needs multiple PRs, split it again.
+3. **Dependencies explicit.** An agent must be able to tell from the table
+   whether its slice is unblocked.
+4. **Constraints by reference.** Slices link to the epic's shared
+   constraints instead of copying them — one source of truth.

--- a/marketplace-skills/writing-agent-ready-issues/templates/issue-template.md
+++ b/marketplace-skills/writing-agent-ready-issues/templates/issue-template.md
@@ -1,0 +1,65 @@
+# Issue Template — Agent-Ready Task
+
+```markdown
+# <Verb + object — one outcome, e.g. "Fix scheduler skipping stopped agents">
+
+Labels: <bug | enhancement> + ready-for-agent
+Epic: #<epic-number> (if part of one)
+
+## 1. Context
+Why this task exists. One or two sentences plus links:
+- Epic / parent issue: #...
+- Related decisions or docs: ...
+
+## 2. Problem / Goal
+One paragraph. What is broken or missing, and what the world looks like
+when this is done. For bugs: exact reproduction steps and observed vs.
+expected behavior.
+
+## 3. Scope
+**In scope:**
+- ...
+
+**Out of scope (do NOT touch):**
+- ...
+
+## 4. Acceptance Criteria
+Every criterion must be checkable by a command, a test, or an observable
+behavior — never by taste.
+
+- [ ] Given <precondition>, when <action>, then <observable result>
+- [ ] New/changed behavior is covered by tests (state which kind)
+- [ ] Existing test suite stays green
+
+## 5. Context Pointers
+Durable references — symbols, modules, contracts, domain concepts.
+No line numbers (they rot).
+
+- Entry point: `<module or symbol>`
+- Behavioral contract that must not break: "<e.g. API stays backward
+  compatible for clients sending the old field>"
+- Similar existing pattern to follow: `<symbol or feature>`
+
+## 6. Verification
+Exact commands the agent must run, and what success looks like:
+
+```bash
+<test command>        # expected: all pass
+<build/lint command>  # expected: exit 0
+```
+
+Manual check (if any): <steps + expected observation>
+
+## 7. Constraints
+- Security: <e.g. endpoint requires auth + ownership check + test>
+- Conventions: <e.g. follow existing service pattern, no new dependencies
+  without approval>
+- Compatibility: <e.g. migration must be reversible>
+
+## 8. When Unsure
+Default rule (adapt only if this task needs something stricter):
+- The doubt touches security or data visibility → STOP and comment on
+  the issue with the concrete question
+- Anything else → choose the conservative option (smaller scope, reuse
+  existing code) and flag the decision in the PR description
+```


### PR DESCRIPTION
## Was

Neuer SKILL.md-Skill `writing-agent-ready-issues` plus neuer Quellordner `marketplace-skills/` fuer SKILL.md-basierte Marktplatz-Skills (registrierbar als Skill-Quelle mit Subdir, Mechanik aus #371).

Der Skill fasst recherchierte Best Practices zusammen, wie ein Product Owner Backlog-Items fuer autonome Agenten aufbereitet:

- Triage-State-Machine (needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix) mit Entscheidungsregeln (Verify before brief, Grab-Bag-Split vs. Epic, Kategorie-Tie-Breaker)
- Definition of Ready fuer Agenten (verifizierbare Akzeptanzkriterien, expliziter Out-of-Scope, haltbare Kontext-Pointer statt Zeilennummern, Verifikationsrezept mit echten Kommandos, Eskalationsregel)
- Epic-Schnitt in vertikale, einzeln mergebare Slices mit expliziter Abhaengigkeitsreihenfolge
- Delegations-Matrix (Agent vs. Mensch) und Fehler-Tabelle
- Templates fuer Issue und Epic

## Verifikation

Anwendungstest mit frischem Subagenten (schwammiges Beispiel-Item aus drei vermischten Wuenschen): Triage, Split und vollstaendiges Issue korrekt erzeugt; die dabei gemeldeten Luecken (Split-Ausgang, needs-info vs. Produktentscheidung, Placeholder-Kommandos, Eskalations-Default, Baseline vor Zielwert) wurden in den Skill eingearbeitet.