### PR TITLE
chore(git): Sicherungskopien der .env ignorieren

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,13 @@ frontend/public/pdfjs/
 # und damit einen Commit-Teil verschluckt — deshalb nur Wurzel + PID-Namen.
 /core
 core.[0-9]*
+
+# Sicherungskopien der .env. Sie entstehen beim Bearbeiten von Hand und beim
+# Einrichten (etwa `cp .env .env.bak`) und enthalten dieselben Geheimnisse wie
+# das Original: Datenbank-, Redis- und OAuth-Zugaenge. Zeile 2 deckt nur `.env`
+# selbst ab — `.env.bak` war damit versionierbar und rutscht bei einem
+# `git add -A` mit. Die beiden Beispieldateien sind ausdruecklich ausgenommen,
+# weil sie versioniert bleiben muessen.
+.env.*
+!.env.example
+!.env.community.example


### PR DESCRIPTION
## Summary

`.env` steht in der `.gitignore`, Sicherungskopien wie `.env.bak` bisher nicht — obwohl sie dieselben Geheimnisse enthalten.

## Type

- [ ] 🚀 feat: new feature
- [ ] 🐛 fix: bug fix
- [ ] 📝 docs: documentation only
- [ ] ♻️ refactor: code change without behavior change
- [ ] ⚡ perf: performance improvement
- [ ] 🧪 test: add/update tests
- [x] 🔧 chore: build / tooling / config

## Changes

- `.gitignore`: Muster `.env.*` ergänzt, mit ausdrücklichen Ausnahmen für die beiden versionierten Beispieldateien `.env.example` und `.env.community.example`.
- Kommentar dazu, warum das Muster bewusst breit ist statt einer Aufzählung bekannter Endungen.

Hintergrund: Auf einer laufenden Anlage lag eine `.env.bak` im Arbeitsbaum — entstanden beim Einrichten. Sie enthält dieselben Datenbank-, Redis- und OAuth-Zugänge wie das Original und wäre bei einem `git add -A` mitgegangen. `git check-ignore -v .env.bak` lieferte vorher nichts.

## Testing

- [ ] Ran `npm run build` (frontend) / orchestrator starts without errors
- [ ] Tested manually in browser/chat/telegram
- [ ] Added/updated tests where relevant
- [ ] Verified migrations run clean (`alembic upgrade head`)

Kein Code betroffen, deshalb keiner der obigen Punkte. Geprüft wurde die Regel selbst:

```
$ git check-ignore -v .env.bak
.gitignore:130:.env.*   .env.bak

$ git check-ignore -q .env.example ; echo $?
1        # nicht ignoriert

$ git check-ignore -q .env.community.example ; echo $?
1        # nicht ignoriert
```

Beide Beispieldateien bleiben also versioniert, `git status` ist nach der Änderung unverändert sauber.

## Breaking Changes

- [x] None
- [ ] Yes — documented in commit message + CHANGELOG

## Contributor License Agreement

By submitting this PR, I confirm that:

- [x] My contribution is licensed under the project's Fair-Code Sustainable Use License
- [x] I grant the copyright holder the right to use and relicense my contribution

## Related Issues

Keines — der Fund fiel beim Einrichten einer eigenen Installation an.
